### PR TITLE
feat: Tuist PRD, DEV 배포 환경 설정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/ViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/ViewController.swift
@@ -12,13 +12,6 @@ public class ViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        #if DEV
-        print("load view DEV")
-        self.view.backgroundColor = .purple
-        #elseif PRD
-        print("load view PRD")
-        self.view.backgroundColor = .brown
-        #endif
         
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/ViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/ViewController.swift
@@ -12,5 +12,13 @@ public class ViewController: UIViewController {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
+        #if DEV
+        print("load view DEV")
+        self.view.backgroundColor = .purple
+        #elseif PRD
+        print("load view PRD")
+        self.view.backgroundColor = .brown
+        #endif
+        
     }
 }

--- a/14th-team5-iOS/XCConfig/dev.xcconfig
+++ b/14th-team5-iOS/XCConfig/dev.xcconfig
@@ -1,0 +1,2 @@
+#include "../XCConfig/shared.xcconfig"
+

--- a/14th-team5-iOS/XCConfig/prd.xcconfig
+++ b/14th-team5-iOS/XCConfig/prd.xcconfig
@@ -1,0 +1,1 @@
+#include "../XCConfig/shared.xcconfig"

--- a/14th-team5-iOS/XCConfig/shared.xcconfig
+++ b/14th-team5-iOS/XCConfig/shared.xcconfig
@@ -1,0 +1,3 @@
+OTHER_SWIFT_FLAGS[config=DEV][sdk=*] = $(inherited) -DDEV
+OTHER_SWIFT_FLAGS[config=PRD][sdk=*] = $(inherited) -DPRD
+

--- a/App.xcworkspace/xcshareddata/xcschemes/App-Workspace.xcscheme
+++ b/App.xcworkspace/xcshareddata/xcschemes/App-Workspace.xcscheme
@@ -471,7 +471,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "DEV"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -479,7 +479,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "DEV"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -499,7 +499,7 @@
       </MacroExpansion>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "PRD"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -515,10 +515,10 @@
       </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Debug">
+      buildConfiguration = "DEV">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "PRD"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -17,6 +17,13 @@ let dependencies = Dependencies(
         .snapkit,
         .then,
         .firebase
-    ]),
+    ],baseSettings: .settings(
+        configurations: [
+            .build(.dev),
+            .build(.prd)
+        ]
+    )
+    
+    ),
     platforms: [.iOS]
 )

--- a/Tuist/ProjectDescriptionHelpers/ConfigurationName+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/ConfigurationName+Templates.swift
@@ -1,0 +1,19 @@
+//
+//  ConfigurationName+Templates.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by Kim dohyun on 11/30/23.
+//
+
+import ProjectDescription
+
+
+public enum BuildTarget: String {
+    case dev = "DEV"
+    case prd = "PRD"
+    
+    public var configurationName: ConfigurationName {
+        return ConfigurationName.configuration(self.rawValue)
+    }
+    
+}

--- a/Tuist/ProjectDescriptionHelpers/ConfigurationName+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/ConfigurationName+Templates.swift
@@ -17,3 +17,22 @@ public enum BuildTarget: String {
     }
     
 }
