### PR TITLE
Feat: 메인 캘린더 UI 구현

### DIFF
--- a/14th-team5-iOS/App/Sources/Extensions/Date+Ext.swift
+++ b/14th-team5-iOS/App/Sources/Extensions/Date+Ext.swift
@@ -1,0 +1,58 @@
+//
+//  Date+Ext.swift
+//  App
+//
+//  Created by 김건우 on 12/7/23.
+//
+
+import Foundation
+
+extension Date {
+    private var calendar: Calendar {
+        return Calendar.autoupdatingCurrent
+    } 
+    
+    func isEqual(
+        _ components: Set<Calendar.Component> = [.year, .month, .day],
+        with date: Date
+    ) -> Bool {
+        let component1 = calendar.dateComponents(components, from: self)
+        let component2 = calendar.dateComponents(components, from: date)
+        
+        for component in components {
+            if component1.value(for: component) != component2.value(for: component) {
+                return false
+            }
+        }
+        return true
+    }
+    
+    func interval(
+        _ components: Set<Calendar.Component>,
+        to date: Date
+    ) -> [Calendar.Component:Int] {
+        var dict = [Calendar.Component:Int]()
+        let interval = calendar.dateComponents(components, from: self, to: date)
+        
+        for component in components {
+            dict[component] = interval.value(for: component) ?? 0
+        }
+        return dict
+    }
+    
+    var year: Int {
+        return calendar.component(.year, from: self)
+    }
+    
+    var month: Int {
+        return calendar.component(.month, from: self)
+    }
+    
+    var day: Int {
+        return calendar.component(.day, from: self)
+    }
+    
+    var isToday: Bool {
+        return self.isEqual(with: Date.now)
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -17,10 +17,166 @@ import Then
 
 final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
     // MARK: - Views
-    private let scoreView: UIView = UIView().then {
+    private lazy var scoreView: UIView = UIView().then {
         $0.layer.masksToBounds = true
-        $0.layer.cornerRadius = 20.0
-        $0.backgroundColor = UIColor.systemGray6
+        $0.layer.cornerRadius = AttributeValue.scoreViewCornerRadius
+        $0.backgroundColor = UIColor.systemGray
+        
+        $0.addSubview(scoreInfoStackView)
+    }
+    
+    private lazy var scoreInfoStackView: UIStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = AttributeValue.scoreInfoStackSpacing
+        $0.alignment = .fill
+        $0.distribution = .fillEqually
+        
+        $0.addArrangedSubview(allParticipatedDayCountView)
+        $0.addArrangedSubview(totalPhotosCountView)
+        $0.addArrangedSubview(myPhotosCountView)
+        
+    }
+    
+    private lazy var allParticipatedDayCountView: UIView = UIView().then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = AttributeValue.scoreInfoViewCornerRadius
+        $0.backgroundColor = UIColor.secondarySystemBackground
+        $0.addSubview(allParticiatedDayCountStackView)
+    }
+    
+    private lazy var allParticiatedDayCountStackView: UIStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 0.0
+        $0.alignment = .fill
+        $0.distribution = .fillProportionally
+        
+        $0.addArrangedSubview(allParticipatedDayCountNum)
+        $0.addArrangedSubview(allParticipatedDayCountLabel)
+    }
+    
+    private let allParticipatedDayCountNum: UILabel = UILabel().then {
+        $0.text = "12"
+        $0.textColor = UIColor.black
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.countFontSize)
+        $0.textAlignment = .center
+    }
+    
+    private let allParticipatedDayCountLabel: UILabel = UILabel().then {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 3
+
+        let attrString = NSMutableAttributedString(string: Strings.allParticipatedDayCountText)
+        attrString.addAttribute(.paragraphStyle, value:paragraphStyle, range: NSMakeRange(0, attrString.length))
+    
+        $0.attributedText = attrString
+        $0.textColor = UIColor.secondaryLabel
+        $0.textAlignment = .center
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.infoLabelFontSize)
+        $0.numberOfLines = 0
+    }
+    
+    private lazy var totalPhotosCountView: UIView = UIView().then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = AttributeValue.scoreInfoViewCornerRadius
+        $0.backgroundColor = UIColor.secondarySystemBackground
+        $0.addSubview(totalPhotosCountStackView)
+    }
+    
+    private lazy var totalPhotosCountStackView: UIStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 0.0
+        $0.alignment = .fill
+        $0.distribution = .fillProportionally
+        
+        $0.addArrangedSubview(totalPhotosCountNum)
+        $0.addArrangedSubview(totalPhotosCountLabel)
+    }
+    
+    private let totalPhotosCountNum: UILabel = UILabel().then {
+        $0.text = "124"
+        $0.textColor = UIColor.black
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.countFontSize)
+        $0.textAlignment = .center
+    }
+    
+    private let totalPhotosCountLabel: UILabel = UILabel().then {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 3
+
+        let attrString = NSMutableAttributedString(string: Strings.totalPhotosCountText)
+        attrString.addAttribute(.paragraphStyle, value:paragraphStyle, range: NSMakeRange(0, attrString.length))
+
+        $0.attributedText = attrString
+        $0.textColor = UIColor.secondaryLabel
+        $0.textAlignment = .center
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.infoLabelFontSize)
+        $0.numberOfLines = 0
+    }
+    
+    private lazy var myPhotosCountView: UIView = UIView().then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = AttributeValue.scoreInfoViewCornerRadius
+        $0.backgroundColor = UIColor.secondarySystemBackground
+        $0.addSubview(myPhotosCountStackView)
+    }
+    
+    private lazy var myPhotosCountStackView: UIStackView = UIStackView().then {
+        $0.axis = .vertical
+        $0.spacing = 0.0
+        $0.alignment = .fill
+        $0.distribution = .fillProportionally
+        
+        $0.addArrangedSubview(myPhotosCountNum)
+        $0.addArrangedSubview(myPhotosCountLabel)
+    }
+    
+    private let myPhotosCountNum: UILabel = UILabel().then {
+        $0.text = "38"
+        $0.textColor = UIColor.black
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.countFontSize)
+        $0.textAlignment = .center
+    }
+    
+    private let myPhotosCountLabel: UILabel = UILabel().then {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 3
+
+        let attrString = NSMutableAttributedString(string: Strings.myPhotosCountText)
+        attrString.addAttribute(.paragraphStyle, value:paragraphStyle, range: NSMakeRange(0, attrString.length))
+        
+        $0.attributedText = attrString
+        $0.textColor = UIColor.secondaryLabel
+        $0.textAlignment = .center
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.infoLabelFontSize)
+        $0.numberOfLines = 0
+    }
+    
+    private let calendarTitleLabel: UILabel = UILabel().then {
+        $0.text = Strings.calendarName
+        $0.textColor = UIColor.white
+        $0.font = UIFont.boldSystemFont(ofSize: AttributeValue.calendarTitleFontSize)
+        $0.backgroundColor = UIColor.black
+    }
+    
+    private lazy var infoButton: UIButton = UIButton(type: .system).then {
+        let sizeConfig = UIImage.SymbolConfiguration(pointSize: 14, weight: .bold)
+        let colorConfig = UIImage.SymbolConfiguration(hierarchicalColor: UIColor.white)
+
+        let image: UIImage? = UIImage(
+            systemName: SFSymbol.exclamationMark,
+            withConfiguration: sizeConfig.applying(colorConfig)
+        )
+        $0.setImage(image, for: .normal)
+    }
+    
+    private lazy var titleStackView: UIStackView = UIStackView().then {
+        $0.axis = .horizontal
+        $0.spacing = 10.0
+        $0.alignment = .fill
+        $0.distribution = .fill
+        
+        $0.addArrangedSubview(calendarTitleLabel)
+        $0.addArrangedSubview(infoButton)
     }
     
     private let calendarView: FSCalendar = FSCalendar().then {
@@ -31,30 +187,61 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
         $0.today = nil
         $0.scrollEnabled = false
         $0.placeholderType = .fillSixRows
+        $0.adjustsBoundingRectWhenChangingMonths = true
         
         $0.appearance.selectionColor = UIColor.clear
         
-        $0.appearance.titleFont = UIFont.boldSystemFont(ofSize: 20)
+        $0.appearance.titleFont = UIFont.boldSystemFont(ofSize: AttributeValue.dayFontSize)
         $0.appearance.titleDefaultColor = UIColor.white
         $0.appearance.titleSelectionColor = UIColor.white
         
-        $0.appearance.weekdayFont = UIFont.systemFont(ofSize: 16)
+        $0.appearance.weekdayFont = UIFont.systemFont(ofSize: AttributeValue.weekdayFontSize)
         $0.appearance.weekdayTextColor = UIColor.white
         $0.appearance.caseOptions = .weekdayUsesSingleUpperCase
         
-        $0.appearance.titlePlaceholderColor = UIColor.systemGray5
+        $0.appearance.titlePlaceholderColor = UIColor.systemGray.withAlphaComponent(0.3)
         
         $0.backgroundColor = UIColor.black
         
         $0.locale = Locale.autoupdatingCurrent
+        $0.register(ImageMonthCalendarCell.self, forCellReuseIdentifier: ImageMonthCalendarCell.identifier)
+        $0.register(PlaceholderCalendarCell.self, forCellReuseIdentifier: PlaceholderCalendarCell.identifier)
     }
     
     // MARK: - Properties
