### PR TITLE
fix: .gitignore에 제거된 hidden.xcconfig 파일 복구

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ fastlane/test_output
 
 iOSInjectionProject/
 
-14th-team5-iOS/XCConfig/hidden.xcconfig
 
 ### Xcode Patch ###
 *.xcodeproj/*

--- a/14th-team5-iOS/XCConfig/hidden.xcconfig
+++ b/14th-team5-iOS/XCConfig/hidden.xcconfig
@@ -1,0 +1,5 @@
+OTHER_SWIFT_FLAGS[config=DEV][sdk=*] = $(inherited) -DDEV
+OTHER_SWIFT_FLAGS[config=PRD][sdk=*] = $(inherited) -DPRD
+
+KAKAO_API_KEY = kakaoef9633acbec7061b1f9e424206f4e4b8
+KAKAO_LOGIN_API_KEY = ef9633acbec7061b1f9e424206f4e4b8


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- .gitignore에 hidden.xcconfig 파일을 복구 했습니다.