+
+extension Configuration {
+    public static func build(_ type: BuildTarget, name: String = "") -> Self {
+        let buildName = type.rawValue
+        switch type {
+        case .dev:
+            return .debug(
+                name: BuildTarget.dev.configurationName,
+                xcconfig: .relativeToXCConfig(type: .dev)
+            )
+        case .prd:
+            return .release(
+                name: BuildTarget.prd.configurationName,
+                xcconfig: .relativeToXCConfig(type: .prd)
+            
+            )
+        }
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Path+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Path+Templates.swift
@@ -1,0 +1,14 @@
+//
+//  Path+Templates.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by Kim dohyun on 11/30/23.
+//
+
+import ProjectDescription
+
+extension Path {
+    public static func relativeToXCConfig(type: BuildTarget) -> Self {
+        return .relativeToRoot("./14th-team5-iOS/XCConfig/\(type.rawValue.lowercased()).xcconfig")
+    }
+}

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -56,7 +56,20 @@ extension Project {
     public static func makeApp(name: String, target: [Target]) -> Project {
         return Project(
             name: name,
-            targets: target
+            settings: .settings(
+                configurations: [
+                    .build(.dev, name: name),
+                    .build(.prd, name: name)
+                ]
+            ),
+            targets: target,
+            schemes: [
+                .makeScheme(.dev, name: name),
+                .makeScheme(.prd, name: name)
+            ],
+            additionalFiles: [
+                "../XCConfig/shared.xcconfig"
+            ]
         )
     }
     

--- a/Tuist/ProjectDescriptionHelpers/Scheme+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme+Templates.swift
@@ -1,0 +1,35 @@
+//
+//  Scheme+Templates.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by Kim dohyun on 11/30/23.
+//
+
+import ProjectDescription
+
+extension Scheme {
+    
+    public static func makeScheme(_ type: BuildTarget, name: String) -> Self {
+        let buildName = type.rawValue
+        switch type {
+        case .dev:
+            return Scheme(
+                name: "\(name)-\(buildName.uppercased())",
+                buildAction: BuildAction(targets: ["\(name)"]),
+                runAction: .runAction(configuration: type.configurationName),
+                archiveAction: .archiveAction(configuration: type.configurationName),
+                profileAction: .profileAction(configuration: type.configurationName),
+                analyzeAction: .analyzeAction(configuration: type.configurationName)
+            )
+        case .prd:
+            return Scheme(
+                name: "\(name)-\(buildName.uppercased())",
+                buildAction: BuildAction(targets: ["\(name)"]),
+                runAction: .runAction(configuration: type.configurationName),
+                archiveAction: .archiveAction(configuration: type.configurationName),
+                profileAction: .profileAction(configuration: type.configurationName),
+                analyzeAction: .analyzeAction(configuration: type.configurationName)
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- Tuist Build Configuration Setting을 통한 DEV 및 PRD 내부 개발 환경 작업

## 변경 로직 ⚒️

- `Project+Templates` 에 `Settings` 값이 추가 되었습니다. 뿐만 아니라 `Configurations` 의 값은 `DEV`, `PRD`로 지정 되도록 구현하였습니다.
- `Project+Templates`에 `Scheme` 값도 포함 시켰습니다. `Scheme`를 통해 Build Configuration을 지정할 뿐만 아니라 `Build Action` Target을 설정 해야 하기 때문입니다.
- `Dependencies.swift`에 `Settings` 값 역시 추가 했습니다. 외부 라이브러리에는 기본적으로 `DEBUG`, `Release` Configurations를 제공하지만 저희는 `DEV`, `PRD` Configurations 네이밍을 사용하였기에 Settings에 값을 추가하였습니다.


## 스크린샷 📷

| 기능 | DEV | PRD |
| :--: | :-------: |  :-------:  |
| PNG  |  ![simulator_screenshot_926E8266-BFC6-4F5B-8F5D-F74C73A48E4C](https://github.com/depromeet/14th-team5-iOS/assets/23008224/ec76a26d-fd85-403d-b69b-af67a4f18ef1)      |  ![simulator_screenshot_3ED9E456-1626-403B-841D-14E5341C31CE](https://github.com/depromeet/14th-team5-iOS/assets/23008224/27896aa3-e0e6-4af7-9974-f8cfea372718) |

## 테스트 케이스 ✅

- [x] **Conditional Compilation Block** 전처리문을 통한 (DEV,PRD) 배포 환경 분기시 빌드 환경에 따라 정상 동작 하는지
- [x] **Third party Library** 및 **Multi module**의 의존성을 제대로 가져오는지, **miss Matching configurations** 오류가 발생하지 않는지

