### PR TITLE
fix: ProfileViewController Feed CollectionView Pagination issue 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
@@ -168,7 +168,6 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
                 guard let userInfo = notification.userInfo else { return nil }
                 return userInfo["selectImage"] as? Data
             }
-            .debug("NotificationPHPicker")
             .map { Reactor.Action.didSelectPHAssetsImage($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -211,8 +210,9 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
                 } else {
                     return false
                 }
-                
-            }.map { Reactor.Action.fetchMorePostItems($0) }
+            }
+            .distinctUntilChanged()
+            .map { Reactor.Action.fetchMorePostItems($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -151,7 +151,6 @@ public final class ProfileViewReactor: Reactor {
                     
                     var sectionItem: [ProfileFeedSectionItem] = []
                     paginationItems.append(contentsOf: entity.results)
-                    print("pageination Test: \(paginationItems)")
                    
                     paginationItems.forEach {
                         sectionItem.append(.feedCategoryItem(ProfileFeedCellReactor(imageURL: $0.imageUrl, title: $0.content, date: DateFormatter.yyyyMMdd.string(from: $0.createdAt))))
@@ -182,15 +181,12 @@ public final class ProfileViewReactor: Reactor {
             
         case let .setProfileMemberItems(entity):
             newState.profileMemberEntity = entity
-            print("member Edit: \(entity)")
             
         case let .setProfilePresingedURL(entity):
             newState.profilePresingedURLEntity = entity
-            print("profilePresingedURL \(entity)")
             
         case let .setPresignedS3Upload(isProfileUpload):
             newState.isProfileUpload = isProfileUpload
-            print("presingedS3Upload \(isProfileUpload)")
         }
         
         return newState

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -151,7 +151,6 @@ public final class ProfileViewReactor: Reactor {
                     
                     var sectionItem: [ProfileFeedSectionItem] = []
                     paginationItems.append(contentsOf: entity.results)
-                    //Pageination 데이터 초기화 되는것 같음 해결 하기(나중에)
                     print("pageination Test: \(paginationItems)")
                    
                     paginationItems.forEach {
@@ -160,7 +159,6 @@ public final class ProfileViewReactor: Reactor {
                     
                     return .concat(
                         .just(.setLoading(true)),
-                        .just(.setProfilePostItems(entity)),
                         .just(.setFeedCategroySection(sectionItem)),
                         .just(.setLoading(false))
                     )

--- a/14th-team5-iOS/Data/Sources/Profile/Repositories/ProfileViewRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Profile/Repositories/ProfileViewRepository.swift
@@ -45,7 +45,6 @@ extension ProfileViewRepository: ProfileViewInterface {
             sort: parameter.sort
         )
         
-        print("last parameters: \(parameters)")
         
         return profileAPIWorker.fetchProfilePost(accessToken: accessToken, parameter: parameters)
             .compactMap { $0?.toDomain() }

--- a/14th-team5-iOS/Data/Sources/Profile/Repositories/ProfileViewRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Profile/Repositories/ProfileViewRepository.swift
@@ -19,7 +19,7 @@ public final class ProfileViewRepository {
         
     public var disposeBag: DisposeBag = DisposeBag()
     private let profileAPIWorker: ProfileAPIWorker = ProfileAPIWorker()
-    private let accessToken: String = "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJhY2Nlc3MiLCJyZWdEYXRlIjoxNzAzNzU3MTM1NzcyLCJ0eXAiOiJKV1QifQ.eyJ1c2VySWQiOiIwMUhKQk5YQVYwVFlRMUtFU1dFUjQ1QTJRUCIsImV4cCI6MTcwMzg0MzUzNX0.-lcEBKB_KI32_rI2Ne1fQPMEa1ueGlK9H1TgSuDTehw"
+    private let accessToken: String = "eyJhbGciOiJIUzI1NiIsInR5cGUiOiJhY2Nlc3MiLCJyZWdEYXRlIjoxNzAzODM2OTUzMzkwLCJ0eXAiOiJKV1QifQ.eyJ1c2VySWQiOiIwMUhKQk5YQVYwVFlRMUtFU1dFUjQ1QTJRUCIsImV4cCI6MTcwMzkyMzM1M30.sROYEmc6sxcSY82UKsei95EaDEw0Af8rx6q0qdmValI"
     
     public init() { }
     

--- a/14th-team5-iOS/Domain/Sources/Profile/UseCases/ProfileViewUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Profile/UseCases/ProfileViewUseCase.swift
@@ -32,7 +32,6 @@ public final class ProfileViewUseCase: ProfileViewUsecaseProtocol {
     }
     
     public func executeProfilePostItems(query: ProfilePostQuery, parameters: ProfilePostDefaultValue) -> Observable<ProfilePostResponse> {
-        print("query : \(query) and paramter: \(parameters)")
         return profileViewRepository.fetchProfilePostItems(query: query, parameter: parameters)
     }
     


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- ProfileViewController FeedCollectionView Pagination 데이터 초기화 issue 수정
- API 중복 호출 issue 수정
## 변경 로직 ⚒️
- fetchMorePostItems Mutation에서 setProfilePostItems를 통해 새로 Item을 초기화 하는 것 때문에 Pagination 이슈가 있었습니다.  
- Pagination 여부 값에 중복 값을 무시 안하다 보니 API가 중복 호출 되기 때문에 distinctUntilChanged 코드를 추가하였습니다. 

## 테스트 케이스 ✅

- [ ] Pagination이 잘 되는지
- [ ] API 여러번 호출 되는 것을 막는지



