### PR TITLE
hotfix: 가족이 제대로 생성되지 못하는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -50,6 +50,12 @@ public final class HomeViewController: BaseViewController<HomeViewReactor> {
         postCollectionView.rx.setDelegate(self)
             .disposed(by: disposeBag)
         
+        Observable<Void>.just(())
+            .take(1)
+            .map { Reactor.Action.viewDidLoad }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         Observable.concat (
             Observable.just(()).map { Reactor.Action.getFamilyMembers },
             Observable.just(()).map { Reactor.Action.getTodayPostList }

--- a/14th-team5-iOS/Core/Sources/Member/MemberRepository.swift
+++ b/14th-team5-iOS/Core/Sources/Member/MemberRepository.swift
@@ -23,7 +23,7 @@ public class MemberRepository: RxObject {
         
         familyId
             .withUnretained(self)
-            .bind(onNext: { $0.0.saveMemberId(with: $0.1) })
+            .bind(onNext: { $0.0.saveFamilyId(with: $0.1) })
             .disposed(by: disposeBag)
         
         inviteCode

--- a/14th-team5-iOS/Data/Sources/Family/FamilyAPI/DataMapping/FamilyResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Family/FamilyAPI/DataMapping/FamilyResponseDTO.swift
@@ -1,0 +1,29 @@
+//
+//  FamilyResponse.swift
+//  Data
+//
+//  Created by 김건우 on 1/10/24.
+//
+
+import Foundation
+
+import Domain
+
+// MARK: - Data Transfer Object (DTO)
+struct FamilyResponseDTO: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case familyId
+        case createdAt
+    }
+    var familyId: String
+    var createdAt: String
+}
+
+extension FamilyResponseDTO {
+    func toDomain() -> FamilyResponse {
+        return .init(
+            familyId: familyId,
+            createdAt: createdAt.iso8601ToDate()
+        )
+    }
+}

--- a/14th-team5-iOS/Data/Sources/Family/FamilyAPI/FamilyAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Family/FamilyAPI/FamilyAPIWorker.swift
@@ -67,6 +67,27 @@ extension FamilyAPIWorker: SearchFamilyRepository {
             .asSingle()
     }
     
+    private func createFamily(spec: APISpec, headers: [BibbiHeader]) -> Single<FamilyResponse?> {
+        return request(spec: spec, headers: headers)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("Family Create Result: \(str)")
+                }
+            }
+            .map(FamilyResponseDTO.self)
+            .catchAndReturn(nil)
+            .map { $0?.toDomain() }
+            .asSingle()
+    }
+    
+    public func createFamily(token accessToken: String) -> Single<FamilyResponse?> {
+        let spec: APISpec = FamilyAPIs.createFamily.spec
+        let headers: [BibbiHeader] = [.acceptJson, .xAppKey, .xAuthToken(accessToken)]
+        
+        return createFamily(spec: spec, headers: headers)
+    }
+    
     private func fetchInvitationUrl(spec: APISpec, headers: [BibbiHeader]) -> Single<FamilyInvitationLinkResponse?> {
         return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)

--- a/14th-team5-iOS/Data/Sources/Family/FamilyAPI/FamilyAPIs.swift
+++ b/14th-team5-iOS/Data/Sources/Family/FamilyAPI/FamilyAPIs.swift
@@ -10,11 +10,14 @@ import Foundation
 import Core
 
 public enum FamilyAPIs: API {
+    case createFamily
     case invitationUrl(String)
     case familyMembers(FamilySearchRequestDTO)
     
     var spec: APISpec {
         switch self {
+        case let .createFamily:
+            return APISpec(method: .post, url: "\(BibbiAPI.hostApi)/me/create-family")
         case let .invitationUrl(familyId):
             return APISpec(method: .post, url: "\(BibbiAPI.hostApi)/links/family/\(familyId)")
         case let .familyMembers(query):

--- a/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
@@ -16,14 +16,21 @@ public final class FamilyRepository: FamilyRepositoryProtocol {
     
     private let familyApiWorker: FamilyAPIWorker = FamilyAPIWorker()
     
-    private let familyId: String = App.Repository.member.familyId.value ?? ""
-    private let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
+    private let familyId: String = App.Repository.member.familyId.value ?? "(가족ID 없음)"
+    private let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? "(토큰 없음)"
     
     public init() { }
 }
 
 extension FamilyRepository {
+    public func createFamily() -> Observable<FamilyResponse?> {
+        return familyApiWorker.createFamily(token: accessToken)
+            .asObservable()
+    }
+    
     public func fetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?> {
+        debugPrint("= familyId: \(familyId)")
+        debugPrint("= accessToken: \(accessToken)")
         return familyApiWorker.fetchInvitationUrl(token: accessToken, familyId: familyId)
             .asObservable()
     }

--- a/14th-team5-iOS/Domain/Sources/Family/InviteFamily/Entities/FamilyResponse.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/InviteFamily/Entities/FamilyResponse.swift
@@ -1,0 +1,18 @@
+//
+//  FamilyResponse.swift
+//  Domain
+//
+//  Created by 김건우 on 1/10/24.
+//
+
+import Foundation
+
+public struct FamilyResponse {
+    public var familyId: String
+    public var createdAt: Date
+    
+    public init(familyId: String, createdAt: Date) {
+        self.familyId = familyId
+        self.createdAt = createdAt
+    }
+}

--- a/14th-team5-iOS/Domain/Sources/Family/InviteFamily/Interfaces/Repositories/FamilyRepository.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/InviteFamily/Interfaces/Repositories/FamilyRepository.swift
@@ -12,6 +12,7 @@ import RxSwift
 public protocol FamilyRepositoryProtocol {
     var disposeBag: DisposeBag { get }
     
+    func createFamily() -> Observable<FamilyResponse?>
     func fetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?>
     func fetchFamilyMembers() -> Observable<PaginationResponseFamilyMemberProfile?>
 }

--- a/14th-team5-iOS/Domain/Sources/Family/InviteFamily/UseCases/InviteFamilyViewUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/InviteFamily/UseCases/InviteFamilyViewUseCase.swift
@@ -10,6 +10,7 @@ import Foundation
 import RxSwift
 
 public protocol InviteFamilyViewUseCaseProtocol {
+    func executeCreateFamily() -> Observable<FamilyResponse?>
     func executeFetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?>
     func executeFetchFamilyMembers() -> Observable<PaginationResponseFamilyMemberProfile?>
 }
@@ -19,6 +20,10 @@ public final class InviteFamilyViewUseCase: InviteFamilyViewUseCaseProtocol {
     
     public init(familyRepository: FamilyRepositoryProtocol) {
         self.familyRepository = familyRepository
+    }
+    
+    public func executeCreateFamily() -> Observable<FamilyResponse?> {
+        return familyRepository.createFamily()
     }
     
     public func executeFetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?> {


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 홈 화면에서 가족 구성원이 없으면 가족 초대 화면이 뜨지 않는 문제 수정
- 홈 화면 및 친구 초대 화면에서 초대 링크가 제대로 생성되지 못하는 문제 수정
- 친구 초대 화면에서 가족 구성원이 뜨지 않는 문제 수정

## 변경 로직 ⚒️

- 홈 화면에 최초 진입하면 `FamilyID`의 존재 여부를 체크 후, 없으면 생성하는 로직 추가