-    static var identifier: String = "CalendarPageViewCell"
+    weak var delegate: CalendarViewDelegate?
+    
+    static var identifier: String = "CalendarPageCell"
     
     // MARK: - Constants
+    private enum Strings {
+        static let calendarName: String = "추억 캘린더"
+        static let allParticipatedDayCountText: String = "모두\n참여한 날"
+        static let totalPhotosCountText: String = "전체\n사진 수"
+        static let myPhotosCountText: String = "나의\n사진 수"
+        
+    }
+    
+    private enum AttributeValue {
+        static let scoreViewCornerRadius: CGFloat = 24.0
+        static let scoreInfoStackSpacing: CGFloat = 8.0
+        static let scoreInfoViewCornerRadius: CGFloat = 18.0
+        static let countFontSize: CGFloat = 20.0
+        static let infoLabelFontSize: CGFloat = 14.0
+        static let calendarTitleFontSize: CGFloat = 20.0
+        static let dayFontSize: CGFloat = 20.0
+        static let weekdayFontSize: CGFloat = 16.0
+    }
+    
     private enum AutoLayout {
-        static let defaultOffsetValue: CGFloat = 0.0
+        static let defaultOffsetValue: CGFloat = 16.0
+        static let scoreViewBottomOffsetValue: CGFloat = 36.0
+        static let infoStackHeightMultiplier: CGFloat = 0.75
+        static let calendarHeightMultiplier: CGFloat = 0.9
+    }
+    
+    private enum SFSymbol {
+        static let exclamationMark: String = "exclamationmark.circle"
     }
     
     // MARK: - Intializer
