### PR TITLE
feat: 캘린더 피드 셀 UI 구현, 피드 셀 통신 구현

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
+++ b/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+        window?.rootViewController = UINavigationController(rootViewController: CalendarDIConatainer().makeViewController())
         window?.makeKeyAndVisible()
     }
     

--- a/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
+++ b/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
@@ -23,7 +23,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let scene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: scene)
-        window?.rootViewController = UINavigationController(rootViewController: CalendarDIConatainer().makeViewController())
+        window?.rootViewController = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
         window?.makeKeyAndVisible()
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/CalendarPageCellDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/CalendarPageCellDIContainer.swift
@@ -23,6 +23,12 @@ public final class CalendarPageCellDIContainer {
         return appDelegate.globalStateProvider
     }
     
+    public let yearMonth: String
+    
+    public init(yearMonth: String) {
+        self.yearMonth = yearMonth
+    }
+    
     public func makeUseCase() -> UseCase {
         return CalendarUseCase(calendarRepository: makeRepository())
     }
@@ -31,7 +37,7 @@ public final class CalendarPageCellDIContainer {
         return CalendarRepository()
     }
     
-    public func makeReactor(yearMonth: String) -> Reactor {
+    public func makeReactor() -> Reactor {
         return CalendarPageCellReactor(yearMonth, usecase: makeUseCase(), provider: globalState)
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/CalendarPostDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/CalendarPostDIContainer.swift
@@ -11,10 +11,12 @@ import Core
 import Data
 import Domain
 
-public final class CalendarPostDIConatainer: BaseDIContainer {
+public final class CalendarPostDIConatainer {
     public typealias ViewController = CalendarPostViewController
-    public typealias UseCase = CalendarUseCaseProtocol
-    public typealias Repository = CalendarRepositoryProtocol
+    public typealias CalUseCase = CalendarUseCaseProtocol
+    public typealias PostUseCase = PostListUseCaseProtocol
+    public typealias CalRepository = CalendarRepositoryProtocol
+    public typealias PostRepository = PostListRepositoryProtocol
     public typealias Reactor = CalendarPostViewReactor
     
     let selectedDate: Date
@@ -34,18 +36,27 @@ public final class CalendarPostDIConatainer: BaseDIContainer {
         return CalendarPostViewController(reactor: makeReactor())
     }
     
-    public func makeUseCase() -> UseCase {
-        return CalendarUseCase(calendarRepository: makeRepository())
+    public func makeCalendarUseCase() -> CalUseCase {
+        return CalendarUseCase(calendarRepository: makeCalendarRepository())
     }
     
-    public func makeRepository() -> Repository {
+    public func makePostListUseCase() -> PostUseCase {
+        return PostListUseCase(postListRepository: makePostListRepository())
+    }
+    
+    public func makeCalendarRepository() -> CalRepository {
         return CalendarRepository()
+    }
+    
+    public func makePostListRepository() -> PostRepository {
+        return PostListAPIWorker()
     }
     
     public func makeReactor() -> Reactor {
         return CalendarPostViewReactor(
             selectedDate,
-            usecase: makeUseCase(),
+            calendarUseCase: makeCalendarUseCase(),
+            postListUseCase: makePostListUseCase(),
             provider: globalState
         )
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import Core
 import Data
+import Differentiator
 import Domain
 import FSCalendar
 import ReactorKit
@@ -17,19 +18,21 @@ import RxSwift
 public final class CalendarPostViewReactor: Reactor {
     // MARK: - Action
     public enum Action {
-        case didSelectCalendarCell(Date)
+        case didSelectDate(Date)
         case fetchCalendarResponse(String)
     }
     
     // MARK: - Mutation
     public enum Mutation {
-        case didSelectCalendarCell(Date)
+        case deleteDatasource
         case fetchCalendarResponse(String, ArrayResponseCalendarResponse)
+        case fetchPaginationResponsePostResponse([PostListData])
     }
     
     // MARK: - State
     public struct State {
-        var selectedCalendarCell: Date
+        var selectedDate: Date
+        var postListDatasource: [PostListSectionModel] = [SectionModel(model: "", items: [])]
         var dictCalendarResponse: [String: [CalendarResponse]] = [:] // (월: [일자 데이터]) 형식으로 불러온 데이터를 저장
     }
     
@@ -38,29 +41,62 @@ public final class CalendarPostViewReactor: Reactor {
     
     public let provider: GlobalStateProviderProtocol
     private let calendarUseCase: CalendarUseCaseProtocol
+    private let postListUseCase: PostListUseCaseProtocol
     
     private var isFetchedYearMonths: [String] = [] // API 호출한 월(月)을 저장
     private var hasThumbnailImageDates: [Date] = [] // 썸네일 이미지가 존재하는 일자를 저장
     
     // MARK: - Intializer
-    init(_ selection: Date, usecase: CalendarUseCaseProtocol, provider: GlobalStateProviderProtocol) {
-        self.initialState = State(selectedCalendarCell: selection)
+    init(
+        _ selection: Date,
+        calendarUseCase: CalendarUseCaseProtocol,
+        postListUseCase: PostListUseCaseProtocol,
+        provider: GlobalStateProviderProtocol
+    ) {
+        self.initialState = State(selectedDate: selection)
         
-        self.calendarUseCase = usecase
+        self.calendarUseCase = calendarUseCase
+        self.postListUseCase = postListUseCase
         self.provider = provider
     }
     
     // MARK: - Mutate
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
-        case let .didSelectCalendarCell(date):
+        case let .didSelectDate(date):
             // 썸네일 이미지가 존재하는 셀에 한하여
             if hasThumbnailImageDates.contains(date) {
                 // 주간 캘린더 셀 클릭 이벤트 방출
-                return provider.calendarGlabalState.didSelectCalendarCell(date)
-                    .flatMap { _ in Observable<Mutation>.empty() }
+                provider.calendarGlabalState.didSelectCalendarCell(date)
             }
-            return Observable<Mutation>.empty()
+            
+            // 멤버ID를 순회하며 가족이 게시한 포스트 가져오기
+            let memberIds: [String] = ["01HJBNWZGNP1KJNMKWVZJ039HY"] // TODO: - 가족의 멤버ID 가져오기
+            var arrayPostResponse: [PostListData] = []
+            
+            let singles = memberIds.map {
+                let postListQuery: PostListQuery = PostListQuery(
+                    page: 1,
+                    size: 10,
+                    date: date.toFormatString(with: "yyyy-MM-dd"),
+                    memberId: $0,
+                    sort: .asc
+                )
+                return postListUseCase.excute(query: postListQuery)
+            }
+            
+            return Single.zip(singles).asObservable()
+                .flatMap {
+                    if let postResponse: [PostListData] = $0.first??.postLists {
+                        arrayPostResponse.append(contentsOf: postResponse)
+                    }
+                    
+                    return Observable<Mutation>.concat(
+                        Observable.just(.deleteDatasource),
+                        Observable.just(.fetchPaginationResponsePostResponse(arrayPostResponse))
+                    )
+                }
+            
         case let .fetchCalendarResponse(yearMonth):
             // 이전에 불러온 적이 없다면
             if !isFetchedYearMonths.contains(yearMonth) {
@@ -87,13 +123,27 @@ public final class CalendarPostViewReactor: Reactor {
     // MARK: - Reduce
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
+        
         switch mutation {
-        // TODO: - 셀을 클릭하면 할 동작 구현하기(포스트 VC 등)
-        case let .didSelectCalendarCell(date):
-            newState.selectedCalendarCell = date
+        case .deleteDatasource:
+            newState.postListDatasource = [SectionModel(model: "", items: [])]
+            
         case let .fetchCalendarResponse(yearMonth, arrayCalendarResponse):
             newState.dictCalendarResponse[yearMonth] = arrayCalendarResponse.results
+            
+        case let .fetchPaginationResponsePostResponse(postResponse):
+            var postResponse = postResponse.sorted {
+                $0.time.toDate() < $1.time.toDate()
+            }
+            var newItems = SectionModel(model: "", items: postResponse)
+            newState.postListDatasource = [
+                SectionModel(
+                    model: "",
+                    items: newItems.items
+                )
+            ]
         }
+        
         return newState
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -87,9 +87,12 @@ public final class CalendarPostViewReactor: Reactor {
             
             return Single.zip(singles).asObservable()
                 .flatMap {
-                    if let postResponse: [PostListData] = $0.first??.postLists {
-                        arrayPostResponse.append(contentsOf: postResponse)
+                    guard let postResponse: [PostListData] = $0.first??.postLists,
+                          !postResponse.isEmpty else {
+                        return Observable<Mutation>.empty()
                     }
+                    
+                    arrayPostResponse.append(contentsOf: postResponse)
                     
                     return Observable<Mutation>.concat(
                         Observable.just(.deleteDatasource),

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/CalendarPageCell.swift
@@ -102,14 +102,14 @@ final class CalendarPageCell: BaseCollectionViewCell<CalendarPageCellReactor> {
             $0.appearance.selectionColor = UIColor.clear
             
             $0.appearance.titleFont = UIFont.pretendard(.body1Regular)
-            $0.appearance.titleDefaultColor = DesignSystemAsset.white.color
-            $0.appearance.titleSelectionColor = DesignSystemAsset.white.color
+            $0.appearance.titleDefaultColor = UIColor.bibbiWhite
+            $0.appearance.titleSelectionColor = UIColor.bibbiWhite
             
             $0.appearance.weekdayFont = UIFont.pretendard(.caption)
-            $0.appearance.weekdayTextColor = DesignSystemAsset.gray300.color
+            $0.appearance.weekdayTextColor = UIColor.gray300
             $0.appearance.caseOptions = .weekdayUsesSingleUpperCase
             
-            $0.appearance.titlePlaceholderColor = UIColor.systemGray.withAlphaComponent(0.3)
+            $0.appearance.titlePlaceholderColor = UIColor.gray700
             
             $0.backgroundColor = UIColor.clear
             

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
@@ -20,8 +20,9 @@ import Then
 final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {    
     // MARK: - Views
     private let dayLabel: BibbiLabel = BibbiLabel(.body1Regular, alignment: .center)
-    private let noThumbnailView: UIView = UIView()
+    private let thumbnailBackgroundView: UIView = UIView()
     private let thumbnailView: UIImageView = UIImageView()
+    private let todayStrokeView: UIView = UIView()
     private let badgeView: UIImageView = UIImageView()
     
     // MARK: - Properties
@@ -47,14 +48,15 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
         thumbnailView.layer.borderWidth = .zero
         thumbnailView.layer.borderColor = UIColor.bibbiWhite.cgColor
         badgeView.isHidden = true
+        todayStrokeView.isHidden = true
     }
     
     // MARK: - Helpers
     private func setupUI() {
         contentView.insertSubview(thumbnailView, at: 0)
-        contentView.insertSubview(noThumbnailView, at: 0)
+        contentView.insertSubview(thumbnailBackgroundView, at: 0)
         contentView.addSubviews(
-            dayLabel, badgeView
+            dayLabel, badgeView, todayStrokeView
         )
     }
     
@@ -63,12 +65,17 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             $0.center.equalTo(contentView.snp.center)
         }
         
-        noThumbnailView.snp.makeConstraints {
+        thumbnailBackgroundView.snp.makeConstraints {
             $0.center.equalTo(contentView.snp.center)
             $0.width.height.equalTo(contentView.snp.width).inset(CalendarCell.AutoLayout.thumbnailInsetValue)
         }
         
         thumbnailView.snp.makeConstraints {
+            $0.center.equalTo(contentView.snp.center)
+            $0.width.height.equalTo(contentView.snp.width).inset(CalendarCell.AutoLayout.thumbnailInsetValue)
+        }
+        
+        todayStrokeView.snp.makeConstraints {
             $0.center.equalTo(contentView.snp.center)
             $0.width.height.equalTo(contentView.snp.width).inset(CalendarCell.AutoLayout.thumbnailInsetValue)
         }
@@ -85,7 +92,7 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             $0.isHidden = true
         }
         
-        noThumbnailView.do {
+        thumbnailBackgroundView.do {
             $0.clipsToBounds = true
             $0.layer.cornerRadius = 13.0
             $0.backgroundColor = DesignSystemAsset.gray900.color
@@ -98,6 +105,13 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             $0.layer.borderWidth = .zero
             $0.layer.borderColor = DesignSystemAsset.white.color.cgColor
             $0.alpha = CalendarCell.Attribute.defaultAlphaValue
+        }
+        
+        todayStrokeView.do {
+            $0.isHidden = true
+            $0.layer.cornerRadius = 13.0
+            $0.layer.borderWidth = 2.0
+            $0.layer.borderColor = DesignSystemAsset.mainGreen.color.cgColor
         }
         
         badgeView.do {
@@ -125,9 +139,8 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             .withUnretained(self)
             .subscribe {
                 if $0.1 {
+                    $0.0.todayStrokeView.isHidden = false
                     $0.0.dayLabel.textBibbiColor = UIColor.mainGreen
-                    $0.0.thumbnailView.layer.borderWidth = 2.0
-                    $0.0.thumbnailView.layer.borderColor = UIColor.mainGreen.cgColor
                 }
             }
             .disposed(by: disposeBag)
@@ -157,15 +170,20 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             .subscribe {
                 if reactor.type == .week {
                     if $0.1 {
+                        $0.0.todayStrokeView.isHidden = true
+                        
+                        $0.0.thumbnailView.alpha = 1.0
+                        $0.0.thumbnailBackgroundView.alpha = 1.0
                         $0.0.thumbnailView.layer.borderWidth = 2.0
-                        $0.0.thumbnailView.layer.borderColor = DesignSystemAsset.white.color.cgColor
+                        $0.0.thumbnailView.layer.borderColor = UIColor.bibbiWhite.cgColor
                     } else {
+                        $0.0.thumbnailView.alpha = 0.3
+                        $0.0.thumbnailBackgroundView.alpha = 0.3
                         $0.0.thumbnailView.layer.borderWidth = 0.0
                         
                         if reactor.currentState.date.isToday {
+                            $0.0.todayStrokeView.isHidden = false
                             $0.0.dayLabel.textBibbiColor = UIColor.mainGreen
-                            $0.0.thumbnailView.layer.borderWidth = 2.0
-                            $0.0.thumbnailView.layer.borderColor = UIColor.mainGreen.cgColor
                         }
                     }
                 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
@@ -19,7 +19,7 @@ import Then
 
 final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {    
     // MARK: - Views
-    private let dayLabel: BibbiLabel = BibbiLabel(.body1Regular)
+    private let dayLabel: BibbiLabel = BibbiLabel(.body1Regular, alignment: .center)
     private let noThumbnailView: UIView = UIView()
     private let thumbnailView: UIImageView = UIImageView()
     private let badgeView: UIImageView = UIImageView()
@@ -42,10 +42,10 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
     }
     
     public override func prepareForReuse() {
-        dayLabel.textColor = UIColor.white
+        dayLabel.textBibbiColor = UIColor.bibbiWhite
         thumbnailView.image = nil
         thumbnailView.layer.borderWidth = .zero
-        thumbnailView.layer.borderColor = UIColor.white.cgColor
+        thumbnailView.layer.borderColor = UIColor.bibbiWhite.cgColor
         badgeView.isHidden = true
     }
     
@@ -83,10 +83,6 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
     private func setupAttribute() {
         titleLabel.do {
             $0.isHidden = true
-        }
-        
-        dayLabel.do {
-            $0.textAlignment = .center
         }
         
         noThumbnailView.do {
@@ -129,9 +125,9 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             .withUnretained(self)
             .subscribe {
                 if $0.1 {
-                    $0.0.dayLabel.textBibbiColor = .mainGreen
+                    $0.0.dayLabel.textBibbiColor = UIColor.mainGreen
                     $0.0.thumbnailView.layer.borderWidth = 2.0
-                    $0.0.thumbnailView.layer.borderColor = UIColor.green.cgColor
+                    $0.0.thumbnailView.layer.borderColor = UIColor.mainGreen.cgColor
                 }
             }
             .disposed(by: disposeBag)
@@ -167,9 +163,9 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
                         $0.0.thumbnailView.layer.borderWidth = 0.0
                         
                         if reactor.currentState.date.isToday {
-                            $0.0.dayLabel.textBibbiColor = .mainGreen
+                            $0.0.dayLabel.textBibbiColor = UIColor.mainGreen
                             $0.0.thumbnailView.layer.borderWidth = 2.0
-                            $0.0.thumbnailView.layer.borderColor = DesignSystemAsset.mainGreen.color.cgColor
+                            $0.0.thumbnailView.layer.borderColor = UIColor.mainGreen.cgColor
                         }
                     }
                 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/ImageCalendarCell.swift
@@ -129,7 +129,7 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
             .withUnretained(self)
             .subscribe {
                 if $0.1 {
-                    $0.0.dayLabel.textTypeSystemColor = .mainGreen
+                    $0.0.dayLabel.textBibbiColor = .mainGreen
                     $0.0.thumbnailView.layer.borderWidth = 2.0
                     $0.0.thumbnailView.layer.borderColor = UIColor.green.cgColor
                 }
@@ -167,7 +167,7 @@ final public class ImageCalendarCell: FSCalendarCell, ReactorKit.View {
                         $0.0.thumbnailView.layer.borderWidth = 0.0
                         
                         if reactor.currentState.date.isToday {
-                            $0.0.dayLabel.textTypeSystemColor = .mainGreen
+                            $0.0.dayLabel.textBibbiColor = .mainGreen
                             $0.0.thumbnailView.layer.borderWidth = 2.0
                             $0.0.thumbnailView.layer.borderColor = DesignSystemAsset.mainGreen.color.cgColor
                         }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -253,7 +253,15 @@ extension CalendarPostViewController {
         return RxCollectionViewSectionedReloadDataSource<PostListSectionModel> { datasource, collectionView, indexPath, item in
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostCollectionViewCell.id, for: indexPath) as! PostCollectionViewCell
             // TODO: - Reactor로 필요한 데이터 주입하기
-            cell.setCell(data: item)
+            cell.reactor = EmojiReactor(
+                emojiRepository: PostListsDIContainer().makeEmojiUseCase(),
+                initialState: .init(
+                    type: .calendar,
+                    postId: item.postId,
+                    memberId: item.author,
+                    imageUrl: item.imageURL
+                )
+            )
             return cell
         }
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 import Core
+import DesignSystem
 import Domain
 import FSCalendar
 import Kingfisher
@@ -91,7 +92,7 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
         
         navigationBarView.do {
             $0.navigationTitle = ""
-            $0.leftBarButtonItem = .setting
+            $0.leftBarButtonItem = .arrowLeft
         }
         
         calendarView.do {
@@ -104,9 +105,9 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             
             $0.appearance.selectionColor = UIColor.clear
             
-            $0.appearance.titleFont = UIFont.boldSystemFont(ofSize: CalendarVC.Attribute.calendarTitleFontSize)
-            $0.appearance.titleDefaultColor = UIColor.white
-            $0.appearance.titleSelectionColor = UIColor.white
+            $0.appearance.titleFont = UIFont.pretendard(.body1Regular)
+            $0.appearance.titleDefaultColor = DesignSystemAsset.white.color
+            $0.appearance.titleSelectionColor = DesignSystemAsset.white.color
             
             $0.backgroundColor = UIColor.clear
             $0.register(ImageCalendarCell.self, forCellReuseIdentifier: ImageCalendarCell.id)
@@ -248,6 +249,15 @@ extension CalendarPostViewController {
 }
 
 extension CalendarPostViewController {
+    private func prepareDatasource() -> RxCollectionViewSectionedReloadDataSource<PostListSectionModel> {
+        return RxCollectionViewSectionedReloadDataSource<PostListSectionModel> { datasource, collectionView, indexPath, item in
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostCollectionViewCell.id, for: indexPath) as! PostCollectionViewCell
+            // TODO: - Reactor로 필요한 데이터 주입하기
+            cell.setCell(data: item)
+            return cell
+        }
+    }
+    
     private func setupBlurEffect() {
         let blurEffect = UIBlurEffect(style: .systemThickMaterialDark)
         let visualEffectView = UIVisualEffectView(effect: blurEffect)
@@ -265,15 +275,6 @@ extension CalendarPostViewController {
             $0.height.equalTo(bounds.height)
         }
         view.layoutIfNeeded()
-    }
-    
-    // TODO: - 다시 정의하기
-    private func prepareDatasource() -> RxCollectionViewSectionedReloadDataSource<PostListSectionModel> {
-        return RxCollectionViewSectionedReloadDataSource<PostListSectionModel> { datasource, collectionView, indexPath, item in
-            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostCollectionViewCell.id, for: indexPath) as! PostCollectionViewCell
-            cell.setCell(data: item)
-            return cell
-        }
     }
 }
 

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -167,7 +167,7 @@ extension CalendarViewController {
     private func prepareDatasource() -> RxCollectionViewSectionedReloadDataSource<SectionOfMonthlyCalendar> {
         return RxCollectionViewSectionedReloadDataSource<SectionOfMonthlyCalendar> { datasource, collectionView, indexPath, yearMonth in
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: CalendarPageCell.id, for: indexPath) as! CalendarPageCell
-            cell.reactor = CalendarPageCellDIContainer().makeReactor(yearMonth: yearMonth)
+            cell.reactor = CalendarPageCellDIContainer(yearMonth: yearMonth).makeReactor()
             return cell
         }
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -132,8 +132,6 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
 }
 
 // MARK: - Extensions
-extension CalendarViewController: BibbiNavigationBarViewDelegate { }
-
 extension CalendarViewController {
     private var orthogonalCompositionalLayout: UICollectionViewCompositionalLayout {
         // item

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Dependency/HomeDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Dependency/HomeDIContainer.swift
@@ -19,7 +19,7 @@ public final class HomeDIContainer {
         return HomeViewController(reactor: makeReactor())
     }
     
-    public func makePostRepository() -> PostListRepository {
+    public func makePostRepository() -> PostListRepositoryProtocol {
         return PostListAPIs.Worker()
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/HomeViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/HomeViewReactor.swift
@@ -79,7 +79,7 @@ extension HomeViewReactor {
                     }
                 }
         case .getTodayPostList:
-            let query: PostListQuery = PostListQuery(page: 1, size: 20, date: "2023-12-05", memberId: "", sort: "DESC")
+            let query: PostListQuery = PostListQuery(page: 1, size: 20, date: "2023-12-05", memberId: "", sort: .desc)
             return postRepository.excute(query: query)
                 .asObservable()
                 .flatMap { postList in

--- a/14th-team5-iOS/App/Sources/Presentation/InviteFamily/View/FamilyMemberProfileCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/InviteFamily/View/FamilyMemberProfileCell.swift
@@ -104,7 +104,7 @@ final class FamiliyMemberProfileCell: BaseTableViewCell<FamilyMemberProfileCellR
         }
         
         isMeLabel.do {
-            $0.textTypeSystemColor = .gray500
+            $0.textBibbiColor = .gray500
         }
         
         contentView.backgroundColor = DesignSystemAsset.black.color

--- a/14th-team5-iOS/App/Sources/Presentation/InviteFamily/ViewController/InviteFamilyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/InviteFamily/ViewController/InviteFamilyViewController.swift
@@ -145,13 +145,13 @@ public final class InviteFamilyViewController: BaseViewController<InviteFamilyVi
         
         inviteFamilyTitleLabel.do {
             $0.text = AddFamilyVC.Strings.addFamilyTitle
-            $0.textTypeSystemColor = .white
+            $0.textBibbiColor = .white
             $0.textAlignment = .left
         }
         
         invitationUrlLabel.do {
             $0.text = AddFamilyVC.Strings.invitationUrlText
-            $0.textTypeSystemColor = .gray500
+            $0.textBibbiColor = .gray500
             $0.textAlignment = .left
         }
         

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Dependency/PostListsDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Dependency/PostListsDIContainer.swift
@@ -19,7 +19,7 @@ final class PostListsDIContainer {
         return PostViewController(reactor: makeReactor(postLists: postLists, selectedIndex: selectedIndex.row))
     }
     
-    func makePostRepository() -> PostListRepository {
+    func makePostRepository() -> PostListRepositoryProtocol {
         return PostListAPIs.Worker()
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Model/SectionOfPostDetail.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Model/SectionOfPostDetail.swift
@@ -9,6 +9,8 @@ import Domain
 
 import RxDataSources
 
+typealias PostListSectionModel = SectionModel<String, PostListData>
+
 struct SectionOfPostDetail {
     var items: [PostData]
     

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Model/String/PostCGFloat.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Model/String/PostCGFloat.swift
@@ -40,7 +40,7 @@ enum PostAutoLayout {
         enum CollectionViewCell {
             enum PostImageView {
                 static let topInset = 82
-                static let cornerRadius: CGFloat = 24
+                static let cornerRadius: CGFloat = 48
             }
             
             enum ShowSelectableEmojiButton {

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
@@ -34,8 +34,10 @@ final class EmojiReactor: Reactor {
     
     struct State {
         let type: CellType
-        var postId: String
-        var memberId: String // 닉네임 찾기용
+        let postId: String
+        let memberId: String // 닉네임 찾기용
+        let imageUrl: String
+        
         var isShowingSelectableEmojiStackView: Bool = false
         var selectedEmoji: (Emojis?, Int) = (nil, 0)
         var unselectedEmoji: (Emojis?, Int) = (nil, 0)

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
@@ -11,6 +11,11 @@ import ReactorKit
 import Domain
 
 final class EmojiReactor: Reactor {
+    enum CellType {
+        case home
+        case calendar
+    }
+    
     enum Action {
         case tappedSelectableEmojiStackView
         /// emoji count + 1
@@ -28,7 +33,9 @@ final class EmojiReactor: Reactor {
     }
     
     struct State {
+        let type: CellType
         var postId: String
+        var memberId: String // 닉네임 찾기용
         var isShowingSelectableEmojiStackView: Bool = false
         var selectedEmoji: (Emojis?, Int) = (nil, 0)
         var unselectedEmoji: (Emojis?, Int) = (nil, 0)

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -27,7 +27,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     /// 이모지 카운트를 보여주기 위한 stackView
     private let emojiCountStackView = UIStackView()
     
-    var reactor = EmojiReactor(emojiRepository: PostListsDIContainer().makeEmojiUseCase(), initialState: .init(type: .home, postId: "01HJBRBSZRF429S1SES900ET5G", memberId: ""))
+    let reactor = EmojiReactor(emojiRepository: PostListsDIContainer().makeEmojiUseCase(), initialState: .init(type: .home, postId: "01HJBRBSZRF429S1SES900ET5G", memberId: "", imageUrl: ""))
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -87,15 +87,22 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             }
             .disposed(by: disposeBag)
         
-        // TODO: - 프로필 이미지 및 닉네임 집어넣기
         reactor.state
-            .map { $0.memberId }
+            .debug("============================ 이미지 처리")
+            .map { $0.imageUrl }
             .distinctUntilChanged()
             .withUnretained(self)
             .subscribe {
-                // do something...
+                $0.0.postImageView.kf.setImage(
+                    with: URL(string: $0.1),
+                    options: [
+                        .transition(.fade(0.25))
+                    ]
+                )
             }
             .disposed(by: disposeBag)
+        
+        // TODO: - 프로필 이미지 및 닉네임 집어넣기
     }
     
     

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -16,6 +16,10 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     typealias Layout = PostAutoLayout.CollectionView.CollectionViewCell
     static let id = "postCollectionViewCell"
     
+    private let profileStackView = UIStackView()
+    private let profileImageView = UIImageView()
+    private let nickNameLabel = BibbiLabel(.caption, textColor: .gray200)
+    
     private let postImageView = UIImageView()
     /// 이모지를 선택하기 위한 버튼을 모아둔 stackView
     private let selectableEmojiStackView = UIStackView()
@@ -23,7 +27,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     /// 이모지 카운트를 보여주기 위한 stackView
     private let emojiCountStackView = UIStackView()
     
-    private let reactor = EmojiReactor(emojiRepository: PostListsDIContainer().makeEmojiUseCase(), initialState: .init(postId: "01HJBRBSZRF429S1SES900ET5G"))
+    var reactor = EmojiReactor(emojiRepository: PostListsDIContainer().makeEmojiUseCase(), initialState: .init(type: .home, postId: "01HJBRBSZRF429S1SES900ET5G", memberId: ""))
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -67,22 +71,57 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
                 self.unselectEmoji(emoji: $0.1.0 ?? .emoji1, count: $0.1.1)
             })
             .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.type }
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .subscribe {
+                if $0.1 == .calendar {
+                    $0.0.profileStackView.isHidden = false
+                    
+                    $0.0.profileStackView.snp.updateConstraints {
+                        $0.top.equalToSuperview()
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
+        
+        // TODO: - 프로필 이미지 및 닉네임 집어넣기
+        reactor.state
+            .map { $0.memberId }
+            .distinctUntilChanged()
+            .withUnretained(self)
+            .subscribe {
+                // do something...
+            }
+            .disposed(by: disposeBag)
     }
     
     
     override func setupUI() {
         super.setupUI()
-        
-        addSubviews(postImageView, showSelectableEmojiButton, emojiCountStackView, selectableEmojiStackView)
+        addSubviews(profileStackView, postImageView, showSelectableEmojiButton, emojiCountStackView, selectableEmojiStackView)
+        profileStackView.addArrangedSubviews(profileImageView, nickNameLabel)
     }
 
     override func setupAutoLayout() {
         super.setupAutoLayout()
 
+        profileStackView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.top.equalToSuperview().offset(Layout.PostImageView.topInset - (34 + 8))
+            $0.height.equalTo(34)
+        }
+        
+        profileImageView.snp.makeConstraints {
+            $0.width.height.equalTo(34)
+        }
+        
         postImageView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
             $0.height.equalTo(postImageView.snp.width)
-            $0.top.equalToSuperview().inset(Layout.PostImageView.topInset)
+            $0.top.equalTo(profileStackView.snp.bottom).offset(8)
         }
         
         showSelectableEmojiButton.snp.makeConstraints {
@@ -107,6 +146,24 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     
     override func setupAttributes() {
         super.setupAttributes()
+        
+        // TODO: - memberID에 맞게 데이터 주입하기
+        profileStackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 12.0
+            $0.isHidden = true
+        }
+        
+        profileImageView.do {
+            $0.image = DesignSystemAsset.emoji1.image
+            $0.contentMode = .scaleAspectFill
+            $0.layer.masksToBounds = true
+            $0.layer.cornerRadius = 34.0 / 2.0
+        }
+        
+        nickNameLabel.do {
+            $0.text = "김건우"
+        }
         
         postImageView.do {
             $0.clipsToBounds = true

--- a/14th-team5-iOS/Core/Sources/Extensions/UIFont+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/UIFont+Ext.swift
@@ -20,7 +20,11 @@ extension UIFont {
 }
 
 extension UIFont {
-    static func fontAttributes(_ textStyle: BibbiFontStyle = .title, textColor color: UIColor = .bibbiWhite, textAlignment: NSTextAlignment = .left) -> FontAttributes {
+    static func fontAttributes(
+        _ textStyle: BibbiFontStyle = .title,
+        textColor color: UIColor = .bibbiWhite,
+        textAlignment: NSTextAlignment = .left
+    ) -> FontAttributes {
         switch textStyle {
         case .title:
             return FontAttributes(

--- a/14th-team5-iOS/Core/Sources/GlobalState/CalendarGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/CalendarGlobalState.swift
@@ -19,7 +19,7 @@ public enum CalendarEvent {
 public protocol CalendarGlobalStateType {
     var event: BehaviorSubject<CalendarEvent> { get }
     func pushCalendarPostVC(_ date: Date) -> Observable<Date>
-    func didSelectCalendarCell(_ date: Date) -> Observable<Date>
+    func didSelectDate(_ date: Date) -> Observable<Date>
     func didTapCalendarInfoButton(_ sourceView: UIView) -> Observable<Void>
 }
 
@@ -31,7 +31,7 @@ final public class CalendarGlobalState: BaseGlobalState, CalendarGlobalStateType
         return Observable<Date>.just(date)
     }
     
-    public func didSelectCalendarCell(_ date: Date) -> Observable<Date> {
+    public func didSelectDate(_ date: Date) -> Observable<Date> {
         event.onNext(.didSelectCalendarCell(date))
         return Observable<Date>.just(date)
     }

--- a/14th-team5-iOS/Core/Sources/Views/BibbiLabel/BibbiLabel.swift
+++ b/14th-team5-iOS/Core/Sources/Views/BibbiLabel/BibbiLabel.swift
@@ -12,35 +12,29 @@ import DesignSystem
 public class BibbiLabel: UILabel {
     // MARK: - Properties
     private var textStyle: UIFont.BibbiFontStyle
-    private var alignment: NSTextAlignment = .left // 기본 정렬 속성
+    private var alignment: NSTextAlignment
     
-    public var textTypeSystemColor: UIColor = .bibbiWhite {
+    public var textBibbiColor: UIColor = .bibbiWhite {
         didSet {
             updateAttributes()
         }
     }
     
     // MARK: - Intializer
-    public init(_ style: UIFont.BibbiFontStyle, alignment: NSTextAlignment = .left, textColor color: UIColor = .bibbiWhite) {
+    public init(
+        _ style: UIFont.BibbiFontStyle,
+        alignment: NSTextAlignment = .left,
+        textColor color: UIColor = .bibbiWhite
+    ) {
         self.textStyle = style
         self.alignment = alignment
-        self.textTypeSystemColor = color
+        self.textBibbiColor = color
         super.init(frame: .zero)
         updateAttributes()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    // MARK: - Helpers
-    private func setupAttributes(_ textStyle: UIFont.BibbiFontStyle, textColor color: UIColor) {
-        let attributes = UIFont.fontAttributes(
-            textStyle,
-            textColor: color
-        )
-        setupBasicAttributes(attributes)
-        setupDetailAttributes(attributes)
     }
 }
 
@@ -53,19 +47,25 @@ extension BibbiLabel {
 }
 
 extension BibbiLabel {
-    public func updateTextStyle(_ style: UIFont.BibbiFontStyle, alignment: NSTextAlignment = .left, textColor color: UIColor? = nil) {
+    public func updateTextStyle(
+        _ style: UIFont.BibbiFontStyle,
+        alignment: NSTextAlignment = .left,
+        textColor color: UIColor? = nil
+    ) {
         self.textStyle = style
         self.alignment = alignment
         if let color = color {
-            self.textTypeSystemColor = color
+            self.textBibbiColor = color
         }
         updateAttributes()
     }
-    
+}
+
+extension BibbiLabel {
     private func updateAttributes() {
         let attributes = UIFont.fontAttributes(
             textStyle,
-            textColor: textTypeSystemColor,
+            textColor: textBibbiColor,
             textAlignment: alignment
         )
         setupBasicAttributes(attributes)

--- a/14th-team5-iOS/Data/Sources/Calendar/Repository/CalendarRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/Repository/CalendarRepository.swift
@@ -16,25 +16,28 @@ import RxSwift
 enum TempStr {
     static let familyId = "familyId"
 
-    static let accessToken = "eyJ0eXBlIjoiYWNjZXNzIiwiYWxnIjoiSFMyNTYiLCJ0eXAiOiJKV1QiLCJyZWdEYXRlIjoxNzAzODI0MDI2NTMyfQ.eyJ1c2VySWQiOiIwMUhKQk5XWkdOUDFLSk5NS1dWWkowMzlIWSIsImV4cCI6MTcwMzkxMDQyNn0.9oLLeuhBcTOvz0Eh0NTfD8fk4rD9yDgEogVEzLf6o5k"
+    static let accessToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInR5cGUiOiJhY2Nlc3MiLCJyZWdEYXRlIjoxNzA0MTA3MzQzMTkwfQ.eyJ1c2VySWQiOiIwMUhKQk5XWkdOUDFLSk5NS1dWWkowMzlIWSIsImV4cCI6MTcwNDE5Mzc0M30.hRniUYNHxEb4zVxfWE1UiKdKScaBi0VpAjWZIvd28KU"
 }
 
 public final class CalendarRepository: CalendarRepositoryProtocol {
     public let disposeBag: DisposeBag = DisposeBag()
     
-    private let apiWorker: CalendarAPIWorker = CalendarAPIWorker()
+    private let calendarApiWorker: CalendarAPIWorker = CalendarAPIWorker()
+    private let postListApiWorker: PostListAPIWorker = PostListAPIWorker()
     
     public init() { }
     
     // TODO: - AccessToken 구하는 코드 구현
     public func fetchMonthlyCalendar(_ yearMonth: String) -> Observable<ArrayResponseCalendarResponse?> {
-        return apiWorker.fetchMonthlyCalendar(yearMonth, accessToken: TempStr.accessToken)
+        return calendarApiWorker.fetchMonthlyCalendar(yearMonth, accessToken: TempStr.accessToken)
             .asObservable()
     }
     
     // TODO: - AccessToken 구하는 코드 구현
-    public func fetchWeekCalendar(_ yearMonth: String, week: Int) -> Observable<ArrayResponseCalendarResponse?> {
-        return apiWorker.fetchWeeklyCalendar(yearMonth, week: week, accessToken: TempStr.accessToken)
+    public func fetchWeeklyCalendar(_ yearMonth: String, week: Int) -> Observable<ArrayResponseCalendarResponse?> {
+        return calendarApiWorker.fetchWeeklyCalendar(yearMonth, week: week, accessToken: TempStr.accessToken)
             .asObservable()
     }
+    
+    // TODO: - 
 }

--- a/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
@@ -15,13 +15,13 @@ import RxSwift
 public final class FamilyRepository: FamilyRepositoryProtocol {
     public let disposeBag: DisposeBag = DisposeBag()
     
-    private let apiWorker: FamilyAPIWorker = FamilyAPIWorker()
+    private let familyApiWorker: FamilyAPIWorker = FamilyAPIWorker()
     
     public init() { }
     
     // TODO: - FamiliyID, AccessToken 구하는 코드 구현
     public func fetchInvitationUrl() -> Observable<URL?> {
-        return apiWorker.fetchInvitationUrl(TempStr.familyId, accessToken: TempStr.accessToken)
+        return familyApiWorker.fetchInvitationUrl(TempStr.familyId, accessToken: TempStr.accessToken)
             .asObservable()
             .compactMap { $0?.url }
             .map { urlString in
@@ -34,7 +34,7 @@ public final class FamilyRepository: FamilyRepositoryProtocol {
     
     // TODO: - AccessToken 구하는 코드 구현
     public func fetchFamilyMembers() -> Observable<PaginationResponseFamilyMemberProfile?> {
-        return apiWorker.fetchFamilyMemeberPage(accessToken: TempStr.accessToken)
+        return familyApiWorker.fetchFamilyMemeberPage(accessToken: TempStr.accessToken)
             .asObservable()
     }
 }

--- a/14th-team5-iOS/Data/Sources/Post/PostList/PostListAPI/PostListAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Post/PostList/PostListAPI/PostListAPIWorker.swift
@@ -11,7 +11,7 @@ import Domain
 import Alamofire
 import RxSwift
 
-typealias PostListAPIWorker = PostListAPIs.Worker
+public typealias PostListAPIWorker = PostListAPIs.Worker
 extension PostListAPIs {
     public final class Worker: APIWorker {
         static let queue = {
@@ -25,7 +25,7 @@ extension PostListAPIs {
     }
 }
 
-extension PostListAPIWorker: PostListRepository {
+extension PostListAPIWorker: PostListRepositoryProtocol {
     public func fetchPostDetail(query: Domain.PostQuery) -> RxSwift.Single<Domain.PostData?> {
         let requestDTO = PostRequestDTO(postId: query.postId)
         let spec = PostListAPIs.fetchPostDetail(requestDTO).spec

--- a/14th-team5-iOS/Domain/Sources/Calendar/Interfaces/Repositories/CalendarRepository.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Interfaces/Repositories/CalendarRepository.swift
@@ -13,5 +13,5 @@ public protocol CalendarRepositoryProtocol {
     var disposeBag: DisposeBag { get }
     
     func fetchMonthlyCalendar(_ yearMonth: String) -> Observable<ArrayResponseCalendarResponse?>
-    func fetchWeekCalendar(_ yearMonth: String, week: Int) -> Observable<ArrayResponseCalendarResponse?>
+    func fetchWeeklyCalendar(_ yearMonth: String, week: Int) -> Observable<ArrayResponseCalendarResponse?>
 }

--- a/14th-team5-iOS/Domain/Sources/Calendar/UseCases/CalendarUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/UseCases/CalendarUseCase.swift
@@ -26,6 +26,6 @@ public final class CalendarUseCase: CalendarUseCaseProtocol {
     }
     
     public func executeFetchWeeklyCalendar(_ yearMonth: String, week: Int) -> Observable<ArrayResponseCalendarResponse?> {
-        return calendarRepository.fetchWeekCalendar(yearMonth, week: week)
+        return calendarRepository.fetchWeeklyCalendar(yearMonth, week: week)
     }
 }

--- a/14th-team5-iOS/Domain/Sources/Post/PostList/Entities/PostListQuery.swift
+++ b/14th-team5-iOS/Domain/Sources/Post/PostList/Entities/PostListQuery.swift
@@ -15,7 +15,13 @@ public struct PostListQuery {
     /// DESC | ASC
     public let sort: String
     
-    public init(page: Int, size: Int, date: String, memberId: String, sort: PostListQuery.Sort) {
+    public init(
+        page: Int,
+        size: Int,
+        date: String,
+        memberId: String = "",
+        sort: PostListQuery.Sort
+    ) {
         self.page = page
         self.size = size
         self.date = date

--- a/14th-team5-iOS/Domain/Sources/Post/PostList/Entities/PostListQuery.swift
+++ b/14th-team5-iOS/Domain/Sources/Post/PostList/Entities/PostListQuery.swift
@@ -15,11 +15,18 @@ public struct PostListQuery {
     /// DESC | ASC
     public let sort: String
     
-    public init(page: Int, size: Int, date: String, memberId: String, sort: String) {
+    public init(page: Int, size: Int, date: String, memberId: String, sort: PostListQuery.Sort) {
         self.page = page
         self.size = size
         self.date = date
         self.memberId = memberId
-        self.sort = sort
+        self.sort = sort.rawValue
+    }
+}
+
+extension PostListQuery {
+    public enum Sort: String {
+        case asc = "ASC"
+        case desc = "DESC"
     }
 }

--- a/14th-team5-iOS/Domain/Sources/Post/PostList/Interfaces/PostListRepositoryProtocol.swift
+++ b/14th-team5-iOS/Domain/Sources/Post/PostList/Interfaces/PostListRepositoryProtocol.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RxSwift
 
-public protocol PostListRepository {
+public protocol PostListRepositoryProtocol {
     func fetchPostDetail(query: PostQuery) -> Single<PostData?>
     func fetchTodayPostList(query: PostListQuery) -> Single<PostListPage?>
 }

--- a/14th-team5-iOS/Domain/Sources/Post/PostList/UseCases/PostListUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Post/PostList/UseCases/PostListUseCase.swift
@@ -14,9 +14,9 @@ public protocol PostListUseCaseProtocol {
 }
 
 public class PostListUseCase: PostListUseCaseProtocol {
-    private let postListRepository: PostListRepository
+    private let postListRepository: PostListRepositoryProtocol
     
-    public init(postListRepository: PostListRepository) {
+    public init(postListRepository: PostListRepositoryProtocol) {
         self.postListRepository = postListRepository
     }
     

--- a/pippi.xcworkspace/contents.xcworkspacedata
+++ b/pippi.xcworkspace/contents.xcworkspacedata
@@ -21,80 +21,64 @@
       </FileRef>
    </Group>
    <Group
-      location = "group:Tuist"
-      name = "Tuist">
-      <Group
-         location = "group:Dependencies"
-         name = "Dependencies">
-         <Group
-            location = "group:SwiftPackageManager"
-            name = "SwiftPackageManager">
-            <Group
-               location = "group:.build"
-               name = ".build">
-               <Group
-                  location = "group:checkouts"
-                  name = "checkouts">
-                  <FileRef
-                     location = "group:Alamofire/Alamofire.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:FSCalendar/FSCalendar.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:GoogleDataTransport/GoogleDataTransport.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:GoogleUtilities/GoogleUtilities.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:Kingfisher/Kingfisher.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:ReactorKit/ReactorKit.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:RxAlamofire/RxAlamofire.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:RxDataSources/RxDataSources.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:RxSwift/RxSwift.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:SnapKit/SnapKit.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:SwiftKeychainWrapper/SwiftKeychainWrapper.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:Then/Then.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:WeakMapTable/WeakMapTable.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:firebase-ios-sdk/Firebase.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:kakao-ios-sdk-rx/RxKakaoOpenSDK.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:nanopb/nanopb.xcodeproj">
-                  </FileRef>
-                  <FileRef
-                     location = "group:promises/Promises.xcodeproj">
-                  </FileRef>
-               </Group>
-            </Group>
-         </Group>
-      </Group>
+      location = "container:"
+      name = "Dependencies">
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Alamofire/Alamofire.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/FSCalendar/FSCalendar.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleDataTransport/GoogleDataTransport.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleUtilities/GoogleUtilities.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Kingfisher/Kingfisher.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/ReactorKit/ReactorKit.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxAlamofire/RxAlamofire.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxDataSources/RxDataSources.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxSwift/RxSwift.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SnapKit/SnapKit.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SwiftKeychainWrapper/SwiftKeychainWrapper.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Then/Then.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/WeakMapTable/WeakMapTable.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Firebase.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk-rx/RxKakaoOpenSDK.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/nanopb/nanopb.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/promises/Promises.xcodeproj">
+      </FileRef>
    </Group>
 </Workspace>


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 캘린더 피드 셀의 통신 구현(더 많은 테스트가 필요)
- 캘린더 화면에 맞게 피드 셀 UI 수정

## 스크린샷 📷

| 이미지 | 이미지 |
| :-------: | :---: |
|  <img src="https://github.com/depromeet/14th-team5-iOS/assets/21079970/0420f359-74c2-4cfd-b1a5-614ea555f552" align="center" width="235" height="511">  | <img src="https://github.com/depromeet/14th-team5-iOS/assets/21079970/533a2fb6-a4ac-4218-ae2d-17afca9fc9b0" align="center" width="235" height="511"> |

## 기타 ✅

### 코드(PostVC, PostListRepo 등) 변경 사항

* `PostListRepository`를 `PostListRepositoryProtocol`로 이름 수정
* `PostListQuery`의 `sort` 프로퍼티가 `String` 타입이 아닌 `PostListQuery.Sort` 열거형을 받도록 수정(`.asc`, `.desc`)
* `EmojiReactor`의 `State`에 `type`, `memberId` 프로퍼티 추가
* `PostCollectionViewCell`에 타입에 따른 UI 및 제약 분기 구문 추가
* 주간 캘린더 뷰에서 `PostCollecitonViewCell`을 사용할 때, 데이터를 Reactor로 주입하도록 코드 수정
```swift
cell.reactor = EmojiReactor(
    emojiRepository: PostListsDIContainer().makeEmojiUseCase(),
    initialState: .init(
        type: .calendar,
        postId: item.postId,
        memberId: item.author,
        imageUrl: item.imageURL
    )
)
```

`$0.top.equalToSuperview().inset(Layout.PostImageView.topInset - 34)`와 같은 일부 코드는 추후에 리팩토링할게요.

close #131
