### PR TITLE
feat: KingFisher, FSCalendar 의존성 추가

### DIFF
--- a/App.xcworkspace/contents.xcworkspacedata
+++ b/App.xcworkspace/contents.xcworkspacedata
@@ -27,10 +27,16 @@
          location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Alamofire/Alamofire.xcodeproj">
       </FileRef>
       <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/FSCalendar/FSCalendar.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
       </FileRef>
       <FileRef
          location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleUtilities/GoogleUtilities.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Kingfisher/Kingfisher.xcodeproj">
       </FileRef>
       <FileRef
          location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/ReactorKit/ReactorKit.xcodeproj">

--- a/App.xcworkspace/xcshareddata/xcschemes/App-Workspace.xcscheme
+++ b/App.xcworkspace/xcshareddata/xcschemes/App-Workspace.xcscheme
@@ -154,6 +154,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "19064F9384CD706033B7730F"
+               BuildableName = "FSCalendar.framework"
+               BlueprintName = "FSCalendar"
+               ReferencedContainer = "container:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/FSCalendar/FSCalendar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "769B28412864CE639D5C8BFF"
                BuildableName = "Firebase.framework"
                BlueprintName = "Firebase"
@@ -480,6 +494,20 @@
                BuildableName = "KakaoSDKUser.framework"
                BlueprintName = "KakaoSDKUser"
                ReferencedContainer = "container:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B3B395FD6136F57D630138BD"
+               BuildableName = "Kingfisher.framework"
+               BlueprintName = "Kingfisher"
+               ReferencedContainer = "container:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Kingfisher/Kingfisher.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -18,7 +18,9 @@ let dependencies = Dependencies(
         .then,
         .firebase,
         .kakaoSDK,
-        .kakaoSDKRx
+        .kakaoSDKRx,
+        .kingFisher,
+        .fsCalendar
     ],baseSettings: .settings(
         configurations: [
             .build(.dev),

--- a/Tuist/ProjectDescriptionHelpers/ModuleType+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModuleType+Templates.swift
@@ -45,7 +45,9 @@ public enum ModuleLayer: String, CaseIterable, ModuleType {
                 .external(name: "Then"),
                 .external(name: "FirebaseAnalytics"),
                 .external(name: "KakaoSDK"),
-                .external(name: "RxKakaoSDK")
+                .external(name: "RxKakaoSDK"),
+                .external(name: "Kingfisher"),
+                .external(name: "FSCalendar")
             ]
         case .DesignSystem:
             return [] 

--- a/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
@@ -23,4 +23,6 @@ extension Package {
     public static let firebase = Package.remote(repo: "firebase/firebase-ios-sdk", version: "10.18.0")
     public static let kakaoSDK = Package.remote(repo: "kakao/kakao-ios-sdk", version: "2.19.0")
     public static let kakaoSDKRx = Package.remote(repo: "kakao/kakao-ios-sdk-rx", version: "2.19.0")
+    public static let kingFisher = Package.remote(repo: "onevcat/Kingfisher", version: "7.9.1")
+    public static let fsCalendar = Package.remote(repo: "WenchaoD/FSCalendar", version: "2.8.3")
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- KingFisher(v7.9.1) 의존성 추가
- FSCalendar(v2.8.3) 의존성 추가

## 기타

* KingFisher는 v7.10.0이 최신 버전이나, `tuist generate`시 `resolved cache profile 'development' from tuist's defaults 'kingfisher' is not a valid configured external dependency for platform` 에러가 출력하는 관계로 한 단계 낮은 버전을 적용하였습니다.

