### PR TITLE
feat: 기본 캘린더 UI 구현

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPageViewCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPageViewCellReactor.swift
@@ -1,0 +1,30 @@
+//
+//  CalendarPageViewCellReactor.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import Foundation
+
+import ReactorKit
+import RxSwift
+
+final class CalendarPageCellReactor: Reactor {
+    // MARK: - Action
+    enum Action { }
+    
+    // MARK: - Mutation
+    enum Mutation { }
+    
+    // MARK: - State
+    struct State { }
+    
+    // MARK: - Properties
+    var initialState: State
+    
+    // MARK: - Intializer
+    init() {
+        self.initialState = State()
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarViewReactor.swift
@@ -1,0 +1,30 @@
+//
+//  CalendarViewReactor.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import Foundation
+
+import ReactorKit
+import RxSwift
+
+final class CalendarViewReactor: Reactor {
+    // MARK: - Action
+    enum Action { }
+    
+    // MARK: - Mutation
+    enum Mutation { }
+    
+    // MARK: - State
+    struct State { }
+    
+    // MARK: - Properties
+    var initialState: State
+    
+    // MARK: - Intializer
+    init() {
+        self.initialState = State()
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageViewCell.swift
@@ -1,0 +1,79 @@
+//
+//  CalendarPageViewCell.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import UIKit
+
+import Core
+import FSCalendar
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class CalendarPageViewCell: BaseCollectionViewCell<CalendarPageCellReactor> {
+    // MARK: - Views
+    private let memoryScoreView: UIView = UIView().then {
+        $0.layer.masksToBounds = true
+        $0.layer.cornerRadius = 10.0
+        $0.backgroundColor = UIColor.systemGray6
+    }
+    
+    private let calendarView: FSCalendar = FSCalendar().then {
+        $0.scrollEnabled = false
+    }
+    
+    // MARK: - Properties
+    static var identifier: String = "CalendarPageViewCell"
+    
+    // MARK: - Constants
+    
+    // MARK: - Intializer
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helpers
+    override func setupUI() { 
+        super.setupUI()
+        contentView.addSubview(memoryScoreView)
+        contentView.addSubview(calendarView)
+    }
+    
+    override func setupAutoLayout() { 
+        super.setupAutoLayout()
+        memoryScoreView.snp.makeConstraints {
+            $0.leading.equalTo(contentView.snp.leading).offset(16.0)
+            $0.top.equalTo(contentView.snp.top).offset(4.0)
+            $0.trailing.equalTo(contentView.snp.trailing).offset(-16.0)
+            $0.bottom.equalTo(calendarView.snp.top).offset(-50.0)
+        }
+        
+        calendarView.snp.makeConstraints {
+            $0.leading.equalTo(contentView.snp.leading).offset(16.0)
+            $0.bottom.equalTo(contentView.snp.bottom)
+            $0.trailing.equalTo(contentView.snp.trailing).offset(-16.0)
+            $0.height.equalTo(contentView.snp.width).multipliedBy(0.95)
+        }
+        
+        
+    }
+    
+    override func setupAttributes() { 
+        super.setupAttributes()
+    }
+    
+    override func bind(reactor: CalendarPageCellReactor) { }
+}
+
+extension CalendarPageViewCell: FSCalendarDelegate { }
+
+extension CalendarPageViewCell: FSCalendarDataSource { }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -1,0 +1,103 @@
+//
+//  CalendarViewController.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import UIKit
+
+import Core
+import FSCalendar
+import ReactorKit
+import RxCocoa
+import RxSwift
+import RxDataSources
+import SnapKit
+import Then
+
+final class CalendarViewController: BaseViewController<CalendarViewReactor> {
+    // MARK: - Views
+    private lazy var collectionView: UICollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: orthogonalCompositionalLayout
+    ).then {
+        $0.dataSource = self // temp code
+        
+        $0.isScrollEnabled = false
+        $0.backgroundColor = UIColor.white
+        
+        $0.register(CalendarPageViewCell.self, forCellWithReuseIdentifier: CalendarPageViewCell.identifier)
+    }
+    
+    // MARK: - Properties
+    
+    // MARK: - Lifecycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: - Helpers
+    override func setupUI() { 
+        super.setupUI()
+        view.addSubview(collectionView)
+    }
+    
+    override func setupAutoLayout() { 
+        super.setupAutoLayout()
+        collectionView.snp.makeConstraints {
+            $0.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    override func setupAttributes() { 
+        super.setupAttributes()
+    }
+    
+    override func bind(reactor: CalendarViewReactor) { }
+}
+
+extension CalendarViewController {
+    var orthogonalCompositionalLayout: UICollectionViewCompositionalLayout {
+        // item
+        let itemSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let item: NSCollectionLayoutItem = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        // group
+        let groupSize: NSCollectionLayoutSize = NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1.0),
+            heightDimension: .fractionalHeight(1.0)
+        )
+        let group: NSCollectionLayoutGroup = NSCollectionLayoutGroup.horizontal(
+            layoutSize: groupSize,
+            subitem: item,
+            count: 1
+        )
+        
+        // section
+        let section: NSCollectionLayoutSection = NSCollectionLayoutSection(group: group)
+        section.orthogonalScrollingBehavior = .groupPaging
+        
+        // layout
+        let layout: UICollectionViewCompositionalLayout = UICollectionViewCompositionalLayout(section: section)
+        
+        return layout
+    }
+}
+
+extension CalendarViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 3
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: CalendarPageViewCell.identifier,
+            for: indexPath
+        ) as! CalendarPageViewCell
+        return cell
+    }
+}

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -22,13 +22,15 @@ let dependencies = Dependencies(
         .kakaoSDKRx,
         .kingFisher,
         .fsCalendar
-    ],baseSettings: .settings(
+    ], productTypes: [
+        "FSCalendar": .framework
+    ],
+     baseSettings: .settings(
         configurations: [
             .build(.dev),
             .build(.prd)
         ]
-    )
-    
+     )
     ),
     platforms: [.iOS]
 )

