### PR TITLE
feat: 위젯 사용자 프로필 이미지 없는경우 닉네임 분기처리

### DIFF
--- a/14th-team5-iOS/App/Project.swift
+++ b/14th-team5-iOS/App/Project.swift
@@ -42,6 +42,7 @@ private let targets: [Target] = [
                     ]),
                 ]),
                 "KAKAO_LOGIN_API_KEY": .string("$(KAKAO_LOGIN_API_KEY)"),
+                "TEAM_ID": .string("$(TEAM_ID)"),
             ]),
             entitlements: .file(path: .relativeToRoot("App.entitlements"))
         )
@@ -55,7 +56,8 @@ private let targets: [Target] = [
             "NSExtension" : .dictionary([
                 "NSExtensionPointIdentifier": .string("com.apple.widgetkit-extension")
             ])
-        ])
+        ]),
+        entitlements: .file(path: .relativeToRoot("WidgetExtension.entitlements"))
     )
 )
 ]

--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/Family.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/Family.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 struct Family: Codable {
-    var profileImageUrl: String?
+    var authorName: String
+    var authorProfileImageUrl: String?
     var postImageUrl: String?
     var postContent: String?
 }

--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyService.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyService.swift
@@ -11,9 +11,8 @@ import Core
 
 struct FamilyService {
     func fetchInfo(completion: @escaping (Result<Family?, Error>) -> Void) {
-//        let token = "eyJyZWdEYXRlIjoxNzA0Njc1NDEwODk4LCJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsInR5cGUiOiJhY2Nlc3MifQ.eyJ1c2VySWQiOiIwMUhKQk5XWkdOUDFLSk5NS1dWWkowMzlIWSIsImV4cCI6MTcwNDc2MTgxMH0.cSf1uH8G-kVZS1dpf4eJwutoAlj2-oK-z05rIaSdtbk"
         
-        let token = App.Repository.token.accessToken.value?.accessToken
+        let token = App.Repository.token.keychain.string(forKey: "accessToken")
         let appKey = "9c61cc7b-0fe9-40eb-976e-6a74c8cb9092"
         let urlString = "https://dev.api.no5ing.kr/v1/widgets/single-recent-family-post"
         

--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyWidgetTimelineProvider.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyWidgetTimelineProvider.swift
@@ -26,7 +26,7 @@ struct FamilyWidgetTimelineProvider: TimelineProvider {
             switch result {
             case .success(let family):
                 entry = FamilyWidgetEntry(date: currentDate, family: family)
-            case .failure(let error):
+            case .failure:
                 entry = FamilyWidgetEntry(date: currentDate, family: nil)
             }
             

--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyWidgetView.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyWidgetView.swift
@@ -57,22 +57,50 @@ struct FamilyWidgetView: View {
     // MARK: 가족중 일부가 사진을 올렸을 때 뷰
     private func getPhotoView(info: Family) -> some View {
         ZStack {
-            NetworkImageView(url: URL(string: info.postImageUrl ?? ""))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            VStack {
-                HStack {
-                    NetworkImageView(url: URL(string: info.profileImageUrl ?? ""))
-                        .frame(height: family == .systemSmall ? 34 : 52)
-                        .frame(width: family == .systemSmall ? 34 : 52)
-                        .clipShape(Circle())
-                        .background(Circle().stroke(Color.white, lineWidth: 4))
-                        .padding(.leading, 14)
-                        .padding(.top, 14)
+            if let postImageUrl = info.postImageUrl {
+                
+                NetworkImageView(url: URL(string: postImageUrl))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                
+                VStack {
+                    
+                    HStack {
+                    
+                        if let profileImageUrl = info.authorProfileImageUrl {
+                            NetworkImageView(url: URL(string: profileImageUrl))
+                                .frame(height: family == .systemSmall ? 34 : 52)
+                                .frame(width: family == .systemSmall ? 34 : 52)
+                                .clipShape(Circle())
+                                .background(Circle().stroke(Color.white, lineWidth: 4))
+                                .padding(.leading, 14)
+                                .padding(.top, 14)
+                            
+                        } else {
+                            
+                            if let firstName = info.authorName.first {
+                                Text(String(firstName))
+                                    .font(family == .systemSmall ?
+                                          DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 16) :
+                                            DesignSystemFontFamily.Pretendard.semiBold.swiftUIFont(size: 18))
+                                    .frame(height: family == .systemSmall ? 34 : 52)
+                                    .frame(width: family == .systemSmall ? 34 : 52)
+                                    .background(Circle().stroke(Color.white, lineWidth: 4))
+                                    .background(DesignSystemAsset.gray700.swiftUIColor)
+                                    .clipShape(Circle())
+                                    .padding(.leading, 14)
+                                    .padding(.top, 14)
+                            }
+                        }
+                        Spacer()
+                    }
+                    
                     Spacer()
+                    
+                    getContentView(for: info.postContent ?? "", family: family)
+                        .padding(.bottom, family == .systemSmall ? 16 : 22)
                 }
-                Spacer()
-                getContentView(for: info.postContent ?? "할 말이 없네", family: family)
-                    .padding(.bottom, family == .systemSmall ? 16 : 22)
+            } else {
+                timeToPhotoView
             }
         }
     }

--- a/14th-team5-iOS/Core/Sources/Token/TokenRepository.swift
+++ b/14th-team5-iOS/Core/Sources/Token/TokenRepository.swift
@@ -55,6 +55,8 @@ public extension String {
 }
 
 public class TokenRepository: RxObject {
+    public lazy var keychain = KeychainWrapper(serviceName: "Bibbi", accessGroup: "P9P4WJ623F.com.5ing.bibbi")
+    
     public let fcmToken = BehaviorRelay<String>(value: KeychainWrapper.standard[.fcmToken] ?? "")
     public let fakeAccessToken = BehaviorRelay<AccessToken?>(value: (KeychainWrapper.standard[.accessToken] as String?)?.decode(AccessToken.self))
     public let accessToken = BehaviorRelay<AccessToken?>(value: (KeychainWrapper.standard[.accessToken] as String?)?.decode(AccessToken.self))
@@ -104,6 +106,14 @@ public class TokenRepository: RxObject {
                     KeychainWrapper.standard.remove(forKey: .accessToken)
                     return
                 }
+                
+                if let jsonData = jsonStr.data(using: .utf8),
+                   let decodedUser = try? JSONDecoder().decode(AccessToken.self, from: jsonData) {
+                    self.keychain.set(decodedUser.accessToken ?? "fail", forKey: "accessToken")
+                } else {
+                    print("Failed to decode jsonStr or jsonStr is nil")
+                }
+                
                 KeychainWrapper.standard[.accessToken] = jsonStr
             }
             .disposed(by: disposeBag)

--- a/Bibbi.xcworkspace/contents.xcworkspacedata
+++ b/Bibbi.xcworkspace/contents.xcworkspacedata
@@ -21,64 +21,80 @@
       </FileRef>
    </Group>
    <Group
-      location = "container:"
-      name = "Dependencies">
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Alamofire/Alamofire.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/FSCalendar/FSCalendar.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleDataTransport/GoogleDataTransport.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/GoogleUtilities/GoogleUtilities.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Kingfisher/Kingfisher.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/ReactorKit/ReactorKit.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxAlamofire/RxAlamofire.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxDataSources/RxDataSources.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/RxSwift/RxSwift.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SnapKit/SnapKit.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/SwiftKeychainWrapper/SwiftKeychainWrapper.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/Then/Then.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/WeakMapTable/WeakMapTable.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/firebase-ios-sdk/Firebase.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk-rx/RxKakaoOpenSDK.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/nanopb/nanopb.xcodeproj">
-      </FileRef>
-      <FileRef
-         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/promises/Promises.xcodeproj">
-      </FileRef>
+      location = "group:Tuist"
+      name = "Tuist">
+      <Group
+         location = "group:Dependencies"
+         name = "Dependencies">
+         <Group
+            location = "group:SwiftPackageManager"
+            name = "SwiftPackageManager">
+            <Group
+               location = "group:.build"
+               name = ".build">
+               <Group
+                  location = "group:checkouts"
+                  name = "checkouts">
+                  <FileRef
+                     location = "group:Alamofire/Alamofire.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:FSCalendar/FSCalendar.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GoogleAppMeasurement/GoogleAppMeasurement.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GoogleDataTransport/GoogleDataTransport.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:GoogleUtilities/GoogleUtilities.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Kingfisher/Kingfisher.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:ReactorKit/ReactorKit.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RxAlamofire/RxAlamofire.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RxDataSources/RxDataSources.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:RxSwift/RxSwift.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SnapKit/SnapKit.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:SwiftKeychainWrapper/SwiftKeychainWrapper.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:Then/Then.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:WeakMapTable/WeakMapTable.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:firebase-ios-sdk/Firebase.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:kakao-ios-sdk-rx/RxKakaoOpenSDK.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:nanopb/nanopb.xcodeproj">
+                  </FileRef>
+                  <FileRef
+                     location = "group:promises/Promises.xcodeproj">
+                  </FileRef>
+               </Group>
+            </Group>
+         </Group>
+      </Group>
    </Group>
 </Workspace>

--- a/Tuist/ProjectDescriptionHelpers/Modular+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modular+Templates.swift
@@ -63,6 +63,7 @@ extension Target {
                 infoPlist: factory.infoPlist,
                 sources: factory.products.isExtensions ? .widgetExtensionSources : .default,
                 resources: factory.products.isExtensions ? .widgetExtensionResources : .default,
+                entitlements: factory.entitlements, 
                 dependencies: factory.dependencies,
                 settings: factory.settings
             )

--- a/WidgetExtension.entitlements
+++ b/WidgetExtension.entitlements
@@ -2,16 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>development</string>
-	<key>com.apple.developer.applesignin</key>
-	<array>
-		<string>Default</string>
-	</array>
-	<key>com.apple.developer.associated-domains</key>
-	<array>
-		<string>applinks:no5ing.kr/o/</string>
-	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.5ing.bibbi</string>


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 위젯과 앱 사이에 KeyChain Sharing 추가
- Widget용 entitlement 추가 
- 위젯 기본 프로필 미 적용시 디자인 수정 

## 변경 로직 ⚒️
- KeyChainShare 추가 

## 스크린샷 📷
![image](https://github.com/depromeet/14th-team5-iOS/assets/96224311/81b3549d-4e52-4096-afb9-c24d1ba7e9f3)

## 테스트 케이스 ✅

- [ ] 기본 위젯 표출여부 
- [ ] 이미지 올렸을 때, 사진 정상 출력 
- [ ] 프로필 사진 없을때 프로필 이미지 정상 출력

clsoe #222