@@ -70,23 +257,54 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
     override func setupUI() { 
         super.setupUI()
         contentView.addSubview(scoreView)
+        contentView.addSubview(titleStackView)
         contentView.addSubview(calendarView)
     }
     
     override func setupAutoLayout() { 
         super.setupAutoLayout()
         scoreView.snp.makeConstraints {
-            $0.leading.equalTo(contentView.snp.leading).offset(16.0)
-            $0.top.equalTo(contentView.snp.top).offset(4.0)
-            $0.trailing.equalTo(contentView.snp.trailing).offset(-16.0)
-            $0.bottom.equalTo(calendarView.snp.top).offset(-50.0)
+            $0.leading.equalTo(contentView.snp.leading).offset(AutoLayout.defaultOffsetValue)
+            $0.top.equalTo(contentView.snp.top).offset(AutoLayout.defaultOffsetValue)
+            $0.trailing.equalTo(contentView.snp.trailing).offset(-AutoLayout.defaultOffsetValue)
+            $0.bottom.equalTo(titleStackView.snp.top).offset(-AutoLayout.scoreViewBottomOffsetValue)
+        }
+        
+        scoreInfoStackView.snp.makeConstraints {
+            $0.leading.equalTo(scoreView.snp.leading).offset(AutoLayout.defaultOffsetValue)
+            $0.trailing.equalTo(scoreView.snp.trailing).offset(-AutoLayout.defaultOffsetValue)
+            $0.bottom.equalTo(scoreView.snp.bottom).offset(-AutoLayout.defaultOffsetValue)
+            $0.height.equalTo(allParticipatedDayCountView.snp.width)
+        }
+        
+        allParticiatedDayCountStackView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview().multipliedBy(AutoLayout.infoStackHeightMultiplier)
+            $0.center.equalTo(allParticipatedDayCountView.snp.center)
+        }
+        
+        totalPhotosCountStackView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview().multipliedBy(AutoLayout.infoStackHeightMultiplier)
+            $0.center.equalTo(totalPhotosCountView.snp.center)
+        }
+        
+        myPhotosCountStackView.snp.makeConstraints {
+            $0.width.equalToSuperview()
+            $0.height.equalToSuperview().multipliedBy(AutoLayout.infoStackHeightMultiplier)
+            $0.center.equalTo(myPhotosCountView.snp.center)
+        }
+        
+        titleStackView.snp.makeConstraints {
+            $0.leading.equalTo(scoreView)
+            $0.bottom.equalTo(calendarView.snp.top).offset(-AutoLayout.defaultOffsetValue)
         }
         
         calendarView.snp.makeConstraints {
-            $0.leading.equalTo(contentView.snp.leading).offset(16.0)
+            $0.leading.equalTo(contentView.snp.leading).offset(AutoLayout.defaultOffsetValue)
             $0.bottom.equalTo(contentView.snp.bottom)
-            $0.trailing.equalTo(contentView.snp.trailing).offset(-16.0)
-            $0.height.equalTo(contentView.snp.width).multipliedBy(0.95)
+            $0.trailing.equalTo(contentView.snp.trailing).offset(-AutoLayout.defaultOffsetValue)
+            $0.height.equalTo(contentView.snp.width).multipliedBy(AutoLayout.calendarHeightMultiplier)
         }
     }
     
