### PR TITLE
Feat: 주간 캘린더 UI 구현, UIStackView+Ext 추가

### DIFF
--- a/14th-team5-iOS/App/Sources/Extensions/Date+Ext.swift
+++ b/14th-team5-iOS/App/Sources/Extensions/Date+Ext.swift
@@ -10,8 +10,26 @@ import Foundation
 extension Date {
     private var calendar: Calendar {
         return Calendar.autoupdatingCurrent
-    } 
+    }
     
+    var isToday: Bool {
+        return self.isEqual(with: Date.now)
+    }
+    
+    var year: Int {
+        return calendar.component(.year, from: self)
+    }
+    
+    var month: Int {
+        return calendar.component(.month, from: self)
+    }
+    
+    var day: Int {
+        return calendar.component(.day, from: self)
+    }
+}
+
+extension Date {
     func isEqual(
         _ components: Set<Calendar.Component> = [.year, .month, .day],
         with date: Date
@@ -38,21 +56,5 @@ extension Date {
             dict[component] = interval.value(for: component) ?? 0
         }
         return dict
-    }
-    
-    var year: Int {
-        return calendar.component(.year, from: self)
-    }
-    
-    var month: Int {
-        return calendar.component(.month, from: self)
-    }
-    
-    var day: Int {
-        return calendar.component(.day, from: self)
-    }
-    
-    var isToday: Bool {
-        return self.isEqual(with: Date.now)
     }
 }

