### PR TITLE
Feat: 초대 링크 복사 화면 UI 수정, 공유 시트 구현

### DIFF
--- a/14th-team5-iOS/App/Sources/Extensions/UIViewController+Ext.swift
+++ b/14th-team5-iOS/App/Sources/Extensions/UIViewController+Ext.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+import Core
 
+extension UIViewController {
+    enum StringLiterals {
+        static let invitationUrlSharePanelTitle: String = "삐삐! 가족에게 보내는 하루 한번 생존 신고"
+    }
+}
 
 extension UIViewController {
     typealias ToastView = UILabel
@@ -45,5 +51,32 @@ extension UIViewController {
             }
         }
     }
+}
+
+extension UIViewController {
+    func makeSharePanel(
+        _ activityItemSources: [UIActivityItemSource],
+        activities: [UIActivity],
+        excludedActivityTypes: [UIActivity.ActivityType] = [.addToReadingList, .copyToPasteboard]
+    ) {
+        let items: [Any] = activityItemSources
+        let activityVC = UIActivityViewController(
+            activityItems: items,
+            applicationActivities: activities
+        )
+        activityVC.excludedActivityTypes = excludedActivityTypes
+        present(activityVC, animated: true)
+    }
     
+    func makeInvitationUrlSharePanel(_ url: URL?, provider globalState: GlobalStateProviderType? = nil) {
+        guard let url = url else { return }
+        let itemSource = UrlActivityItemSource(
+            title: StringLiterals.invitationUrlSharePanelTitle,
+            url: url
+        )
+        let copyToPastboard = CopyInvitationUrlActivity(provider: globalState)
+        
+        UIPasteboard.general.string = url.description
+        makeSharePanel([itemSource], activities: [copyToPastboard])
+    }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPageViewCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPageViewCellReactor.swift
@@ -15,7 +15,7 @@ final class CalendarPageCellReactor: Reactor {
     // MARK: - Action
     enum Action {
         case didSelectCell(Date)
-        case didPressInfoButton(UIView)
+        case didTapInfoButton(UIView)
     }
     
     // MARK: - Mutation
@@ -42,8 +42,8 @@ final class CalendarPageCellReactor: Reactor {
         case let .didSelectCell(date):
             return provider.calendarGlabalState.didSelectCell(date)
                 .map { _ in .none }
-        case let .didPressInfoButton(sourceView):
-            return provider.calendarGlabalState.didPressedInfoButton(sourceView)
+        case let .didTapInfoButton(sourceView):
+            return provider.calendarGlabalState.didTapInfoButton(sourceView)
                 .map { _ in .none }
         }
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -321,7 +321,7 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
         infoButton.rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
             .withUnretained(self)
-            .map { Reactor.Action.didPressInfoButton($0.0.infoButton) }
+            .map { Reactor.Action.didTapInfoButton($0.0.infoButton) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/14th-team5-iOS/App/Sources/Presentation/LinkShare/Reactor/LinkShareViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/LinkShare/Reactor/LinkShareViewReactor.swift
@@ -13,19 +13,66 @@ import RxSwift
 
 final class LinkShareViewReactor: Reactor {
     // MARK: - Action
-    enum Action { }
+    enum Action { 
+        case didTapInvitationUrlButton
+    }
     
     // MARK: - Mutate
-    enum Mutation { }
+    enum Mutation { 
+        case presentSharePanel(URL?)
+        case presentToastMessage
+    }
     
     // MARK: - State
-    struct State { }
+    struct State { 
+        @Pulse var invitationUrl: URL?
+        @Pulse var shouldPresentToastMessage: Bool = false
+    }
     
     // MARK: - Properties
     let initialState: State
+    let provider: GlobalStateProviderType
     
     // MARK: - Intializer
-    init() {
+    init(_ provider: GlobalStateProviderType) {
         self.initialState = State()
+        self.provider = provider
+    }
+    
+    // MARK: - Transform
+    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        let eventMutation = provider.activityGlobalState.event
+            .flatMap { event -> Observable<Mutation> in
+                switch event {
+                case .didTapCopyInvitationUrlAction:
+                    return Observable<Mutation>.just(.presentToastMessage)
+                }
+            }
+        
+        return Observable<Mutation>.merge(mutation, eventMutation)
+    }
+    
+    // MARK: - Mutate
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .didTapInvitationUrlButton:
+            // TODO: - 공유 링크 가져오기 코드 구현
+            return Observable<Mutation>.just(
+                .presentSharePanel(URL(string: "https://github.com/depromeet/14th-team5-iOS"))
+            )
+        }
+    }
+    
+    // MARK: - Reduce
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .presentSharePanel(url):
+            newState.invitationUrl = url
+        // TODO: - ToastMessage 구현하기
+        case .presentToastMessage:
+            newState.shouldPresentToastMessage = true
+        }
+        return newState
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/LinkShare/Strings/LinkShareVC.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/LinkShare/Strings/LinkShareVC.swift
@@ -24,24 +24,18 @@ enum LinkShareVC {
     enum AutoLayout {
         static let defaultOffsetValue: CGFloat = 16.0
         static let shareViewTopOffsetValue: CGFloat = 8.0
-        static let shareViewHeightValue: CGFloat = 260.0
+        static let shareViewHeightValue: CGFloat = 140.0
         
         static let shareTitleLabelTopOffsetValue: CGFloat = 16.0
-        
-        static let defaultShareButtonStackOffsetValue: CGFloat = 22.0
-        
-        static let shareButtonMultiplier: CGFloat = 1.0
+
         static let copyShareLinkButtonHeight: CGFloat = 50.0
     }
     
     enum Attribute {
         static let shareViewCornerRadius: CGFloat = 10.0
         static let shareTitleFontSize: CGFloat = 16.0
-        static let shareButtonsHorizontalStackSpacing: CGFloat = 16.0
-        static let shareButtonsVerticalStackSpacing: CGFloat = 3.0
-        static let shareButtonCorenrRadius: CGFloat = 15.0
-        static let shareButtonLabelFontSize: CGFloat = 14.0
         static let copyShareLinkButtonFontSize: CGFloat = 16.0
+        
         static let tableHeaderFontSize: CGFloat = 20.0
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/LinkShare/Strings/LinkShareVC.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/LinkShare/Strings/LinkShareVC.swift
@@ -19,6 +19,8 @@ enum LinkShareVC {
         static let copyShareLinkButtonTitle: String = "초대 링크 복사"
         
         static let familyTableHeader: String = "당신의 가족"
+        
+        static let successCopyInvitationUrlToPastboard: String = "링크가 복사되었습니다."
     }
     
     enum AutoLayout {

--- a/14th-team5-iOS/App/Sources/Presentation/LinkShare/ViewController/LinkShareViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/LinkShare/ViewController/LinkShareViewController.swift
@@ -19,24 +19,6 @@ final class LinkShareViewController: BaseViewController<LinkShareViewReactor> {
     private let shareView: UIView = UIView()
     private let shareTitleLabel: UILabel = UILabel()
     
-    private let shareButtonsStackView: UIStackView = UIStackView()
-    
-    private let kakaoTalkStackView: UIStackView = UIStackView()
-    private let kakaoTalkShareButton: UIButton = UIButton(type: .system)
-    private let kakaoTalkLabel: UILabel = UILabel()
-    
-    private let messageStackView: UIStackView = UIStackView()
-    private let messageShareButton: UIButton = UIButton(type: .system)
-    private let messageLabel: UILabel = UILabel()
-    
-    private let instagramStackView: UIStackView = UIStackView()
-    private let instagramShareButton: UIButton = UIButton(type: .system)
-    private let instagramLabel: UILabel = UILabel()
-    
-    private let moreStackView: UIStackView = UIStackView()
-    private let moreShareButton: UIButton = UIButton(type: .system)
-    private let moreLabel: UILabel = UILabel()
-    
     private let copyShareLinkButton: UIButton = UIButton(type: .system)
     
     private let tableHeader: UILabel = UILabel()
@@ -58,23 +40,7 @@ final class LinkShareViewController: BaseViewController<LinkShareViewReactor> {
             tableHeader, yourFamilyTableView
         )
         shareView.addSubviews(
-            shareTitleLabel, shareButtonsStackView, copyShareLinkButton
-        )
-        
-        shareButtonsStackView.addArrangedSubviews(
-            kakaoTalkStackView, messageStackView, instagramStackView, moreStackView
-        )
-        kakaoTalkStackView.addArrangedSubviews(
-            kakaoTalkShareButton, kakaoTalkLabel
-        )
-        messageStackView.addArrangedSubviews(
-            messageShareButton, messageLabel
-        )
-        instagramStackView.addArrangedSubviews(
-            instagramShareButton, instagramLabel
-        )
-        moreStackView.addArrangedSubviews(
-            moreShareButton, moreLabel
+            shareTitleLabel, copyShareLinkButton
         )
     }
     
@@ -92,31 +58,9 @@ final class LinkShareViewController: BaseViewController<LinkShareViewReactor> {
             $0.centerX.equalTo(shareView.snp.centerX)
         }
         
-        shareButtonsStackView.snp.makeConstraints {
-            $0.leading.equalTo(shareView.snp.leading).offset(LinkShareVC.AutoLayout.defaultShareButtonStackOffsetValue)
-            $0.top.equalTo(shareTitleLabel.snp.bottom).offset(LinkShareVC.AutoLayout.defaultShareButtonStackOffsetValue)
-            $0.trailing.equalTo(shareView.snp.trailing).offset(-LinkShareVC.AutoLayout.defaultShareButtonStackOffsetValue)
-        }
-        
-        kakaoTalkShareButton.snp.makeConstraints {
-            $0.width.equalTo(kakaoTalkShareButton.snp.height).multipliedBy(LinkShareVC.AutoLayout.shareButtonMultiplier)
-        }
-        
-        messageShareButton.snp.makeConstraints {
-            $0.width.equalTo(messageShareButton.snp.height).multipliedBy(LinkShareVC.AutoLayout.shareButtonMultiplier)
-        }
-        
-        instagramShareButton.snp.makeConstraints {
-            $0.width.equalTo(instagramShareButton.snp.height).multipliedBy(LinkShareVC.AutoLayout.shareButtonMultiplier)
-        }
-        
-        moreShareButton.snp.makeConstraints {
-            $0.width.equalTo(moreShareButton.snp.height).multipliedBy(LinkShareVC.AutoLayout.shareButtonMultiplier)
-        }
-        
         copyShareLinkButton.snp.makeConstraints {
-            $0.leading.equalTo(shareButtonsStackView.snp.leading)
-            $0.trailing.equalTo(shareButtonsStackView.snp.trailing)
+            $0.leading.equalTo(shareTitleLabel.snp.leading)
+            $0.trailing.equalTo(shareTitleLabel.snp.trailing)
             $0.bottom.equalTo(shareView.snp.bottom).offset(-LinkShareVC.AutoLayout.defaultOffsetValue)
             $0.height.equalTo(LinkShareVC.AutoLayout.copyShareLinkButtonHeight)
         }
@@ -145,97 +89,6 @@ final class LinkShareViewController: BaseViewController<LinkShareViewReactor> {
         shareTitleLabel.do {
             $0.text = LinkShareVC.Strings.shareTitle
             $0.font = UIFont.boldSystemFont(ofSize: LinkShareVC.Attribute.shareTitleFontSize)
-            $0.textColor = UIColor.white
-            $0.textAlignment = .center
-        }
-        
-        shareButtonsStackView.do {
-            $0.axis = .horizontal
-            $0.spacing = LinkShareVC.Attribute.shareButtonsHorizontalStackSpacing
-            $0.alignment = .fill
-            $0.distribution = .fillEqually
-        }
-        
-        kakaoTalkStackView.do {
-            $0.axis = .vertical
-            $0.spacing = LinkShareVC.Attribute.shareButtonsVerticalStackSpacing
-            $0.alignment = .fill
-            $0.distribution = .fill
-        }
-        
-        kakaoTalkShareButton.do {
-            $0.setTitle("이미지", for: .normal)
-            $0.layer.masksToBounds = true
-            $0.layer.cornerRadius = LinkShareVC.Attribute.shareButtonCorenrRadius
-            $0.backgroundColor = UIColor.white
-        }
-        
-        kakaoTalkLabel.do {
-            $0.text = LinkShareVC.Strings.kakaoTalkButtonTitle
-            $0.font = UIFont.systemFont(ofSize: LinkShareVC.Attribute.shareButtonLabelFontSize)
-            $0.textColor = UIColor.white
-            $0.textAlignment = .center
-        }
-        
-        messageStackView.do {
-            $0.axis = .vertical
-            $0.spacing = LinkShareVC.Attribute.shareButtonsVerticalStackSpacing
-            $0.alignment = .fill
-            $0.distribution = .fill
-        }
-        
-        messageShareButton.do {
-            $0.setTitle("이미지", for: .normal)
-            $0.layer.masksToBounds = true
-            $0.layer.cornerRadius = LinkShareVC.Attribute.shareButtonCorenrRadius
-            $0.backgroundColor = UIColor.white
-        }
-        
-        messageLabel.do {
-            $0.text = LinkShareVC.Strings.messageButtonTitle
-            $0.font = UIFont.systemFont(ofSize: LinkShareVC.Attribute.shareButtonLabelFontSize)
-            $0.textColor = UIColor.white
-            $0.textAlignment = .center
-        }
-        
-        instagramStackView.do {
-            $0.axis = .vertical
-            $0.spacing = LinkShareVC.Attribute.shareButtonsVerticalStackSpacing
-            $0.alignment = .fill
-            $0.distribution = .fill
-        }
-        
-        instagramShareButton.do {
-            $0.setTitle("이미지", for: .normal)
-            $0.layer.masksToBounds = true
-            $0.layer.cornerRadius = LinkShareVC.Attribute.shareButtonCorenrRadius
-            $0.backgroundColor = UIColor.white
-        }
-        
-        instagramLabel.do {
-            $0.text = LinkShareVC.Strings.instagramButtonTitle
-            $0.font = UIFont.systemFont(ofSize: LinkShareVC.Attribute.shareButtonLabelFontSize)
-            $0.textColor = UIColor.white
-            $0.textAlignment = .center
-        }
-        
-        moreStackView.do {
-            $0.axis = .vertical
-            $0.spacing = LinkShareVC.Attribute.shareButtonsVerticalStackSpacing
-            $0.alignment = .fill
-            $0.distribution = .fill
-        }
-        
-        moreShareButton.do {
-            $0.setTitle("이미지", for: .normal)
-            $0.layer.masksToBounds = true
-            $0.layer.cornerRadius = LinkShareVC.Attribute.shareButtonCorenrRadius
-            $0.backgroundColor = UIColor.white
-        }
-        
-        moreLabel.do {
-            $0.text = LinkShareVC.Strings.moreButtonTitle
-            $0.font = UIFont.systemFont(ofSize: LinkShareVC.Attribute.shareButtonLabelFontSize)
             $0.textColor = UIColor.white
             $0.textAlignment = .center
         }

--- a/14th-team5-iOS/Core/Sources/GlobalState/ActivityGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/ActivityGlobalState.swift
@@ -1,0 +1,29 @@
+//
+//  ActivityGlobalState.swift
+//  Core
+//
+//  Created by 김건우 on 12/13/23.
+//
+
+import UIKit
+
+import RxSwift
+
+public enum ActivityEvent {
+    case didTapCopyInvitationUrlAction
+}
+
+public protocol ActivityGlobalStateType {
+    var event: PublishSubject<ActivityEvent> { get }
+    func didTapCopyInvitationUrlAction() -> Observable<Void>
+}
+
+final public class ActivityGlobalState: BaseGlobalState, ActivityGlobalStateType {
+    public var event: PublishSubject<ActivityEvent> = PublishSubject<ActivityEvent>()
+    
+    public func didTapCopyInvitationUrlAction() -> Observable<Void> {
+        event.onNext(.didTapCopyInvitationUrlAction)
+        return Observable<Void>.just(())
+    }
+}
+

--- a/14th-team5-iOS/Core/Sources/GlobalState/CalendarGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/CalendarGlobalState.swift
@@ -17,7 +17,7 @@ public enum CalendarEvent {
 public protocol CalendarGlobalStateType {
     var event: PublishSubject<CalendarEvent> { get }
     func didSelectCell(_ date: Date) -> Observable<Date>
-    func didPressedInfoButton(_ sourceView: UIView) -> Observable<Void>
+    func didTapInfoButton(_ sourceView: UIView) -> Observable<Void>
 }
 
 final public class CalendarGlobalState: BaseGlobalState, CalendarGlobalStateType {
@@ -28,7 +28,7 @@ final public class CalendarGlobalState: BaseGlobalState, CalendarGlobalStateType
         return Observable<Date>.just(date)
     }
     
-    public func didPressedInfoButton(_ sourceView: UIView) -> Observable<Void> {
+    public func didTapInfoButton(_ sourceView: UIView) -> Observable<Void> {
         event.onNext(.didTapInfoButton(sourceView))
         return Observable<Void>.just(())
     }

--- a/14th-team5-iOS/Core/Sources/GlobalState/GlobalStateProvider.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/GlobalStateProvider.swift
@@ -8,10 +8,12 @@
 import Foundation
 
 public protocol GlobalStateProviderType: AnyObject {
+    var activityGlobalState: ActivityGlobalStateType { get }
     var calendarGlabalState: CalendarGlobalStateType { get }
 }
 
 final public class GlobalStateProvider: GlobalStateProviderType {
+    lazy public var activityGlobalState: ActivityGlobalStateType = ActivityGlobalState(provider: self)
     lazy public var calendarGlabalState: CalendarGlobalStateType = CalendarGlobalState(provider: self)
     
     public init() { }

--- a/14th-team5-iOS/Core/Sources/SharePanel/CopyInvitationUrlActivity.swift
+++ b/14th-team5-iOS/Core/Sources/SharePanel/CopyInvitationUrlActivity.swift
@@ -1,0 +1,49 @@
+//
+//  CopyInvitationUrlActivity.swift
+//  Core
+//
+//  Created by 김건우 on 12/13/23.
+//
+
+import UIKit
+
+public class CopyInvitationUrlActivity: UIActivity {
+    enum Activity {
+        static let activityTitle: String = "초대 링크 복사"
+        static let activitySymbol: String = "doc.on.doc"
+    }
+    
+    let provider: GlobalStateProviderType?
+    
+    let bundleId: String = Bundle.main.bundleIdentifier!
+    var typeName: String = String(describing: CopyInvitationUrlActivity.self)
+    
+    public init(provider: GlobalStateProviderType?) {
+        self.provider = provider
+    }
+    
+    public override class var activityCategory: UIActivity.Category {
+        return UIActivity.Category.action
+    }
+    
+    public override var activityType: UIActivity.ActivityType? {
+        return UIActivity.ActivityType("\(bundleId).\(typeName)")
+    }
+    
+    public override var activityTitle: String? {
+        return Activity.activityTitle
+    }
+    
+    public override var activityImage: UIImage? {
+        return UIImage(systemName: Activity.activitySymbol)
+    }
+    
+    public override func canPerform(withActivityItems activityItems: [Any]) -> Bool {
+        return true
+    }
+    
+    public override func perform() {
+        provider?.activityGlobalState.didTapCopyInvitationUrlAction()
+    }
+    
+}

--- a/14th-team5-iOS/Core/Sources/SharePanel/UrlActivityItemSource.swift
+++ b/14th-team5-iOS/Core/Sources/SharePanel/UrlActivityItemSource.swift
@@ -1,0 +1,40 @@
+//
+//  UrlActivityItemSource.swift
+//  Core
+//
+//  Created by 김건우 on 12/14/23.
+//
+
+import LinkPresentation
+
+public class UrlActivityItemSource: NSObject, UIActivityItemSource {
+    var title: String
+    var url: URL
+    
+    public init(title: String, url: URL) {
+        self.title = title
+        self.url = url
+        super.init()
+    }
+    
+    public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
+        return url
+    }
+    
+    public func activityViewController(_ activityViewController: UIActivityViewController, itemForActivityType activityType: UIActivity.ActivityType?) -> Any? {
+        return url
+    }
+    
+    public func activityViewController(_ activityViewController: UIActivityViewController, subjectForActivityType activityType: UIActivity.ActivityType?) -> String {
+        return title
+    }
+
+    public func activityViewControllerLinkMetadata(_ activityViewController: UIActivityViewController) -> LPLinkMetadata? {
+        let metadata = LPLinkMetadata()
+        metadata.title = title
+        metadata.iconProvider = NSItemProvider(object: UIImage(systemName: "text.bubble")!)
+        metadata.originalURL = url
+        return metadata
+    }
+
+}


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 초대 링크 복사 화면 UI를 수정하였습니다.

- 공유 시트(UIActivityViewController)를 구현하였습니다.
   * 임시로 본 리포지터리 링크를 공유하도록 하였습니다.

## 스크린샷 📷

| 이미지 | 이미지
| :-------: | :------: |
| <img src="https://github.com/depromeet/14th-team5-iOS/assets/21079970/ec94926f-5939-4255-a241-a7a38faafbab" align="center" width="235" height="511"> | <img src="https://github.com/depromeet/14th-team5-iOS/assets/21079970/418d6059-da06-4d21-9a32-34a40531e21c" align="center" width="235" height="511"> |

## 기타

```swift
func makeInvitationUrlSharePanel(_ url: URL?, provider globalState: GlobalStateProviderType? = nil) {
        guard let url = url else { return }
        let itemSource = UrlActivityItemSource(
            title: StringLiterals.invitationUrlSharePanelTitle,
            url: url
        )
        let copyToPastboard = CopyInvitationUrlActivity(provider: globalState)
        
        UIPasteboard.general.string = url.description
        makeSharePanel([itemSource], activities: [copyToPastboard])
    }
```

- URL 공유 시트는 UIViewController+Ext에 `makeInvitationUrlSharePanel(_ url:, provider:)` 함수를 호출하시면 됩니다. 
   * 이때, `초대 링크 복사` 버튼을 클릭한 후, 뷰 컨트롤러에서 별도 작업이 필요하다면 `GlobalState`도 함께 전달해야 합니다. (저는 ToastView 출력을 위해 `GlobalState`를 전달하였습니다)