@@ -96,17 +314,64 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
         calendarView.dataSource = self
     }
     
-    override func bind(reactor: CalendarPageCellReactor) { }
+    override func bind(reactor: CalendarPageCellReactor) { 
+        super.bind(reactor: reactor)
+        
+        // Action
+        infoButton.rx.tap
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .withUnretained(self)
+            .subscribe {
+                $0.0.delegate?.presentPopoverView(sourceView: $0.0.infoButton)
+            }
+            .disposed(by: disposeBag)
+    }
 }
 
 extension CalendarPageCell: FSCalendarDelegate { 
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
-        return true
+        let calendarMonth = calendar.currentPage.month
+        let positionMonth = date.month
+        // 셀의 날짜가 현재 월(月)과 동일하다면
+        if calendarMonth == positionMonth {
+            return true
+        }
+        return false
     }
 }
 
-extension CalendarPageCell: FSCalendarDataSource { 
+extension CalendarPageCell: FSCalendarDataSource {
     func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {
-        <#code#>
+        let calendarMonth = calendar.currentPage.month
+        let positionMonth = date.month
+        // 셀의 날짜가 현재 월(月)과 동일하다면
+        if calendarMonth == positionMonth {
+            let cell = calendar.dequeueReusableCell(
+                withIdentifier: ImageMonthCalendarCell.identifier,
+                for: date,
+                at: position
+            ) as! ImageMonthCalendarCell
+            
+            // Dummy Data
+            let imageUrls = [
+                "https://cdn.pixabay.com/photo/2023/11/20/13/48/butterfly-8401173_1280.jpg",
+                "https://cdn.pixabay.com/photo/2023/11/10/02/30/woman-8378634_1280.jpg",
+                "https://cdn.pixabay.com/photo/2023/11/26/08/27/leaves-8413064_1280.jpg",
+                "https://cdn.pixabay.com/photo/2023/09/03/17/00/chives-8231068_1280.jpg",
+                "https://cdn.pixabay.com/photo/2023/09/25/13/42/kingfisher-8275049_1280.png",
+                "", "", "", ""
+            ]
+            cell.configure(date, imageUrl: imageUrls.randomElement() ?? "")
+            
+            return cell
+        // 셀의 날짜가 현재 월(月)과 동일하지 않다면
+        } else {
+            let cell = calendar.dequeueReusableCell(
+                withIdentifier: PlaceholderCalendarCell.identifier,
+                for: date,
+                at: position
+            ) as! PlaceholderCalendarCell
+            return cell
+        }
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -15,22 +15,47 @@ import RxSwift
 import SnapKit
 import Then
 
-final class CalendarPageViewCell: BaseCollectionViewCell<CalendarPageCellReactor> {
+final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
     // MARK: - Views
-    private let memoryScoreView: UIView = UIView().then {
+    private let scoreView: UIView = UIView().then {
         $0.layer.masksToBounds = true
-        $0.layer.cornerRadius = 10.0
+        $0.layer.cornerRadius = 20.0
         $0.backgroundColor = UIColor.systemGray6
     }
     
     private let calendarView: FSCalendar = FSCalendar().then {
+        $0.rowHeight = 50.0
+        $0.headerHeight = 0.0
+        $0.weekdayHeight = 40.0
+        
+        $0.today = nil
         $0.scrollEnabled = false
+        $0.placeholderType = .fillSixRows
+        
+        $0.appearance.selectionColor = UIColor.clear
+        
+        $0.appearance.titleFont = UIFont.boldSystemFont(ofSize: 20)
+        $0.appearance.titleDefaultColor = UIColor.white
+        $0.appearance.titleSelectionColor = UIColor.white
+        
+        $0.appearance.weekdayFont = UIFont.systemFont(ofSize: 16)
+        $0.appearance.weekdayTextColor = UIColor.white
+        $0.appearance.caseOptions = .weekdayUsesSingleUpperCase
+        
+        $0.appearance.titlePlaceholderColor = UIColor.systemGray5
+        
+        $0.backgroundColor = UIColor.black
+        
+        $0.locale = Locale.autoupdatingCurrent
     }
     
     // MARK: - Properties
     static var identifier: String = "CalendarPageViewCell"
     
     // MARK: - Constants
+    private enum AutoLayout {
+        static let defaultOffsetValue: CGFloat = 0.0
+    }
     
     // MARK: - Intializer
     override init(frame: CGRect) {
@@ -44,13 +69,13 @@ final class CalendarPageViewCell: BaseCollectionViewCell<CalendarPageCellReactor
     // MARK: - Helpers
     override func setupUI() { 
         super.setupUI()
-        contentView.addSubview(memoryScoreView)
+        contentView.addSubview(scoreView)
         contentView.addSubview(calendarView)
     }
     
     override func setupAutoLayout() { 
         super.setupAutoLayout()
-        memoryScoreView.snp.makeConstraints {
+        scoreView.snp.makeConstraints {
             $0.leading.equalTo(contentView.snp.leading).offset(16.0)
             $0.top.equalTo(contentView.snp.top).offset(4.0)
             $0.trailing.equalTo(contentView.snp.trailing).offset(-16.0)
@@ -63,17 +88,25 @@ final class CalendarPageViewCell: BaseCollectionViewCell<CalendarPageCellReactor
             $0.trailing.equalTo(contentView.snp.trailing).offset(-16.0)
             $0.height.equalTo(contentView.snp.width).multipliedBy(0.95)
         }
-        
-        
     }
     
     override func setupAttributes() { 
         super.setupAttributes()
+        calendarView.delegate = self
+        calendarView.dataSource = self
     }
     
     override func bind(reactor: CalendarPageCellReactor) { }
 }
 
-extension CalendarPageViewCell: FSCalendarDelegate { }
+extension CalendarPageCell: FSCalendarDelegate { 
+    func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
+        return true
+    }
+}
 
-extension CalendarPageViewCell: FSCalendarDataSource { }
+extension CalendarPageCell: FSCalendarDataSource { 
+    func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {
+        <#code#>
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
@@ -1,0 +1,8 @@
+//
+//  ImageCalendarCell.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import Foundation

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
@@ -1,8 +1,0 @@
-//
-//  ImageCalendarCell.swift
-//  App
-//
-//  Created by 김건우 on 12/6/23.
-//
-
-import Foundation

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageMonthCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageMonthCalendarCell.swift
@@ -1,0 +1,107 @@
+//
+//  ImageCalendarCell.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import Foundation
+
+import Core
+import FSCalendar
+import Kingfisher
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class ImageMonthCalendarCell: FSCalendarCell {
+    // MARK: - Views
+    private let thumbnailView: UIImageView = UIImageView().then {
+        $0.clipsToBounds = true
+        $0.contentMode = .scaleAspectFill
+        $0.layer.cornerRadius = AttributeValue.thumbnailCornerRadius
+        $0.layer.borderWidth = 0.0
+        $0.layer.borderColor = UIColor.white.cgColor
+        $0.alpha = AttributeValue.defaultAlphaValue
+    }
+    
+    private let badgeView: UIView = UIView().then {
+        $0.clipsToBounds = true
+        $0.layer.cornerRadius = AutoLayout.badgeHeightValue / 2.0
+        $0.backgroundColor = UIColor.white
+        $0.isHidden = true
+    }
+    
+    // MARK: - Properties
+    static let identifier: String = "ImageMonthCalendarCell"
+    
+    // MARK: - Constants
+    private enum AttributeValue {
+        static let defaultAlphaValue: CGFloat = 0.8
+        static let thumbnailCornerRadius: CGFloat = 10.0
+        static let thumbnailBorderWidth: CGFloat = 2.5
+    }
+    
+    private enum AutoLayout {
+        static let thumbnailInsetValue: CGFloat = 5.0
+        static let badgeHeightValue: CGFloat = 9.0
+        static let badgeOffsetValue: CGFloat = 2.0
+    }
+    
+    // MARK: - Intializer
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupUI()
+        setupAutoLayout()
+    }
+    
+    required init(coder aDecoder: NSCoder!) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helpers
+    func setupUI() {
+        contentView.insertSubview(thumbnailView, at: 0)
+        contentView.addSubview(badgeView)
+    }
+    
+    func setupAutoLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.center.equalTo(contentView.snp.center)
+        }
+        
+        thumbnailView.snp.makeConstraints {
+            $0.center.equalTo(contentView.snp.center)
+            $0.width.height.equalTo(contentView.snp.width).inset(AutoLayout.thumbnailInsetValue)
+        }
+        
+        badgeView.snp.makeConstraints {
+            $0.top.equalTo(contentView.snp.top).offset(AutoLayout.badgeOffsetValue)
+            $0.trailing.equalTo(contentView.snp.trailing).offset(-AutoLayout.badgeOffsetValue)
+            $0.width.height.equalTo(AutoLayout.badgeHeightValue)
+        }
+        
+    }
+    
+    // Temp Code
+    func configure(_ date: Date, imageUrl: String) {
+        if let url = URL(string: imageUrl) {
+            thumbnailView.kf.setImage(with: url)
+            
+            let random = Bool.random()
+            badgeView.isHidden = random
+        } 
+        
+        if date.isToday {
+            thumbnailView.layer.borderWidth = AttributeValue.thumbnailBorderWidth
+        }
+    }
+    
+    override func prepareForReuse() {
+        thumbnailView.image = nil
+        thumbnailView.layer.borderWidth = .zero
+        badgeView.isHidden = true
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/PlaceholderCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/PlaceholderCalendarCell.swift
@@ -1,0 +1,8 @@
+//
+//  PlaceholderCalendarCell.swift
+//  App
+//
+//  Created by 김건우 on 12/6/23.
+//
+
+import Foundation

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/PlaceholderCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/PlaceholderCalendarCell.swift
@@ -6,3 +6,34 @@
 //
 
 import Foundation
+
+import Core
+import FSCalendar
+import Kingfisher
+import ReactorKit
+import RxCocoa
+import RxSwift
+import SnapKit
+import Then
+
+final class PlaceholderCalendarCell: FSCalendarCell {
+    // MARK: - Properties
+    static let identifier: String = "PlaceholderCalendarCell"
+    
+    // MARK: - Intializer
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupAutoLayout()
+    }
+    
+    required init(coder aDecoder: NSCoder!) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Helpers
+    func setupAutoLayout() {
+        titleLabel.snp.makeConstraints {
+            $0.center.equalTo(contentView.snp.center)
+        }
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarDescriptionPopoverViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarDescriptionPopoverViewController.swift
@@ -1,0 +1,62 @@
+//
+//  CalendarDescriptionPopoverViewController.swift
+//  App
+//
+//  Created by 김건우 on 12/7/23.
+//
+
+import UIKit
+
+import Core
+import FSCalendar
+import ReactorKit
+import RxCocoa
+import RxSwift
+import RxDataSources
+import SnapKit
+import Then
+
+class CalendarDescriptionPopoverViewController: UIViewController {
+    // MARK: - Views
+    let descrpitionLabel: UILabel = UILabel().then {
+        $0.text = Strings.descriptionText
+        $0.textColor = UIColor.white
+        $0.textAlignment = .center
+    }
+    
+    // MARK: - Constants
+    private enum Strings {
+        static let descriptionText: String = "모두 참여한 날에는 날짜 옆 동그라미가 추가돼요"
+    }
+    
+    private enum AutoLayout {
+        static let defaultOffsetValue: CGFloat = 4.0
+        static let descriptionLabelBoottomOffsetValue: CGFloat = 16.0
+    }
+    
+    // MARK: - Lifecycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupAutoLayout()
+        setupAttributes()
+    }
+    
+    private func setupUI() {
+        view.addSubview(descrpitionLabel)
+    }
+    
+    private func setupAutoLayout() {
+        descrpitionLabel.snp.makeConstraints {
+            $0.leading.equalTo(view.snp.leading).offset(AutoLayout.defaultOffsetValue)
+            $0.top.equalTo(view.snp.top).offset(AutoLayout.defaultOffsetValue)
+            $0.trailing.equalTo(view.snp.trailing).offset(-AutoLayout.defaultOffsetValue)
+            $0.bottom.equalTo(view.snp.bottom).offset(-AutoLayout.descriptionLabelBoottomOffsetValue)
+        }
+    }
+    
+    private func setupAttributes() {
+        view.backgroundColor = UIColor.darkGray
+    }
+
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -16,25 +16,39 @@ import RxDataSources
 import SnapKit
 import Then
 
+// MARK: - Delegate
+protocol CalendarViewDelegate: AnyObject {
+    func goToWeekCalendarView(_ date: Date)
+    func presentPopoverView(sourceView: UIView)
+}
+
+// MARK: - ViewController
 final class CalendarViewController: BaseViewController<CalendarViewReactor> {
     // MARK: - Views
     private lazy var collectionView: UICollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: orthogonalCompositionalLayout
     ).then {
-        $0.dataSource = self // temp code
+        $0.dataSource = self
         
         $0.isScrollEnabled = false
-        $0.backgroundColor = UIColor.white
+        $0.backgroundColor = UIColor.black
         
-        $0.register(CalendarPageViewCell.self, forCellWithReuseIdentifier: CalendarPageViewCell.identifier)
+        $0.register(CalendarPageCell.self, forCellWithReuseIdentifier: CalendarPageCell.identifier)
     }
     
-    // MARK: - Properties
+    // MARK: - Constants
+    private enum AttributeValue {
+        static let popoverWidth: CGFloat = 350.0
+        static let popoverHeight: CGFloat = 40.0
+    }
     
     // MARK: - Lifecycles
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // temp code
+        view.backgroundColor = UIColor.black
     }
     
     // MARK: - Helpers
@@ -48,10 +62,6 @@ final class CalendarViewController: BaseViewController<CalendarViewReactor> {
         collectionView.snp.makeConstraints {
             $0.edges.equalTo(view.safeAreaLayoutGuide)
         }
-    }
-    
-    override func setupAttributes() { 
-        super.setupAttributes()
     }
     
     override func bind(reactor: CalendarViewReactor) { }
@@ -88,6 +98,31 @@ extension CalendarViewController {
     }
 }
 
+extension CalendarViewController: CalendarViewDelegate {
+    func goToWeekCalendarView(_ date: Date) {
+        // do something...
+    }
+    
+    func presentPopoverView(sourceView: UIView) {
+        let vc = CalendarDescriptionPopoverViewController()
+        vc.preferredContentSize = CGSize(
+            width: AttributeValue.popoverWidth,
+            height: AttributeValue.popoverHeight
+        )
+        vc.modalPresentationStyle = .popover
+        if let presentation = vc.presentationController {
+            presentation.delegate = self
+        }
+        present(vc, animated: true)
+        if let pop = vc.popoverPresentationController {
+            pop.sourceView = sourceView
+            pop.sourceRect = sourceView.bounds
+        }
+        
+    }
+}
+
+// Temp Code
 extension CalendarViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return 3
@@ -95,9 +130,17 @@ extension CalendarViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: CalendarPageViewCell.identifier,
+            withReuseIdentifier: CalendarPageCell.identifier,
             for: indexPath
-        ) as! CalendarPageViewCell
+        ) as! CalendarPageCell
+        cell.reactor = CalendarPageCellReactor()
+        cell.delegate = self
         return cell
+    }
+}
+
+extension CalendarViewController: UIPopoverPresentationControllerDelegate {
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        return .none
     }
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- Date+Extension을 추가하였습니다.
   - 날짜 비교(isEqual) 및 날짜 간격(interval)을 구하는 함수가 포함되어 있습니다. 

- 메인 캘린더 UI를 구현하였습니다.
   - 일부 UI (색상 등)은 추후 수정하겠습니다.
   - 뷰 컨트롤러에 더미 데이터가 포함되어 있습니다. 
   - 중복된 일부 뷰는 추후 공통 모듈로 빼도록 하겠습니다.

## 스크린샷 📷

| 이미지 | 
| :--: | 
| <img src="https://github.com/depromeet/14th-team5-iOS/assets/21079970/f1a5ea39-0e06-4c8b-a23f-b95a09be775d" align="center" width="235" height="511"> |