--- a/14th-team5-iOS/App/Sources/Extensions/UIStackView+Ext.swift
+++ b/14th-team5-iOS/App/Sources/Extensions/UIStackView+Ext.swift
@@ -1,0 +1,16 @@
+//
+//  UIStackView+Ext.swift
+//  App
+//
+//  Created by 김건우 on 12/8/23.
+//
+
+import UIKit
+
+extension UIStackView {
+    func addArrangedSubViews(_ views: UIView...) {
+        for view in views {
+            self.addArrangedSubview(view)
+        }
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarFeedViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarFeedViewReactor.swift
@@ -1,0 +1,30 @@
+//
+//  CalendarFeedViewReactor.swift
+//  App
+//
+//  Created by 김건우 on 12/8/23.
+//
+
+import Foundation
+
+import ReactorKit
+import RxSwift
+
+final class CalendarFeedViewReactor: Reactor {
+    // MARK: - Action
+    enum Action { }
+    
+    // MARK: - Mutation
+    enum Mutation { }
+    
+    // MARK: - State
+    struct State { }
+    
+    // MARK: - Properties
+    var initialState: State
+    
+    // MARK: - Intializer
+    init() {
+        self.initialState = State()
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -329,6 +329,10 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
 }
 
 extension CalendarPageCell: FSCalendarDelegate { 
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        delegate?.goToCalendarFeedView(date)
+    }
+    
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
         let calendarMonth = calendar.currentPage.month
         let positionMonth = date.month

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -180,7 +180,6 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
     }
     
     private let calendarView: FSCalendar = FSCalendar().then {
-        $0.rowHeight = 50.0
         $0.headerHeight = 0.0
         $0.weekdayHeight = 40.0
         

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageMonthCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageMonthCalendarCell.swift
@@ -17,6 +17,12 @@ import SnapKit
 import Then
 
 final class ImageMonthCalendarCell: FSCalendarCell {
+    // MARK: - Enums
+    enum CellType {
+        case month
+        case week
+    }
+    
     // MARK: - Views
     private let thumbnailView: UIImageView = UIImageView().then {
         $0.clipsToBounds = true
@@ -40,6 +46,8 @@ final class ImageMonthCalendarCell: FSCalendarCell {
     // MARK: - Constants
     private enum AttributeValue {
         static let defaultAlphaValue: CGFloat = 0.8
+        static let deselectAlphaValue: CGFloat = 0.4
+        static let selectAlphaValue: CGFloat = 0.8
         static let thumbnailCornerRadius: CGFloat = 10.0
         static let thumbnailBorderWidth: CGFloat = 2.5
     }
@@ -85,23 +93,29 @@ final class ImageMonthCalendarCell: FSCalendarCell {
         
     }
     
+    override func prepareForReuse() {
+        thumbnailView.image = nil
+        thumbnailView.layer.borderWidth = .zero
+        badgeView.isHidden = true
+    }
+}
+
+extension ImageMonthCalendarCell {
     // Temp Code
-    func configure(_ date: Date, imageUrl: String) {
+    func configure(_ date: Date, imageUrl: String, cellType type: CellType = .month) {
         if let url = URL(string: imageUrl) {
             thumbnailView.kf.setImage(with: url)
             
             let random = Bool.random()
             badgeView.isHidden = random
-        } 
-        
-        if date.isToday {
-            thumbnailView.layer.borderWidth = AttributeValue.thumbnailBorderWidth
         }
-    }
-    
-    override func prepareForReuse() {
-        thumbnailView.image = nil
-        thumbnailView.layer.borderWidth = .zero
-        badgeView.isHidden = true
+        
+        if type == .week {
+            thumbnailView.alpha = 0.4
+        } else {
+            if date.isToday {
+                thumbnailView.layer.borderWidth = AttributeValue.thumbnailBorderWidth
+            }
+        }
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarDescriptionPopoverViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarDescriptionPopoverViewController.swift
@@ -16,7 +16,7 @@ import RxDataSources
 import SnapKit
 import Then
 
-class CalendarDescriptionPopoverViewController: UIViewController {
+final class CalendarDescriptionPopoverViewController: UIViewController {
     // MARK: - Views
     let descrpitionLabel: UILabel = UILabel().then {
         $0.text = Strings.descriptionText

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarFeedViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarFeedViewController.swift
@@ -19,14 +19,12 @@ import Then
 final class CalendarFeedViewController: BaseViewController<CalendarFeedViewReactor> {
     // MARK: - Views
     private lazy var calendarView: FSCalendar = FSCalendar().then {
-        $0.rowHeight = 55.0
         $0.headerHeight = 0.0
-        $0.weekdayHeight = 40.0
+        $0.weekdayHeight = 30.0
         
         $0.today = nil
         $0.scope = .week
         $0.allowsMultipleSelection = false
-        $0.adjustsBoundingRectWhenChangingMonths = true
         
         $0.appearance.selectionColor = UIColor.clear
         
@@ -57,7 +55,7 @@ final class CalendarFeedViewController: BaseViewController<CalendarFeedViewReact
     }
     
     private enum AutoLayout {
-        static let calendarHeightValue: CGFloat = 110.0
+        static let calendarHeightValue: CGFloat = 350.0
     }
     
     // MARK: - Lifecycles
@@ -88,7 +86,14 @@ final class CalendarFeedViewController: BaseViewController<CalendarFeedViewReact
     override func bind(reactor: CalendarFeedViewReactor) { }
 }
 
-extension CalendarFeedViewController: FSCalendarDelegate { }
+extension CalendarFeedViewController: FSCalendarDelegate {
+    func calendar(_ calendar: FSCalendar, boundingRectWillChange bounds: CGRect, animated: Bool) {
+        calendar.snp.updateConstraints {
+            $0.height.equalTo(bounds.height)
+        }
+        view.layoutIfNeeded()
+    }
+}
 
 extension CalendarFeedViewController: FSCalendarDataSource {
     func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarFeedViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarFeedViewController.swift
@@ -1,0 +1,114 @@
+//
+//  CalendarFeedViewController.swift
+//  App
+//
+//  Created by 김건우 on 12/8/23.
+//
+
+import UIKit
+
+import Core
+import FSCalendar
+import ReactorKit
+import RxCocoa
+import RxSwift
+import RxDataSources
+import SnapKit
+import Then
+
+final class CalendarFeedViewController: BaseViewController<CalendarFeedViewReactor> {
+    // MARK: - Views
+    private lazy var calendarView: FSCalendar = FSCalendar().then {
+        $0.rowHeight = 55.0
+        $0.headerHeight = 0.0
+        $0.weekdayHeight = 40.0
+        
+        $0.today = nil
+        $0.scope = .week
+        $0.allowsMultipleSelection = false
+        $0.adjustsBoundingRectWhenChangingMonths = true
+        
+        $0.appearance.selectionColor = UIColor.clear
+        
+        $0.appearance.titleFont = UIFont.boldSystemFont(ofSize: AttributeValue.dayFontSize)
+        $0.appearance.titleDefaultColor = UIColor.white
+        $0.appearance.titleSelectionColor = UIColor.white
+        
+        $0.appearance.weekdayFont = UIFont.systemFont(ofSize: AttributeValue.weekdayFontSize)
+        $0.appearance.weekdayTextColor = UIColor.white
+        $0.appearance.caseOptions = .weekdayUsesSingleUpperCase
+        
+        $0.appearance.titlePlaceholderColor = UIColor.systemGray.withAlphaComponent(0.3)
+        
+        $0.backgroundColor = UIColor.black
+        
+        $0.locale = Locale.autoupdatingCurrent
+        $0.register(ImageMonthCalendarCell.self, forCellReuseIdentifier: ImageMonthCalendarCell.identifier)
+        $0.register(PlaceholderCalendarCell.self, forCellReuseIdentifier: PlaceholderCalendarCell.identifier)
+    }
+    
+    // MARK: - Properties
+    
+    // MARK: - Constants
+    private enum AttributeValue {
+        static let calendarTitleFontSize: CGFloat = 20.0
+        static let dayFontSize: CGFloat = 20.0
+        static let weekdayFontSize: CGFloat = 16.0
+    }
+    
+    private enum AutoLayout {
+        static let calendarHeightValue: CGFloat = 110.0
+    }
+    
+    // MARK: - Lifecycles
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    // MARK: - Helpers
+    override func setupUI() { 
+        super.setupUI()
+        view.addSubview(calendarView)
+    }
+    
+    override func setupAutoLayout() { 
+        super.setupAutoLayout()
+        calendarView.snp.makeConstraints {
+            $0.leading.top.trailing.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(AutoLayout.calendarHeightValue)
+        }
+    }
+    
+    override func setupAttributes() { 
+        super.setupAttributes()
+        calendarView.delegate = self
+        calendarView.dataSource = self
+    }
+
+    override func bind(reactor: CalendarFeedViewReactor) { }
+}
+
+extension CalendarFeedViewController: FSCalendarDelegate { }
+
+extension CalendarFeedViewController: FSCalendarDataSource {
+    func calendar(_ calendar: FSCalendar, cellFor date: Date, at position: FSCalendarMonthPosition) -> FSCalendarCell {
+        let cell = calendar.dequeueReusableCell(
+            withIdentifier: ImageMonthCalendarCell.identifier,
+            for: date,
+            at: position
+        ) as! ImageMonthCalendarCell
+        
+        // Dummy Data
+        let imageUrls = [
+            "https://cdn.pixabay.com/photo/2023/11/20/13/48/butterfly-8401173_1280.jpg",
+            "https://cdn.pixabay.com/photo/2023/11/10/02/30/woman-8378634_1280.jpg",
+            "https://cdn.pixabay.com/photo/2023/11/26/08/27/leaves-8413064_1280.jpg",
+            "https://cdn.pixabay.com/photo/2023/09/03/17/00/chives-8231068_1280.jpg",
+            "https://cdn.pixabay.com/photo/2023/09/25/13/42/kingfisher-8275049_1280.png",
+            "", "", "", ""
+        ]
+        cell.configure(date, imageUrl: imageUrls.randomElement() ?? "", cellType: .week)
+        
+        return cell
+    }
+}

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -18,7 +18,7 @@ import Then
 
 // MARK: - Delegate
 protocol CalendarViewDelegate: AnyObject {
-    func goToWeekCalendarView(_ date: Date)
+    func goToCalendarFeedView(_ date: Date)
     func presentPopoverView(sourceView: UIView)
 }
 
@@ -46,9 +46,6 @@ final class CalendarViewController: BaseViewController<CalendarViewReactor> {
     // MARK: - Lifecycles
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        // temp code
-        view.backgroundColor = UIColor.black
     }
     
     // MARK: - Helpers
@@ -99,8 +96,9 @@ extension CalendarViewController {
 }
 
 extension CalendarViewController: CalendarViewDelegate {
-    func goToWeekCalendarView(_ date: Date) {
-        // do something...
+    func goToCalendarFeedView(_ date: Date) {
+        let vc = CalendarFeedViewController()
+        navigationController?.pushViewController(vc, animated: true)
     }
     
     func presentPopoverView(sourceView: UIView) {

--- a/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
@@ -25,5 +25,5 @@ extension Package {
     public static let kakaoSDK = Package.remote(repo: "kakao/kakao-ios-sdk", version: "2.19.0")
     public static let kakaoSDKRx = Package.remote(repo: "kakao/kakao-ios-sdk-rx", version: "2.19.0")
     public static let kingFisher = Package.remote(repo: "onevcat/Kingfisher", version: "7.9.1")
-    public static let fsCalendar = Package.remote(repo: "WenchaoD/FSCalendar", version: "2.7.0")
+    public static let fsCalendar = Package.remote(repo: "WenchaoD/FSCalendar", version: "2.8.3")
 }

--- a/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
@@ -25,5 +25,5 @@ extension Package {
     public static let kakaoSDK = Package.remote(repo: "kakao/kakao-ios-sdk", version: "2.19.0")
     public static let kakaoSDKRx = Package.remote(repo: "kakao/kakao-ios-sdk-rx", version: "2.19.0")
     public static let kingFisher = Package.remote(repo: "onevcat/Kingfisher", version: "7.9.1")
-    public static let fsCalendar = Package.remote(repo: "WenchaoD/FSCalendar", version: "2.8.3")
+    public static let fsCalendar = Package.remote(repo: "WenchaoD/FSCalendar", version: "2.7.0")
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- UIStackView+Ext를 추가하였습니다.
   * 다수의 뷰를 한번에 스택에 추가할 수 있는 함수(addArrangedSubviews)가 포함되어 있습니다.

- 주간 캘린더 UI를 구현하였습니다.
   * (코드 스타일이 정해지는대로) 중복된 뷰를 공통 모듈로 빼도록 하겠습니다.
   * 피드 셀 구현은 공통 모듈을 먼저 만드는 게 좋아보여 별도 이슈에서 작업하도록 하겠습니다.
   * 선택 강조 UI는 아직 셀 모델을 작성하지 않은 관계로 잠깐 테스트만 하고, 코드에서 뺏습니다.

## 스크린샷 📷

| 이미지 | 
| :--: | 
| <img src="https://github.com/depromeet/14th-team5-iOS/assets/21079970/a5802db7-7c81-42c5-9e1d-391e1e1f5081" align="center" width="235" height="511"> |


## 테스트 케이스 ✅

- [ ] 타 작업 환경에서도 월간・주간 캘린더 UI가 올바르게 그려지는지 확인
