### PR TITLE
fix: 회원 가입시 프로필 이미지 업로드 로직 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountProfileViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountProfileViewController.swift
@@ -51,11 +51,15 @@ final class AccountProfileViewController: BaseViewController<AccountSignUpReacto
         
         NotificationCenter.default.rx
             .notification(.AccountViewPresignURLDismissNotification)
-            .compactMap { notification -> String? in
-                guard let userInfo = notification.userInfo else { return nil }
-                return userInfo["presignedURL"] as? String
+            .compactMap { notification -> (String, Data)? in
+                guard let userInfo = notification.userInfo,
+                      let presignedURL = userInfo["presignedURL"] as? String,
+                      let originImage = userInfo["originImage"] as? Data else { return nil
+                }
+                
+                return (presignedURL, originImage)
             }
-            .map { Reactor.Action.profilePresignedURL($0)}
+            .map { Reactor.Action.profilePresignedURL($0.0, $0.1)}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
@@ -65,6 +69,12 @@ final class AccountProfileViewController: BaseViewController<AccountSignUpReacto
             .withUnretained(self)
             .observe(on: Schedulers.main)
             .bind(onNext: { $0.0.setProfilewView(with: $0.1) })
+            .disposed(by: disposeBag)
+        
+        reactor.state.compactMap { $0.profileImage }
+            .map { UIImage(data: $0) }
+            .debug("ProfileView Account Bind")
+            .bind(to: profileView.rx.image)
             .disposed(by: disposeBag)
         
 //        reactor.state.map { $0.didTapCompletehButtonFinish }

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountSignUpViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountSignUpViewController.swift
@@ -106,7 +106,7 @@ extension AccountSignUpViewController {
     private func createAlertController(owner: AccountSignUpViewController) {
         let alertController: UIAlertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         let presentCameraAction: UIAlertAction = UIAlertAction(title: "카메라", style: .default) { _ in
-            let cameraViewController = CameraDIContainer(cameraType: .account).makeViewController()
+            let cameraViewController = CameraDIContainer(cameraType: .profile).makeViewController()
             owner.navigationController?.pushViewController(cameraViewController, animated: true)
         }
         let presentAlbumAction: UIAlertAction = UIAlertAction(title: "앨범", style: .default) { _ in

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountSignUpViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountSignUpViewController.swift
@@ -57,6 +57,17 @@ public final class AccountSignUpViewController: BasePageViewController<AccountSi
             .withUnretained(self)
             .bind(onNext: { $0.0.createAlertController(owner: $0.0) })
             .disposed(by: disposeBag)
+        
+        NotificationCenter.default.rx
+            .notification(.PHPickerAssetsDidFinishPickingProcessingPhotoNotification)
+            .compactMap { notification -> Data? in
+                guard let userInfo = notification.userInfo else { return nil }
+                return userInfo["selectImage"] as? Data
+            }
+            .map{ Reactor.Action.didTapPHAssetsImage($0)}
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
     }
     
     public override func setupUI() {

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/CameraViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/CameraViewController.swift
@@ -163,19 +163,16 @@ public final class CameraViewController: BaseViewController<CameraViewReactor> {
             .disposed(by: disposeBag)
         
         
-        Observable
-            .zip(
-                reactor.pulse(\.$profileMemberEntity),
-                reactor.state.map { $0.memberId }.distinctUntilChanged()
-            ).filter { $0.1.isEmpty }
-            .compactMap { $0.0 }
-            .compactMap { (try Data(contentsOf: $0.memberImage), $0.memberImage.absoluteString) }
+        reactor.state
+            .map { ($0.accountImage, $0.profileImageURLEntity)}
+            .filter { $0.1 != nil }
             .withUnretained(self)
-            .subscribe { (owner, originEntity) in
-                let userInfo: [AnyHashable: Any] = ["presignedURL": originEntity.1, "originImage": originEntity.0]
+            .subscribe(onNext: { (owner, originEntity) in
+                let userInfo: [AnyHashable: Any] = ["presignedURL": originEntity.1?.imageURL, "originImage": originEntity.0]
                 NotificationCenter.default.post(name: .AccountViewPresignURLDismissNotification, object: nil, userInfo: userInfo)
                 owner.dismissCameraViewController()
-            }.disposed(by: disposeBag)
+            }).disposed(by: disposeBag)
+            
         
         shutterButton
             .rx.tap

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
@@ -88,14 +88,7 @@ public final class CameraViewReactor: Reactor {
                     .flatMap { owner, entity -> Observable<CameraViewReactor.Mutation> in
                         // presignedURL에 image Upload 이것도 역시 병렬 큐 사용
                         guard let presingedURL = entity?.imageURL else { return .empty() }
-                        
-                        if self.currentState.cameraType == .account {
-                            return .concat(
-                                .just(.setProfileImageURLResponse(entity)),
-                                .just(.setLoading(false))
-                            )
-                        }
-                        
+                                                
                         return owner.cameraUseCase.executeProfileUploadToS3(toURL: presingedURL, imageData: fileData)
                             .subscribe(on: ConcurrentDispatchQueueScheduler.init(qos: .background))
                             .asObservable()

--- a/14th-team5-iOS/Data/Sources/Account/AccountRepository/AccountRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Account/AccountRepository/AccountRepository.swift
@@ -26,6 +26,8 @@ public protocol AccountImpl: AnyObject {
     func appleLogin(with snsType: SNS, vc: UIViewController) -> Observable<APIResult>
     func executeNicknameUpdate(memberId: String, parameter: AccountNickNameEditParameter) -> Observable<AccountNickNameEditResponse>
     func signUp(name: String, date: String, photoURL: String?) -> Observable<AccessTokenResponse?>
+    func executePresignedImageURLCreate(parameter: CameraDisplayImageParameters) -> Observable<CameraDisplayImageResponse?>
+    func executeProfileImageUpload(to url: String, data: Data) -> Observable<Bool>
 }
 
 public final class AccountRepository: AccountImpl {
@@ -35,6 +37,7 @@ public final class AccountRepository: AccountImpl {
     
     let signInHelper = AccountSignInHelper()
     private let apiWorker = AccountAPIWorker()
+    private let profileWorker = ProfileAPIWorker()
     private let meApiWorekr = MeAPIWorker()
     
     private let signInResult = PublishRelay<APIResult>()
@@ -119,6 +122,18 @@ public final class AccountRepository: AccountImpl {
             .compactMap { $0?.toDomain() }
             .asObservable()
     }
+    
+    public func executePresignedImageURLCreate(parameter: CameraDisplayImageParameters) -> Observable<CameraDisplayImageResponse?> {
+        return profileWorker.createProfileImagePresingedURL(accessToken: accessToken, parameters: parameter)
+            .compactMap { $0?.toDomain() }
+            .asObservable()
+    }
+    
+    public func executeProfileImageUpload(to url: String, data: Data) -> Observable<Bool> {
+        return profileWorker.uploadToProfilePresingedURL(accessToken: accessToken, toURL: url, with: data)
+            .asObservable()
+    }
+    
     
     public init() {
         signInHelper.bind()

--- a/14th-team5-iOS/Domain/Sources/Camera/Interfaces/CameraDisplayViewInterface.swift
+++ b/14th-team5-iOS/Domain/Sources/Camera/Interfaces/CameraDisplayViewInterface.swift
@@ -13,7 +13,6 @@ import RxSwift
 public enum UploadLocation {
     case feed
     case profile
-    case account
     
     public var location: String {
         switch self {
@@ -21,8 +20,6 @@ public enum UploadLocation {
             return "images/feed/"
         case .profile:
             return "images/profile/"
-        case .account:
-            return ""
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- AccountSignUpReactor didTapPHAssetsImage 추가하였습니다.
- AccountRepository Presigned API 통신 코드 or 이미지 업로드 코드 추가하였습니다.
- CameraViewReactor member ID Empty일 경우 분기 처리 구문 추가하였습니다.

## 변경 로직 ⚒️

- CameraViewReactor memberID 에따라 분기 처리 구문 로직이 추가 되었습니다.
- AccountRepository에 Presigned URL API 통신 코드  및 이미지 업로드 코드를 추가하였습니다.


## 테스트 케이스 ✅

- [ ] CameraViewController에 영향이 없는지(예) 피드 게시물, 프로필. 편집)



