### PR TITLE
Feat/#63: 주간 캘린더에 피드 UI 구현, 캘린더 셀 UI 수정, RoundedToastView 메서드 추가 

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
+++ b/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
@@ -20,8 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = UINavigationController(rootViewController: CalendarDIConatainer().makeViewController())
-//        window?.rootViewController = UINavigationController(rootViewController: FeedDetailViewController(reacter: FeedDetailReactor()))
+        window?.rootViewController = UINavigationController(rootViewController: HomeViewController(reacter: HomeViewReactor()))
         window?.makeKeyAndVisible()
     }
 }

--- a/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
+++ b/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
@@ -20,7 +20,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = UINavigationController(rootViewController: HomeViewController(reacter: HomeViewReactor()))
+        window?.rootViewController = UINavigationController(rootViewController: CalendarDIConatainer().makeViewController())
+//        window?.rootViewController = UINavigationController(rootViewController: FeedDetailViewController(reacter: FeedDetailReactor()))
         window?.makeKeyAndVisible()
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/AddFamiliy/ViewController/AddFamiliyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/AddFamiliy/ViewController/AddFamiliyViewController.swift
@@ -215,10 +215,10 @@ public final class AddFamiliyViewController: BaseViewController<AddFamiliyViewRe
         reactor.pulse(\.$shouldPresentToastMessage)
             .filter { $0 }
             .withUnretained(self)