--- a/pippi.xcworkspace/contents.xcworkspacedata
+++ b/pippi.xcworkspace/contents.xcworkspacedata
@@ -21,74 +21,58 @@
       </FileRef>
    </Group>
    <Group
-      location = "group:Tuist"
-      name = "Tuist">
-      <Group
-         location = "group:Dependencies"
-         name = "Dependencies">
-         <Group
-            location = "group:SwiftPackageManager"
-            name = "SwiftPackageManager">
-            <Group
-               location = "group:.build"
-               name = ".build">
-               <Group
-                  location = "group:checkouts"
-                  name = "checkouts">
-                  <FileRef
-                     location = "group:Alamofire/Alamofire.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:FSCalendar/FSCalendar.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:GoogleUtilities/GoogleUtilities.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:Kingfisher/Kingfisher.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:ReactorKit/ReactorKit.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:RxAlamofire/RxAlamofire.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:RxDataSources/RxDataSources.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:RxSwift/RxSwift.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:SnapKit/SnapKit.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:Then/Then.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:WeakMapTable/WeakMapTable.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:firebase-ios-sdk/Firebase.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:kakao-ios-sdk-rx/RxKakaoOpenSDK.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:nanopb/nanopb.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:promises/Promises.xcodeproj">
-                  </FileRef>
-               </Group>
-            </Group>
-         </Group>
-      </Group>
+      location = "container:"
+      name = "Dependencies">
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Alamofire/Alamofire.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/FSCalendar/FSCalendar.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleUtilities/GoogleUtilities.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Kingfisher/Kingfisher.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/ReactorKit/ReactorKit.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxAlamofire/RxAlamofire.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxDataSources/RxDataSources.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxSwift/RxSwift.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SnapKit/SnapKit.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Then/Then.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/WeakMapTable/WeakMapTable.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Firebase.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk-rx/RxKakaoOpenSDK.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/nanopb/nanopb.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/promises/Promises.xcodeproj">
+      </FileRef>
    </Group>
 </Workspace>


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 기본 메인 캘린더 화면의 UI를 구현하였습니다. 컬렉션 뷰의 레이아웃을 정하고, 각 셀에 간단한 캘린더 뷰와 추억점수 뷰를 집어넣었습니다.

## 기타

- `FSCalendar`가 Objective-C로 작성되어 있는 까닭에 테스트 시, 앱이 죽어버리는 현상이 발생하였습니다. Tuist SPM + 다이나믹 프레임워크를 적용해 해결하였습니다. `tuist clean`과 `tuist fetch`를 해주세요.

