### PR TITLE
feat: ProfileView UI Design 수정 및 닉네임 변경 API 추가

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/Dependeyncy/AccountSignUpDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/Dependeyncy/AccountSignUpDIContainer.swift
@@ -15,6 +15,12 @@ public final class AccountSignUpDIContainer: BaseDIContainer {
     public typealias ViewContrller = AccountSignUpViewController
     public typealias Repository = AccountImpl
     public typealias Reactor = AccountSignUpReactor
+    public typealias NickNameViewController = AccountNicknameViewController
+    private let memberId: String
+    
+    public init(memberId: String = "") {
+        self.memberId = memberId
+    }
     
     public func makeViewController() -> AccountSignUpViewController {
         return AccountSignUpViewController(reacter: makeReactor())
@@ -25,6 +31,11 @@ public final class AccountSignUpDIContainer: BaseDIContainer {
     }
     
     public func makeReactor() -> Reactor {
-        return AccountSignUpReactor(accountRepository: AccountRepository())
+        return AccountSignUpReactor(accountRepository: AccountRepository(), memberId: memberId)
+    }
+    
+    
+    public func makeNickNameViewController() -> NickNameViewController {
+        return AccountNicknameViewController(reacter: makeReactor())
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
@@ -297,9 +297,18 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
             .disposed(by: disposeBag)
         
         reactor.pulse(\.$displaySection)
+            .observe(on: MainScheduler.asyncInstance)
             .asDriver(onErrorJustReturn: [])
             .drive(displayEditCollectionView.rx.items(dataSource: displayEditDataSources))
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .compactMap { $0.displayPostEntity?.postId }
+            .filter { !$0.isEmpty }
+            .withUnretained(self)
+            .bind(onNext: { $0.0.transitionToHomeViewController()})
+            .disposed(by: disposeBag)
+        
     }
 }
 
@@ -393,6 +402,10 @@ extension CameraDisplayViewController {
         [cancelAction,settingAction].forEach(permissionAlertController.addAction(_:))
         
         present(permissionAlertController, animated: true)
+    }
+    
+    private func transitionToHomeViewController() {
+        self.navigationController?.popToRootViewController(animated: true)
     }
 }
 

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyAuthorizationTableViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyAuthorizationTableViewCell.swift
@@ -19,37 +19,30 @@ import Then
 
 public final class PrivacyAuthorizationTableViewCell: BaseTableViewCell<PrivacyCellReactor> {
     //MARK: Views
-    private let descrptionLabel: UILabel = UILabel()
+    private let descrptionLabel: TypeSystemLabel = TypeSystemLabel(.head2Regular, textColor: .warningRed)
     private let arrowAccessView: UIImageView = UIImageView()
-    private let underLineView: UIView = UIView()
     
     
     
     public override func setupUI() {
         super.setupUI()
-        contentView.addSubviews(descrptionLabel, arrowAccessView, underLineView)
+        contentView.addSubviews(descrptionLabel, arrowAccessView)
     }
     
     public override func setupAttributes() {
         super.setupAttributes()
                 
         contentView.do {
-            $0.backgroundColor = .black
+            $0.backgroundColor = DesignSystemAsset.black.color
         }
         
         descrptionLabel.do {
-            $0.textColor = UIColor(red: 255/255, green: 64/255, blue: 21/255, alpha: 1.0)
-            $0.font = .systemFont(ofSize: 17, weight: .regular)
             $0.textAlignment = .left
         }
         
         arrowAccessView.do {
             $0.contentMode = .scaleToFill
             $0.image = DesignSystemAsset.arrow.image
-        }
-        
-        underLineView.do {
-            $0.backgroundColor = UIColor(red: 56/255, green: 56/255, blue: 58/255, alpha: 1.0)
         }
     }
     
@@ -69,12 +62,6 @@ public final class PrivacyAuthorizationTableViewCell: BaseTableViewCell<PrivacyC
             $0.centerY.equalTo(descrptionLabel)
         }
         