-            .subscribe {
+            .subscribe {                
                 $0.0.makeRoundedToastView(
                     title: AddFamiliyVC.Strings.successCopyInvitationUrl,
-                    systemName: "link",
+                    symbol: "link",
                     width: 200
                 )
             }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/ImageCalendarCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/ImageCalendarCellReactor.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 // NOTE: - 임시 코드
 struct TempCalendarCellModel {
+    let date: Date
     var imageUrl: String?
     var isHidden: Bool
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Strings/CalenderCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Strings/CalenderCell.swift
@@ -20,7 +20,7 @@ enum CalendarCell {
         static let calendarLeadingTrailingOffsetValue: CGFloat = 0.5
         static let calendarHeightMultiplier: CGFloat = 0.98
         
-        static let thumbnailInsetValue: CGFloat = 2.75
+        static let thumbnailInsetValue: CGFloat = 2.5
         static let badgeHeightValue: CGFloat = 9.0
         static let badgeOffsetValue: CGFloat = 2.0
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -120,6 +120,8 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
         
         calendarView.delegate = self
         calendarView.dataSource = self
+        
+        setupCalendarTitle(calendarView.currentPage)
     }
     
     override func bind(reactor: CalendarPageCellReactor) { 
@@ -145,14 +147,22 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
     private func bindOutput(reactor: CalendarPageCellReactor) { }
 }
 
+extension CalendarPageCell {
+    func setupCalendarTitle(_ date: Date) {
+        calendarTitleLabel.text = DateFormatter.yyyyMM.string(from: date)
+    }
+}
+
 extension CalendarPageCell: FSCalendarDelegate {     
     func calendar(_ calendar: FSCalendar, shouldSelect date: Date, at monthPosition: FSCalendarMonthPosition) -> Bool {
         let calendarMonth = calendar.currentPage.month
         let positionMonth = date.month
+        let calendarImageCell = calendar.cell(for: date, at: monthPosition) as! ImageCalendarCell
         // 셀의 날짜가 현재 월(月)과 동일하다면
-        if calendarMonth == positionMonth {
+        if calendarMonth == positionMonth && calendarImageCell.hasThumbnailImage {
             return true
         }
+        
         return false
     }
 }
@@ -178,7 +188,7 @@ extension CalendarPageCell: FSCalendarDataSource {
                 "https://cdn.pixabay.com/photo/2023/09/25/13/42/kingfisher-8275049_1280.png",
                 "", "", "", ""
             ]
-            let cellModel = TempCalendarCellModel(imageUrl: imageUrls.randomElement(), isHidden: Bool.random())
+            let cellModel = TempCalendarCellModel(date: date, imageUrl: imageUrls.randomElement(), isHidden: Bool.random())
             
             cell.reactor = ImageCalendarCellReactor(cellModel)
             return cell

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarFeedViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarFeedViewController.swift
@@ -231,8 +231,9 @@ extension CalendarFeedViewController: FSCalendarDataSource {
             "https://cdn.pixabay.com/photo/2023/09/25/13/42/kingfisher-8275049_1280.png",
             "", "", "", ""
         ]
-        cell.configure(date, imageUrl: imageUrls.randomElement() ?? "", cellType: .week)
+        let cellModel = TempCalendarCellModel(date: date, imageUrl: imageUrls.randomElement(), isHidden: Bool.random())
         
+        cell.reactor = ImageCalendarCellReactor(cellModel)
         return cell
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -29,6 +29,11 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
         super.viewDidLoad()
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.isHidden = false
+    }
+    
     // MARK: - Helpers
     public override func setupUI() {
         super.setupUI()

--- a/14th-team5-iOS/Core/Sources/Extensions/UINavigationController+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/UINavigationController+Ext.swift
@@ -1,0 +1,19 @@
+//
+//  UINavigationController+Ext.swift
+//  Core
+//
+//  Created by 김건우 on 12/20/23.
+//
+
+import UIKit
+
+extension UINavigationController: UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}

--- a/14th-team5-iOS/Core/Sources/Extensions/UIViewController+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/UIViewController+Ext.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 
+import DesignSystem
+
 extension UIViewController {
     enum StringLiterals {
         static let invitationUrlSharePanelTitle: String = "삐삐! 가족에게 보내는 하루 한번 생존 신고"
@@ -52,70 +54,38 @@ extension UIViewController {
         
     /// 둥근 모양의 토스트 메시지를 보여줍니다.
     /// - Parameters:
-    ///   - title: 토스트 메시지 속 텍스트
-    ///   - name: SFSymbol 이름 (선택)
+    ///   - title: 토스트 메시지
+    ///   - name: SFSymbol 이름
+    ///   - pattetteColors: SFSymbol 색상 (기본값 darkGray)
     ///   - width: 너비 (기본값 250)
     ///   - height: 높이 (기본값 60)
+    ///   - duration: 알림 표시 지속 시간 (기본값 0.5)
     ///   - offset: 표시할 위치 (기본값 40)
     public func makeRoundedToastView(
         title: String,
-        systemName name: String? = nil,
+        symbol name: String,
+        palletteColors colors: [UIColor] = [.darkGray],
         width: CGFloat = 250,
         height: CGFloat = 60,
+        duration: CGFloat = 0.5,
         offset: CGFloat = 40
     ) {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             
-            let symbolConfig = UIImage.SymbolConfiguration(paletteColors: [UIColor.darkGray])
-            let sfSymbol: UIImage? = UIImage(systemName: name ?? "", withConfiguration: symbolConfig)
-            
-            let toastView: UIView = UIView()
-            let stackView: UIStackView = UIStackView()
-            let imageView: UIImageView = UIImageView(image: sfSymbol)
-            let labelView: UILabel = UILabel()
-            
-            labelView.text = title
-            labelView.textColor = UIColor.white
-            labelView.textAlignment = .center
-            labelView.font = UIFont.systemFont(ofSize: 17)
-            
-            imageView.contentMode = .scaleAspectFit
-            
-            stackView.axis = .horizontal
-            stackView.spacing = 5.0
-            stackView.alignment = .fill
-            stackView.distribution = .fillProportionally
-            
-            toastView.alpha = 1.0
-            toastView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
-            toastView.layer.cornerRadius = height / 2.0
-            toastView.layer.masksToBounds = true
-            
-            self.view.addSubview(toastView)
-            toastView.addSubview(stackView)
-            stackView.addArrangedSubviews(
-                imageView, labelView
+            let toastView: UIView = self.getRoundedToastView(
+                title,
+                symbol: name,
+                palletteColors: colors,
+                width: width,
+                height: height,
+                offset: offset
             )
-            
-            toastView.snp.makeConstraints {
-                $0.height.equalTo(60)
-                $0.width.equalTo(width)
-                $0.bottom.equalToSuperview().offset(offset)
-                $0.centerX.equalToSuperview()
-            }
-            
-            stackView.snp.makeConstraints {
-                $0.top.bottom.equalToSuperview()
-                $0.leading.equalTo(toastView.snp.leading).offset(16.0)
-                $0.trailing.equalTo(toastView.snp.trailing).offset(-16.0)
-                $0.centerY.equalTo(toastView.snp.centerY)
-            }
             
             UIView.animate(withDuration: 0.6, delay: 0.0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.4) {
                 toastView.transform = CGAffineTransform(translationX: 0, y: -offset * 2)
             } completion: { _ in
-                UIView.animate(withDuration: 0.6, delay: 0.5, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.4) {
+                UIView.animate(withDuration: 0.6, delay: duration, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.4) {
                     toastView.transform = CGAffineTransform(translationX: 0, y: offset * 2)
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
@@ -123,6 +93,111 @@ extension UIViewController {
                 }
             }
         }
+    }
+    
+    /// 둥근 모양의 토스트 메시지를 보여줍니다.
+    /// - Parameters:
+    ///   - title: 토스트 메시지
+    ///   - designSystemImage: 이미지
+    ///   - width: 너비 (기본값 250)
+    ///   - height: 높이 (기본값 60)
+    ///   - duration: 알림 표시 지속 시간 (기본값 0.5)
+    ///   - offset: 표시할 위치 (기본값 40)
+    public func makeRoundedToastView(
+        title: String,
+        designSystemImage image: DesignSystemImages,
+        width: CGFloat = 250,
+        height: CGFloat = 60,
+        duration: CGFloat = 0.5,
+        offset: CGFloat = 40
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            
+            let toastView: UIView = self.getRoundedToastView(
+                title,
+                designSystemImage: image,
+                width: width,
+                height: height,
+                offset: offset
+            )
+            
+            UIView.animate(withDuration: 0.6, delay: 0.0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.4) {
+                toastView.transform = CGAffineTransform(translationX: 0, y: -offset * 2)
+            } completion: { _ in
+                UIView.animate(withDuration: 0.6, delay: duration, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.4) {
+                    toastView.transform = CGAffineTransform(translationX: 0, y: offset * 2)
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                    toastView.removeFromSuperview()
+                }
+            }
+        }
+    }
+    
+    private func getRoundedToastView(
+        _ title: String,
+        symbol name: String? = nil,
+        palletteColors colors: [UIColor]? = nil,
+        designSystemImage image: DesignSystemImages? = nil,
+        width: CGFloat,
+        height: CGFloat,
+        offset: CGFloat
+    ) -> UIView {
+        let toastView: UIView = UIView()
+        let stackView: UIStackView = UIStackView()
+        let labelView: UILabel = UILabel()
+        var imageView: UIImageView!
+        
+        // SF심볼 이미지를 받았다면
+        if let name = name {
+            let config = UIImage.SymbolConfiguration(paletteColors: colors ?? [.darkGray])
+            let symbol: UIImage? = UIImage(systemName: name, withConfiguration: config)
+            
+            imageView = UIImageView(image: symbol)
+        // 일반 이미지를 받았다면
+        } else {
+            imageView = UIImageView(image: UIImage(named: image?.name ?? ""))
+        }
+        
+        labelView.text = title
+        labelView.textColor = UIColor.white
+        labelView.textAlignment = .center
+        labelView.font = UIFont.systemFont(ofSize: 17)
+        
+        imageView.contentMode = .scaleAspectFit
+        
+        stackView.axis = .horizontal
+        stackView.spacing = 5.0
+        stackView.alignment = .fill
+        stackView.distribution = .fillProportionally
+        
+        toastView.alpha = 1.0
+        toastView.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+        toastView.layer.cornerRadius = height / 2.0
+        toastView.layer.masksToBounds = true
+        
+        self.view.addSubview(toastView)
+        toastView.addSubview(stackView)
+        stackView.addArrangedSubviews(
+            imageView, labelView
+        )
+        
+        toastView.snp.makeConstraints {
+            $0.height.equalTo(height)
+            $0.width.equalTo(width)
+            $0.bottom.equalToSuperview().offset(offset)
+            $0.centerX.equalToSuperview()
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(toastView.snp.leading).offset(16.0)
+            $0.trailing.equalTo(toastView.snp.trailing).offset(-16.0)
+            $0.centerY.equalTo(toastView.snp.centerY)
+        }
+        
+        return toastView
     }
 }
 

--- a/14th-team5-iOS/Core/Sources/Extensions/UIViewController+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/UIViewController+Ext.swift
@@ -151,9 +151,8 @@ extension UIViewController {
             title: StringLiterals.invitationUrlSharePanelTitle,
             url: url
         )
-        let copyToPastboard = CopyInvitationUrlActivity(provider: globalState)
+        let copyToPastboard = CopyInvitationUrlActivity(url, provider: globalState)
         
-        UIPasteboard.general.string = url.description
         makeSharePanel([itemSource], activities: [copyToPastboard])
     }
 }

--- a/14th-team5-iOS/Core/Sources/SharePanel/CopyInvitationUrlActivity.swift
+++ b/14th-team5-iOS/Core/Sources/SharePanel/CopyInvitationUrlActivity.swift
@@ -13,12 +13,14 @@ public class CopyInvitationUrlActivity: UIActivity {
         static let activitySymbol: String = "doc.on.doc"
     }
     
+    let url: URL
     let provider: GlobalStateProviderType?
     
     let bundleId: String = Bundle.main.bundleIdentifier!
     var typeName: String = String(describing: CopyInvitationUrlActivity.self)
     
-    public init(provider: GlobalStateProviderType?) {
+    public init(_ url: URL, provider: GlobalStateProviderType?) {
+        self.url = url
         self.provider = provider
     }
     
@@ -43,6 +45,7 @@ public class CopyInvitationUrlActivity: UIActivity {
     }
     
     public override func perform() {
+        UIPasteboard.general.string = url.description
         provider?.activityGlobalState.didTapCopyInvitationUrlAction()
     }
     


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 주간 캘린더에 피드 UI 구현
- 캘린더 셀 UI 수정
- RoundedToastView 메서드 추가
- 링크 공유 시트에서 링크가 의도치않게 복사되는 문제 수정

## 스크린샷 📷

| 이미지 |
| :----: |
|  ![Simulator Screenshot - iPhone 15 Pro - 2023-12-20 at 12 54 37](https://github.com/depromeet/14th-team5-iOS/assets/21079970/754f9d8d-942e-447d-99ae-f13ce5191482) |


## 기타

- 상세 피드의 컬렉션 셀의 사이즈를 제대로 맞추지 못하는 문제가 있습니다. 해결했는데, `FeedDetailViewController`의 `CollectionViewLayout`를 수정해야 해서 이번 커밋에는 포함시키지 않았습니다.


