### PR TITLE
fix: 회원가입 qa 검출사항 목록 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
@@ -122,10 +122,7 @@ public final class AccountSignInViewController: BaseViewController<AccountSignIn
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        reactor.state.map { $0.pushAccountSingUpVC }
-            .distinctUntilChanged()
-            .filter { $0 }
-            .withLatestFrom(App.Repository.token.accessToken)
+        App.Repository.token.accessToken
             .observe(on: Schedulers.main)
             .withUnretained(self)
             .bind(onNext: { $0.0.showNextPage(token: $0.1) })
@@ -135,12 +132,15 @@ public final class AccountSignInViewController: BaseViewController<AccountSignIn
 
 extension AccountSignInViewController {
     private func showNextPage(token: AccessToken?) {
-        if let _ = token {
-            let container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+        
+        guard let token = token, let isTemporaryToken = token.isTemporaryToken else { return }
+        
+        if isTemporaryToken {
+            let container = UINavigationController(rootViewController: AccountSignUpDIContainer().makeViewController())
             container.modalPresentationStyle = .fullScreen
             present(container, animated: false)
         } else {
-            let container = UINavigationController(rootViewController: AccountSignUpDIContainer().makeViewController())
+            let container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
             container.modalPresentationStyle = .fullScreen
             present(container, animated: false)
         }

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/Reactor/AccountSignUpReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/Reactor/AccountSignUpReactor.swift
@@ -25,9 +25,9 @@ public final class AccountSignUpReactor: Reactor {
         case didTapNicknameNextButton
         case didTapNickNameButton(String)
         
-        case setYear(Int)
-        case setMonth(Int)
-        case setDay(Int)
+        case setYear(Int?)
+        case setMonth(Int?)
+        case setDay(Int?)
         case didTapDateNextButton
         
         case profileImageTapped // Action Sheet출력 하는 이벤트
@@ -39,9 +39,9 @@ public final class AccountSignUpReactor: Reactor {
         case setNickname(String)
         case didTapNicknameNextButton
         
-        case setYearValue(Int)
-        case setMonthValue(Int)
-        case setDayValue(Int)
+        case setYearValue(Int?)
+        case setMonthValue(Int?)
+        case setDayValue(Int?)
         case didTapDateNextButton
         case setEditNickName(AccountNickNameEditResponse?)
         
@@ -134,18 +134,32 @@ extension AccountSignUpReactor {
         case .setNickname(let nickname):
             newState.nickname = nickname
             newState.isValidNickname = nickname.count <= 10
-            newState.isValidNicknameButton = nickname.count > 2
+            newState.isValidNicknameButton = nickname.count >= 1
         case .didTapNicknameNextButton:
             newState.nicknameButtonTappedFinish = true
         case .setYearValue(let year):
-            newState.year = year
-            newState.isValidYear = year < 2023
+            
+            if let year = year {
+                newState.year = year
+                newState.isValidYear = year < 2023
+            } else {
+                newState.isValidDay = false
+            }
+           
         case .setMonthValue(let month):
-            newState.month = month
-            newState.isValidMonth = month < 13
+            if let month = month {
+                newState.month = month
+                newState.isValidMonth = month < 13
+            } else {
+                newState.isValidMonth = false
+            }
         case .setDayValue(let day):
-            newState.day = day
-            newState.isValidDay = day < 31
+            if let day = day {
+                newState.day = day
+                newState.isValidDay = day < 31
+            } else {
+                newState.isValidDay = false
+            }
         case .didTapDateNextButton:
             newState.dateButtonTappedFinish = true
         case .setprofilePresignedURL(let url):
@@ -154,13 +168,6 @@ extension AccountSignUpReactor {
             newState.profileImageButtontapped = true
         case .didTapCompletehButton(let token):
             if let token = token {
-                
-//                let accessToken = token.accessToken
-//                let refreshToken = token.refreshToken
-//                let isTemporaryToken = token.isTemporaryToken
-//                
-//                let tk = AccessToken(accessToken: accessToken, refreshToken: refreshToken, isTemporaryToken: isTemporaryToken)
-//                App.Repository.token.accessToken.accept(tk)
                 newState.didTapCompletehButtonFinish = token
             }
         case let .setEditNickName(entity):

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountDateViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountDateViewController.swift
@@ -57,7 +57,7 @@ final class AccountDateViewController: BaseViewController<AccountSignUpReactor> 
             .text.orEmpty
             .distinctUntilChanged()
             .filter { $0.count <= 4 }
-            .compactMap { Int($0) }
+            .map { Int($0) }
         
         yearEditingChange
             .map { Reactor.Action.setYear($0) }
@@ -75,25 +75,22 @@ final class AccountDateViewController: BaseViewController<AccountSignUpReactor> 
         let monthEditingChange = monthInputFieldView.rx
             .text.orEmpty
             .distinctUntilChanged()
-            .filter { $0.count <= 2 }
-            .compactMap { Int($0) }
         
         monthEditingChange
+            .map { Int($0) }
             .map { Reactor.Action.setMonth($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
         monthEditingChange
-            .withUnretained(self)
-            .map { $0.0.moveToNextDayField($0.1) }
-            .filter { $0 }
+            .filter { $0.count >= 2 }
             .withUnretained(self)
             .bind(onNext: { $0.0.dayInputFieldView.becomeFirstResponder() })
             .disposed(by: disposeBag)
         
-        dayInputFieldView.rx.text
+        dayInputFieldView.rx.text.orEmpty
             .distinctUntilChanged()
-            .compactMap { $0.flatMap { Int($0) } }
+            .map { Int($0) }
             .map { Reactor.Action.setDay($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -347,11 +344,10 @@ fileprivate extension AccountDateViewController {
 }
 
 fileprivate extension AccountDateViewController {
-    private func moveToNextMonthField(_ value: Int) -> Bool {
-        value >= 1000 ? true : false
-    }
-    
-    private func moveToNextDayField(_ value: Int) -> Bool {
-        value >= 10 ? true : false
+    private func moveToNextMonthField(_ value: Int?) -> Bool {
+        guard let value = value else {
+            return false
+        }
+        return value >= 1900 ? true : false
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -31,7 +31,7 @@ public final class HomeViewController: BaseViewController<HomeViewReactor> {
     
     public override func viewDidLoad() {
         super.viewDidLoad()
-        print("AccessTokne 내놔 : \(App.Repository.token.accessToken.value?.accessToken) or refreshToken : \(App.Repository.token.accessToken.value?.refreshToken)")
+        
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingReactor.swift
@@ -12,7 +12,6 @@ import Data
 
 import ReactorKit
 
-
 public final class OnBoardingReactor: Reactor {
     
     public var initialState: State
@@ -58,7 +57,7 @@ extension OnBoardingReactor {
         var newState = state
         switch mutation {
         case .setPermissionStatus(let isPermissionGranted):
-            newState.isPermissionGranted = true
+            newState.isPermissionGranted = isPermissionGranted
         }
         return newState
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
@@ -110,15 +110,11 @@ public final class SplashViewController: BaseViewController<SplashViewReactor> {
         
         let container: UINavigationController
         
-        guard let isTemporaryToken = App.Repository.token.accessToken.value?.isTemporaryToken else {
+        if App.Repository.token.accessToken.value?.isTemporaryToken == true {
             container = UINavigationController(rootViewController: AccountSignInDIContainer().makeViewController())
             sceneDelegate.window?.rootViewController = container
             sceneDelegate.window?.makeKeyAndVisible()
             return
-        }
-        
-        if isTemporaryToken {
-            container = UINavigationController(rootViewController: AccountSignUpDIContainer().makeViewController())
         } else {
             if UserDefaults.standard.finishTutorial {
                 container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())

--- a/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
@@ -99,19 +99,29 @@ public final class SplashViewController: BaseViewController<SplashViewReactor> {
     private func showNextPage(with member: MemberInfo?) {
         
         guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+        let container: UINavigationController
         
         if let _ = member?.memberId {
             var container: UINavigationController
-            container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+            if UserDefaults.standard.finishTutorial {
+                container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+            } else {
+                container = UINavigationController(rootViewController: OnBoardingDIContainer().makeViewController())
+            }
             sceneDelegate.window?.rootViewController = container
             sceneDelegate.window?.makeKeyAndVisible()
             return
         }
         
-        let container: UINavigationController
-        
-        if App.Repository.token.accessToken.value?.isTemporaryToken == true {
+        guard let isTemporary = App.Repository.token.accessToken.value?.isTemporaryToken else {
             container = UINavigationController(rootViewController: AccountSignInDIContainer().makeViewController())
+            sceneDelegate.window?.rootViewController = container
+            sceneDelegate.window?.makeKeyAndVisible()
+            return
+        }
+        
+        if isTemporary {
+            container = UINavigationController(rootViewController: AccountSignUpDIContainer().makeViewController())
             sceneDelegate.window?.rootViewController = container
             sceneDelegate.window?.makeKeyAndVisible()
             return

--- a/14th-team5-iOS/Data/Sources/API/APIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/API/APIWorker.swift
@@ -52,13 +52,12 @@ public final class BibbiRequestInterceptor: RequestInterceptor, BibbiRouterInter
             completion(.success(urlRequest))
             return
         }
-        guard let accessToken = App.Repository.token.accessToken.value?.accessToken,
-              let fakeToken = App.Repository.token.fakeAccessToken.value?.accessToken else {
+        guard let accessToken = App.Repository.token.accessToken.value?.accessToken else {
             completion(.success(urlRequest))
             return
         }
     
-        urlRequest.setValue(accessToken.isEmpty ? fakeToken : accessToken , forHTTPHeaderField: "X-AUTH-TOKEN")
+        urlRequest.setValue(accessToken, forHTTPHeaderField: "X-AUTH-TOKEN")
         completion(.success(urlRequest))
     }
     

--- a/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIWorker.swift
@@ -29,7 +29,7 @@ extension AccountAPIs {
         
         // MARK: Values
         private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.fakeAccessToken
+            return App.Repository.token.accessToken
                 .map {
                     guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
                     return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]

--- a/14th-team5-iOS/Data/Sources/Camera/Repositories/CameraViewRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Camera/Repositories/CameraViewRepository.swift
@@ -50,7 +50,7 @@ extension CameraViewRepository: CameraViewInterface {
     
     public func fetchProfileImageURL(parameters: CameraDisplayImageParameters, type: UploadLocation) -> Observable<CameraDisplayImageResponse?> {
         
-        let accessToken = App.Repository.token.accessToken.value?.accessToken?.isEmpty ?? true ? App.Repository.token.fakeAccessToken.value?.accessToken ?? "" : App.Repository.token.accessToken.value?.accessToken ?? ""
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         return cameraAPIWorker.createPresignedURL(accessToken: accessToken, parameters: parameters, type: type)
             .compactMap { $0?.toDomain() }
             .asObservable()

--- a/14th-team5-iOS/Data/Sources/Service/AccountSignInHelper.swift
+++ b/14th-team5-iOS/Data/Sources/Service/AccountSignInHelper.swift
@@ -82,12 +82,7 @@ extension AccountSignInHelper {
                 guard let token = token else {
                     return .failed
                 }
-                
-                if token.isTemporaryToken == false {
-                    App.Repository.token.accessToken.accept(token)
-                } else {
-                    App.Repository.token.fakeAccessToken.accept(token)
-                }
+                App.Repository.token.accessToken.accept(token)
                 
                 return .success
             }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 닉네임 1 ~ 9글자 적용 
- monthInputField 2글자 입력시 dayInput으로 이동 
- AccessToken내부에 isTemporaryToken 으로 분기 처리 변경 
- 온보딩 화면에서 앱 종료 이후 재 진입시 온보딩 화면으로 이동 
- SNS 로그인 이후, 뒤로가기시 회원가입 flow 진입 방지 
- 앱 회원가입 이후, 재설치 사용자 바로 홈화면으로 진입 

## 변경 로직 ⚒️

- fakeAccessToken 제거 및 isTemporaryToken으로 분기처리 변경 

## 테스트 케이스 ✅

- [ ] 닉네임 필드 1 ~ 9글자 valid 체크 
- [ ] 회원가입, 로그인 이후 AccessToken으로 잘 정리 되는지 
- [ ] 온보딩 종료 -> 재 진입 시 온보딩 화면 
- [ ] 회원가입 날짜 필드 월 기입시, 일 필드로 잘 이동하는지 
- [ ] 회원가입 취소 이후, 화면 전환 이동 방지 

close #235 