-        underLineView.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(16)
-            $0.right.equalToSuperview()
-            $0.height.equalTo(1)
-            $0.bottom.equalToSuperview().offset(-1)
-        }
     }
     
     

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyTableViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyTableViewCell.swift
@@ -17,21 +17,20 @@ import Then
 
 public final class PrivacyTableViewCell: BaseTableViewCell<PrivacyCellReactor> {
     //MARK: Views
-    private let descrptionLabel: UILabel = UILabel()
+    private let descrptionLabel: TypeSystemLabel = TypeSystemLabel(.head2Regular, textColor: .gray200)
     private let arrowAccessView: UIImageView = UIImageView()
-    private let underLineView: UIView = UIView()
     
     
     public override func setupUI() {
         super.setupUI()
-        contentView.addSubviews(descrptionLabel, arrowAccessView, underLineView)
+        contentView.addSubviews(descrptionLabel, arrowAccessView)
     }
     
     public override func setupAttributes() {
         super.setupAttributes()
         
         contentView.do {
-            $0.backgroundColor = .black
+            $0.backgroundColor = DesignSystemAsset.black.color
         }
         
         arrowAccessView.do {
@@ -40,13 +39,7 @@ public final class PrivacyTableViewCell: BaseTableViewCell<PrivacyCellReactor> {
         }
         
         descrptionLabel.do {
-            $0.textColor = .white
-            $0.font = .systemFont(ofSize: 17, weight: .regular)
             $0.textAlignment = .left
-        }
-        
-        underLineView.do {
-            $0.backgroundColor = UIColor(red: 56/255, green: 56/255, blue: 58/255, alpha: 1.0)
         }
     }
     
@@ -64,13 +57,6 @@ public final class PrivacyTableViewCell: BaseTableViewCell<PrivacyCellReactor> {
             $0.width.equalTo(7)
             $0.height.equalTo(12)
             $0.centerY.equalTo(descrptionLabel)
-        }
-        
-        underLineView.snp.makeConstraints {
-            $0.left.equalToSuperview().offset(16)
-            $0.right.equalToSuperview()
-            $0.height.equalTo(1)
-            $0.bottom.equalToSuperview().offset(-1)
         }
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/PrivacyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/PrivacyViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import Core
+import DesignSystem
 import RxSwift
 import RxCocoa
 import RxDataSources
@@ -59,7 +60,7 @@ public final class PrivacyViewController: BaseViewController<PrivacyViewReactor>
         }
         
         privacyTableView.do {
-            $0.backgroundColor = UIColor(red: 0.09, green: 0.09, blue: 0.09, alpha: 1)
+            $0.backgroundColor = DesignSystemAsset.black.color
             $0.separatorStyle = .none
             $0.register(PrivacyTableViewCell.self, forCellReuseIdentifier: "PrivacyTableViewCell")
             $0.register(PrivacyAuthorizationTableViewCell.self, forCellReuseIdentifier: "PrivacyAuthorizationTableViewCell")

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/ReusableView/PrivacyAuthorizationHeaderFooterView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/ReusableView/PrivacyAuthorizationHeaderFooterView.swift
@@ -7,12 +7,13 @@
 
 import UIKit
 
+import Core
 import SnapKit
 import Then
 
 
 public final class PrivacyAuthorizationHeaderFooterView: UITableViewHeaderFooterView {
-    private let headerLabel: UILabel = UILabel()
+    private let headerLabel: TypeSystemLabel = TypeSystemLabel(.body2Regular, textColor: .gray300)
     
     public override init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)
@@ -33,9 +34,7 @@ public final class PrivacyAuthorizationHeaderFooterView: UITableViewHeaderFooter
     private func setupAttributes() {
         headerLabel.do {
             $0.text = "로그인"
-            $0.textColor = UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.6)
             $0.textAlignment = .left
-            $0.font = .systemFont(ofSize: 13, weight: .regular)
         }
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/ReusableView/PrivacyHeaderFooterView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/ReusableView/PrivacyHeaderFooterView.swift
@@ -7,12 +7,14 @@
 
 import UIKit
 
+import Core
+import DesignSystem
 import SnapKit
 import Then
 
 
 public final class PrivacyHeaderFooterView: UITableViewHeaderFooterView {
-    private let headerLabel: UILabel = UILabel()
+    private let headerLabel: TypeSystemLabel = TypeSystemLabel(.body2Regular, textColor: .gray300)
     
     
     public override init(reuseIdentifier: String?) {
@@ -34,9 +36,7 @@ public final class PrivacyHeaderFooterView: UITableViewHeaderFooterView {
     private func setupAttributes() {
         headerLabel.do {
             $0.text = "계정 및 권한"
-            $0.textColor = UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.6)
             $0.textAlignment = .left
-            $0.font = .systemFont(ofSize: 13, weight: .regular)
         }
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Cell/ProfileFeedCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Cell/ProfileFeedCollectionViewCell.swift
@@ -19,8 +19,8 @@ import Then
 public final class ProfileFeedCollectionViewCell: BaseCollectionViewCell<ProfileFeedCellReactor> {
     private let feedImageView: UIImageView = UIImageView()
     private let feedStackView: UIStackView = UIStackView()
-    private let feedTitleLabel: UILabel = UILabel()
-    private let feedUplodeLabel: UILabel = UILabel()
+    private let feedTitleLabel: TypeSystemLabel = TypeSystemLabel(.body2Regular, textColor: .gray200)
+    private let feedUplodeLabel: TypeSystemLabel = TypeSystemLabel(.caption, textColor: .gray400)
     
     
     public override func prepareForReuse() {
@@ -46,16 +46,12 @@ public final class ProfileFeedCollectionViewCell: BaseCollectionViewCell<Profile
         
         feedTitleLabel.do {
             $0.text = "99"
-            $0.textColor = DesignSystemAsset.gray200.color
-            $0.font = DesignSystemFontFamily.Pretendard.regular.font(size: 14)
             $0.textAlignment = .left
             $0.numberOfLines = 1
         }
         
         feedUplodeLabel.do {
             $0.text = "3월 7일"
-            $0.textColor = DesignSystemAsset.gray400.color
-            $0.font = .systemFont(ofSize: 12)
             $0.textAlignment = .left
             $0.numberOfLines = 1
         }

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
@@ -200,6 +200,15 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
             .bind(onNext: { $0.0.setupProfileImage($0.1)})
             .disposed(by: disposeBag)
         
+        profileView.profileNickNameButton
+            .rx.tap
+            .withLatestFrom(reactor.state.compactMap { $0.profileMemberEntity?.memberId })
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .withUnretained(self)
+            .bind(onNext: { $0.0.transitionNickNameViewController(memberId: $0.1)})
+            .disposed(by: disposeBag)
+        
+        
         profileFeedCollectionView.rx
             .didScroll
             .withLatestFrom(profileFeedCollectionView.rx.contentOffset)
@@ -254,6 +263,10 @@ extension ProfileViewController {
         
     }
     
+    private func transitionNickNameViewController(memberId: String) {
+        let accountNickNameViewController:AccountNicknameViewController = AccountSignUpDIContainer(memberId: memberId).makeNickNameViewController()
+        self.navigationController?.pushViewController(accountNickNameViewController, animated: false)
+    }
     
     private func createAlertController(owner: ProfileViewController) {
         let alertController: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
@@ -35,7 +35,7 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
 
     private let profileIndicatorView: UIActivityIndicatorView = UIActivityIndicatorView(style: .medium)
     private lazy var profileView: BibbiProfileView = BibbiProfileView(cornerRadius: 50)
-    private let profileTitleView: UILabel = UILabel()
+    private let profileTitleView: TypeSystemLabel = TypeSystemLabel(.head2Bold, textColor: .gray200)
     private let privacyButton: UIButton = UIButton()
     private let profileLineView: UIView = UIView()
     private lazy var profilePickerController: PHPickerViewController = PHPickerViewController(configuration: pickerConfiguration)
@@ -71,7 +71,6 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
         profileTitleView.do {
             $0.textColor = DesignSystemAsset.gray200.color
             $0.text = "활동"
-            $0.font = DesignSystemFontFamily.Pretendard.bold.font(size: 18)
         }
         
         profilePickerController.do {
@@ -82,9 +81,9 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
             $0.backgroundColor = .separator
         }
         
-//        privacyButton.do {
-//            $0.setImage(DesignSystemAsset.privacy.image, for: .normal)
-//        }
+        privacyButton.do {
+            $0.setImage(DesignSystemAsset.setting.image, for: .normal)
+        }
         
         navigationItem.do {
             $0.titleView = profileTitleView

--- a/14th-team5-iOS/Core/Sources/ShareView/BibbiProfileView.swift
+++ b/14th-team5-iOS/Core/Sources/ShareView/BibbiProfileView.swift
@@ -55,13 +55,15 @@ public class BibbiProfileView: UIView {
         }
         
         profileNickNameButton.do {
+            let paragraphStyle = NSMutableParagraphStyle()
             $0.configuration?.imagePlacement = .trailing
             $0.configuration?.baseBackgroundColor = .clear
             $0.configuration?.image = DesignSystemAsset.edit.image
             $0.configuration?.imagePadding = 5
             $0.configuration?.attributedTitle = AttributedString(NSAttributedString(string: "하나밖에없는 혈육", attributes: [
                 .foregroundColor: DesignSystemAsset.gray200.color,
-                .font: DesignSystemFontFamily.Pretendard.bold.font(size: 16)
+                .font: DesignSystemFontFamily.Pretendard.semiBold.font(size: 16),
+                .kern: -0.3
             ]))
         }
         

--- a/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIWorker.swift
@@ -72,4 +72,21 @@ extension AccountAPIWorker {
         
         return signUpWith(spec: spec, jsonEncodable: payLoad)
     }
+    
+    func updateProfileNickName(accessToken: String, memberId: String, parameter: Encodable) -> Single<AccountNickNameEditDTO?> {
+        let spec = AccountAPIs.profileNickNameEdit(memberId).spec
+        
+        return request(spec: spec, headers: [BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson], jsonEncodable: parameter)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("Account nickName update Result: \(str)")
+                }
+            }
+            .map(AccountNickNameEditDTO.self)
+            .catchAndReturn(nil)
+            .asSingle()
+        
+        
+    }
 }

--- a/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIs.swift
+++ b/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIs.swift
@@ -13,6 +13,7 @@ enum AccountAPIs: API {
     case refreshToken
     case signUp
     case signIn(SNS)
+    case profileNickNameEdit(String)
     
     var spec: APISpec {
         switch self {
@@ -24,6 +25,8 @@ enum AccountAPIs: API {
             return APISpec(method: .post, url: "\(BibbiAPI.hostApi)/auth/register")
         case .signIn(let sns):
             return APISpec(method: .post, url: "\(BibbiAPI.hostApi)/auth/social/\(sns.rawValue)")
+        case .profileNickNameEdit(let memberId):
+            return APISpec(method: .put, url: "\(BibbiAPI.hostApi)/members/name/\(memberId)")
         }
     }
     

--- a/14th-team5-iOS/Data/Sources/Account/AccountRepository/AccountRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Account/AccountRepository/AccountRepository.swift
@@ -18,10 +18,13 @@ public protocol AccountImpl: AnyObject {
     func kakaoLogin(with snsType: SNS, vc: UIViewController) -> Observable<Void>
     func appleLogin(with snsType: SNS, vc: UIViewController) -> Observable<Void>
     func signUp(name: String, date: String, photoURL: String?) -> Observable<Void>
+    func executeNicknameUpdate(memberId: String, parameter: AccountNickNameEditParameter) -> Observable<AccountNickNameEditResponse>
 }
 
 public final class AccountRepository: AccountImpl {
     public var disposeBag: DisposeBag = DisposeBag()
+    
+    private let accessToken: String = "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJhY2Nlc3MiLCJyZWdEYXRlIjoxNzAzODM2OTUzMzkwLCJ0eXAiOiJKV1QifQ.eyJ1c2VySWQiOiIwMUhKQk5YQVYwVFlRMUtFU1dFUjQ1QTJRUCIsImV4cCI6MTcwMzkyMzM1M30.sROYEmc6sxcSY82UKsei95EaDEw0Af8rx6q0qdmValI"
     
     let signInHelper = AccountSignInHelper()
     private let apiWorker = AccountAPIWorker()
@@ -36,6 +39,12 @@ public final class AccountRepository: AccountImpl {
         return apiWorker.signUpWith(name: name, date: date, photoURL: photoURL)
             .asObservable()
             .map { _ in }
+    }
+    
+    public func executeNicknameUpdate(memberId: String, parameter: AccountNickNameEditParameter) -> Observable<AccountNickNameEditResponse> {
+        return apiWorker.updateProfileNickName(accessToken: accessToken, memberId: memberId, parameter: parameter)
+            .compactMap { $0?.toDomain() }
+            .asObservable()
     }
     
     public init() {

--- a/14th-team5-iOS/Data/Sources/Camera/Repositories/CameraDisplayViewRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Camera/Repositories/CameraDisplayViewRepository.swift
@@ -20,7 +20,7 @@ public final class CameraDisplayViewRepository {
     private let cameraDisplayAPIWorker: CameraAPIWorker = CameraAPIWorker()
     
     public var disposeBag: DisposeBag = DisposeBag()
-    public var token: String = "eyJ0eXBlIjoiYWNjZXNzIiwicmVnRGF0ZSI6MTcwMzY3MjI5ODg2NywidHlwIjoiSldUIiwiYWxnIjoiSFMyNTYifQ.eyJ1c2VySWQiOiIxNSIsImV4cCI6MTcwMzc1ODY5OH0.TNxTXHaWEzFOxB4A88m05y4KUkssW2wzGKm50bIGKlM"
+    public var token: String = "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJhY2Nlc3MiLCJyZWdEYXRlIjoxNzAzODM0NTk4Mzg3LCJ0eXAiOiJKV1QifQ.eyJ1c2VySWQiOiIxNCIsImV4cCI6MTcwMzkyMDk5OH0.GeRHjF2Ydcz39LjjId36VzABKv43ZZq1xulYAEU3J-E"
     
    
     

--- a/14th-team5-iOS/Domain/Sources/Account/DataMapping/AccountNickNameEditDTO.swift
+++ b/14th-team5-iOS/Domain/Sources/Account/DataMapping/AccountNickNameEditDTO.swift
@@ -1,0 +1,32 @@
+//
+//  AccountNickNameEditDTO.swift
+//  Domain
+//
+//  Created by Kim dohyun on 12/29/23.
+//
+
+import Foundation
+
+
+public struct AccountNickNameEditDTO: Decodable {
+    public var memberId: String
+    public var name: String
+    public var imageUrl: String
+    public var familyId: String
+    public var dayOfBirth: String
+    
+}
+
+
+extension AccountNickNameEditDTO {
+    public func toDomain() -> AccountNickNameEditResponse {
+        return .init(
+            memberId: memberId,
+            name: name,
+            imageUrl: URL(string: imageUrl) ?? URL(fileURLWithPath: ""),
+            familyId: familyId,
+            dayOfBirth: dayOfBirth
+        )
+    }
+    
+}

--- a/14th-team5-iOS/Domain/Sources/Account/Entity/AccountNickNameEditResponse.swift
+++ b/14th-team5-iOS/Domain/Sources/Account/Entity/AccountNickNameEditResponse.swift
@@ -1,0 +1,18 @@
+//
+//  AccountNickNameEditResponse.swift
+//  Domain
+//
+//  Created by Kim dohyun on 12/29/23.
+//
+
+import Foundation
+
+
+public struct AccountNickNameEditResponse {
+    public var memberId: String
+    public var name: String
+    public var imageUrl: URL
+    public var familyId: String
+    public var dayOfBirth: String
+    
+}

--- a/14th-team5-iOS/Domain/Sources/Account/Parameters/AccountNickNameEditParameter.swift
+++ b/14th-team5-iOS/Domain/Sources/Account/Parameters/AccountNickNameEditParameter.swift
@@ -1,0 +1,19 @@
+//
+//  AccountNickNameEditParameter.swift
+//  Domain
+//
+//  Created by Kim dohyun on 12/29/23.
+//
+
+import Foundation
+
+
+public struct AccountNickNameEditParameter: Encodable {
+    
+    public var name: String
+    
+    public init(name: String) {
+        self.name = name
+    }
+    
+}

--- a/14th-team5-iOS/Domain/Sources/Camera/Entity/CameraDisplayPostResponse.swift
+++ b/14th-team5-iOS/Domain/Sources/Camera/Entity/CameraDisplayPostResponse.swift
@@ -9,12 +9,12 @@ import Foundation
 
 
 public struct CameraDisplayPostResponse {
-    var postId: String?
-    var authorId: String?
-    var commentCount: Int?
-    var emojiCount: Int?
-    var imageURL: String?
-    var content: String?
-    var createdAt: String?
+    public var postId: String?
+    public var authorId: String?
+    public var commentCount: Int?
+    public var emojiCount: Int?
+    public var imageURL: String?
+    public var content: String?
+    public var createdAt: String?
     
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- ProfileViewController, PrivacyViewController TypeSystemLabel 기반 UI 수정
- AccountSignUpDiContainer AccountNickNameViewController FactoryMethod 추가 및 memberId inject 코드 추가
- AccountAPIs 프로필 편집 API 추가 및 Repository, Reactor 비즈니스 로직 추가

## 변경 로직 ⚒️

- AccountSignUpDiContainer에 AccountNickNameViewController 만 별도 생성하는 코드를 추가하였습니다.
- AccountAPIs에 프로필 편집 API Path와 Worker에 프로필 편집 통신 코드를 추가했습니다. or Repository, Reactor 비즈니스 로직 코드 추가
- ProfileViewController, PrivacyController TypeSystemLabel 기반 UI 수정 하였습니다.

## 스크린샷 📷

| 기능 | 스크린 샷 | 스크린 샷 | 스크린 샷 |
| :--: | :-------: | :-------: | :-------: |
| JPEG  | <img src="https://github.com/depromeet/14th-team5-iOS/assets/23008224/94ef3977-7191-4e01-88c7-ed13743536a6" width="300" /> | <img src="https://github.com/depromeet/14th-team5-iOS/assets/23008224/b1a63bb2-69d2-46ec-8cd1-95aaabe1d00a" width="300" /> |  <img src="https://github.com/depromeet/14th-team5-iOS/assets/23008224/59ad7c1b-5352-4196-a1a0-9747893fe386" width="300" /> |



