### PR TITLE
fix: 온보딩 이후 권한여부 묻기 및 다음으로 이동 정상작동

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/AppDelegate.swift
+++ b/14th-team5-iOS/App/Sources/Application/AppDelegate.swift
@@ -64,12 +64,6 @@ extension AppDelegate {
         Messaging.messaging().isAutoInitEnabled = true
         UNUserNotificationCenter.current().delegate = self
         
-        let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: authOptions,
-            completionHandler: { _,_ in }
-        )
-        
         application.registerForRemoteNotifications()
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingReactor.swift
@@ -22,11 +22,11 @@ public final class OnBoardingReactor: Reactor {
     }
     
     public enum Mutation {
-        case setPermissionStatus(Bool)
+        case permissionTapped
     }
     
     public struct State {
-        var isPermissionGranted: Bool = false
+        var permissionTappedFinish: Bool = false
     }
     
     init(accountRepository: AccountRepository) {
@@ -40,14 +40,13 @@ extension OnBoardingReactor {
         switch action {
         case .permissionTapped:
             return Observable.create { observer in
-                UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) {
-                    if let error = $1 {
-                        observer.onError(error)
-                    } else {
-                        observer.onNext(.setPermissionStatus($0))
+                UNUserNotificationCenter.current().requestAuthorization(
+                    options: [.alert, .badge, .sound],
+                    completionHandler: { granted, error in
+                        observer.onNext(Mutation.permissionTapped)
                         observer.onCompleted()
                     }
-                }
+                )
                 return Disposables.create()
             }
         }
@@ -56,8 +55,8 @@ extension OnBoardingReactor {
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-        case .setPermissionStatus(let isPermissionGranted):
-            newState.isPermissionGranted = isPermissionGranted
+        case .permissionTapped:
+            newState.permissionTappedFinish = true
         }
         return newState
     }

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
@@ -121,7 +121,7 @@ final public class OnBoardingViewController: BaseViewController<OnBoardingReacto
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        reactor.state.map { $0.isPermissionGranted }
+        reactor.state.map { $0.permissionTappedFinish }
             .distinctUntilChanged()
             .observe(on: Schedulers.main)
             .withUnretained(self)


### PR DESCRIPTION
## 작업 내용 🧑‍💻
- 온보딩 이후 권한 팝업 위치 이동 
- 온보딩 이후 권한 미설정 하여도 다음으로 버튼 동작 

## 변경 로직 ⚒️
- AppDelegate 에서 호출하던 권한 요청 위치 이동 

## 스크린샷 📷

| 기능 | 스크린 샷 |
| :--: | :-------: |
| GIF  |           |

## 테스트 케이스 ✅

- [ ] 온보딩 이후 권한 요청을 하는 지 
- [ ] 온보딩 이후 권한 거절하여도 다음으로 동작하는지 

close #246 
