### PR TITLE
fix: 가족 초대 링크 터치 영역 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/CalendarDIConatainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/CalendarDIConatainer.swift
@@ -11,7 +11,7 @@ import Core
 import Data
 import Domain
 
-public final class CalendarDIConatainer: BaseDIContainer {
+public final class CalendarDIConatainer {
     public typealias ViewController = CalendarViewController
     public typealias UseCase = CalendarUseCaseProtocol
     public typealias Repository = CalendarRepositoryProtocol
@@ -28,15 +28,28 @@ public final class CalendarDIConatainer: BaseDIContainer {
         return CalendarViewController(reactor: makeReactor())
     }
     
-    public func makeUseCase() -> UseCase {
-        return CalendarUseCase(calendarRepository: makeRepository())
+    public func makeFamilyUseCase() -> SearchFamilyUseCase {
+        return SearchFamilyUseCase(searchFamilyRepository: makeFamilyRepository())
     }
     
-    public func makeRepository() -> Repository {
+    public func makeCalendarUseCase() -> UseCase {
+        return CalendarUseCase(calendarRepository: makeCalendarRepository())
+    }
+    
+    public func makeCalendarRepository() -> Repository {
         return CalendarRepository()
     }
     
+    public func makeFamilyRepository() -> SearchFamilyRepository {
+        return FamilyAPIs.Worker()
+    }
+    
+    
     public func makeReactor() -> Reactor {
-        return CalendarViewReactor(usecase: makeUseCase(), provider: globalState)
+        return CalendarViewReactor(
+            familyUseCase: makeFamilyUseCase(),
+            calendarUseCase: makeCalendarUseCase(),
+            provider: globalState
+        )
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarViewReactor.swift
@@ -16,6 +16,7 @@ import RxSwift
 public final class CalendarViewReactor: Reactor {
     // MARK: - Action
     public enum Action {
+        case fetchFamilyMembers
         case addYearMonthItem(String)
         case popViewController
     }
@@ -40,13 +41,15 @@ public final class CalendarViewReactor: Reactor {
     public var initialState: State
     
     public let provider: GlobalStateProviderProtocol
+    private let familyUseCase: SearchFamilyMemberUseCaseProtocol
     private let calendarUseCase: CalendarUseCaseProtocol
     
     // MARK: - Intializer
-    init(usecase: CalendarUseCaseProtocol, provider: GlobalStateProviderProtocol) {
+    init(familyUseCase: SearchFamilyUseCase, calendarUseCase: CalendarUseCaseProtocol, provider: GlobalStateProviderProtocol) {
         self.initialState = State()
         
-        self.calendarUseCase = usecase
+        self.familyUseCase = familyUseCase
+        self.calendarUseCase = calendarUseCase
         self.provider = provider
     }
     
@@ -70,6 +73,13 @@ public final class CalendarViewReactor: Reactor {
     // MARK: - Mutate
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
+        case .fetchFamilyMembers:
+            let query: SearchFamilyQuery = SearchFamilyQuery(type: "FAMILY", page: 1, size: 20)
+            return familyUseCase.excute(query: query)
+                .asObservable()
+                .flatMap {_ in 
+                    return Observable<Mutation>.empty()
+                }
         case let .addYearMonthItem(yearMonth):
             return Observable<Mutation>.just(.injectYearMonthItem(yearMonth))
             

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -89,6 +89,11 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
             .map { Reactor.Action.addYearMonthItem($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        Observable<Void>.just(())
+            .map { Reactor.Action.fetchFamilyMembers }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
 
         navigationBarView.rx.didTapLeftBarButton
             .map { _ in Reactor.Action.popViewController }

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Dependency/HomeDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Dependency/HomeDIContainer.swift
@@ -39,7 +39,7 @@ public final class HomeDIContainer {
         return SearchFamilyUseCase(searchFamilyRepository: makeFamilyRepository())
     }
     
-    func makeInviteFamilyUseCase() -> InviteFamilyViewUseCaseProtocol {
+    func makeInviteFamilyUseCase() -> FamilyViewUseCaseProtocol {
         return InviteFamilyViewUseCase(familyRepository: makeInviteFamilyRepository())
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/HomeViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/HomeViewReactor.swift
@@ -53,9 +53,9 @@ public final class HomeViewReactor: Reactor {
     public let provider: GlobalStateProviderProtocol = GlobalStateProvider()
     private let familyRepository: SearchFamilyMemberUseCaseProtocol
     private let postRepository: PostListUseCaseProtocol
-    private let familyUseCase: InviteFamilyViewUseCaseProtocol
+    private let familyUseCase: FamilyViewUseCaseProtocol
     
-    init(familyRepository: SearchFamilyMemberUseCaseProtocol, postRepository: PostListUseCaseProtocol, familyUseCase: InviteFamilyViewUseCaseProtocol) {
+    init(familyRepository: SearchFamilyMemberUseCaseProtocol, postRepository: PostListUseCaseProtocol, familyUseCase: FamilyViewUseCaseProtocol) {
         self.familyUseCase = familyUseCase
         self.familyRepository = familyRepository
         self.postRepository = postRepository

--- a/14th-team5-iOS/App/Sources/Presentation/InviteFamily/Dependency/InviteFamilyDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/InviteFamily/Dependency/InviteFamilyDIContainer.swift
@@ -13,7 +13,7 @@ import Domain
 
 public final class InviteFamilyDIContainer: BaseDIContainer {
     public typealias ViewController = InviteFamilyViewController
-    public typealias UseCase = InviteFamilyViewUseCaseProtocol
+    public typealias UseCase = FamilyViewUseCaseProtocol
     public typealias Repository = FamilyRepositoryProtocol
     public typealias Reactor = InviteFamilyViewReactor
     
@@ -28,7 +28,7 @@ public final class InviteFamilyDIContainer: BaseDIContainer {
         return InviteFamilyViewController(reactor: makeReactor())
     }
     
-    public func makeUsecase() -> InviteFamilyViewUseCaseProtocol {
+    public func makeUsecase() -> FamilyViewUseCaseProtocol {
         return InviteFamilyViewUseCase(familyRepository: makeRepository())
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/InviteFamily/Reactor/InviteFamilyViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/InviteFamily/Reactor/InviteFamilyViewReactor.swift
@@ -43,13 +43,13 @@ public final class InviteFamilyViewReactor: Reactor {
     // MARK: - Properties
     public let initialState: State
     
-    public let inviteFamilyUseCase: InviteFamilyViewUseCaseProtocol
+    public let inviteFamilyUseCase: FamilyViewUseCaseProtocol
     public let provider: GlobalStateProviderProtocol
     
     private let memberId: String? = App.Repository.member.memberID.value
     
     // MARK: - Intializer
-    init(usecase: InviteFamilyViewUseCaseProtocol, provider: GlobalStateProviderProtocol) {
+    init(usecase: FamilyViewUseCaseProtocol, provider: GlobalStateProviderProtocol) {
         self.initialState = State(
             familyInvitationUrl: nil,
             shouldPresentCopySuccessToastMessageView: false,

--- a/14th-team5-iOS/App/Sources/Presentation/InviteFamily/ViewController/InviteFamilyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/InviteFamily/ViewController/InviteFamilyViewController.swift
@@ -26,7 +26,7 @@ public final class InviteFamilyViewController: BaseViewController<InviteFamilyVi
     private let labelStackView: UIStackView = UIStackView()
     private let inviteFamilyTitleLabel: BibbiLabel = BibbiLabel(.head2Bold, textColor: .gray200)
     private let invitationUrlLabel: BibbiLabel = BibbiLabel(.body2Regular, textColor: .gray300)
-    private let shareButton: UIButton = UIButton(type: .system)
+    private let shareImageView: UIImageView = UIImageView()
     
     private let dividerView: UIView = UIView()
     
@@ -55,7 +55,7 @@ public final class InviteFamilyViewController: BaseViewController<InviteFamilyVi
             navigationBarView, shareContainerView
         )
         shareContainerView.addSubviews(
-            envelopeImageView, labelStackView, shareButton
+            envelopeImageView, labelStackView, shareImageView
         )
         labelStackView.addArrangedSubviews(
             inviteFamilyTitleLabel, invitationUrlLabel
@@ -94,7 +94,7 @@ public final class InviteFamilyViewController: BaseViewController<InviteFamilyVi
             $0.centerY.equalTo(shareContainerView.snp.centerY)
         }
         
-        shareButton.snp.makeConstraints {
+        shareImageView.snp.makeConstraints {
             $0.trailing.equalTo(shareContainerView.snp.trailing).offset(-AddFamilyVC.AutoLayout.shareInvitationUrlButtonTrailingOffsetValue)
             $0.width.height.equalTo(23.0)
             $0.centerY.equalTo(shareContainerView.snp.centerY)
@@ -151,12 +151,10 @@ public final class InviteFamilyViewController: BaseViewController<InviteFamilyVi
             $0.text = AddFamilyVC.Strings.invitationUrlText
         }
         
-        shareButton.do {
-            $0.setImage(
-                DesignSystemAsset.shareLine.image.withRenderingMode(.alwaysTemplate),
-                for: .normal
-            )
+        shareImageView.do {
+            $0.image = DesignSystemAsset.shareLine.image
             $0.tintColor = DesignSystemAsset.gray500.color
+            $0.contentMode = .scaleAspectFit
         }
         
         dividerView.do {
@@ -203,7 +201,7 @@ public final class InviteFamilyViewController: BaseViewController<InviteFamilyVi
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        shareButton.rx.tap
+        shareContainerView.rx.tap
             .throttle(RxConst.throttleInterval, scheduler: MainScheduler.instance)
             .map { Reactor.Action.didTapShareButton }
             .bind(to: reactor.action)

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -131,10 +131,14 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
                     ]
                 )
                 
-                guard let author = $0.1.author else { return }
-                $0.0.userNameLabel.text = author.name
+                guard let name = $0.1.author?.name,
+                      let profileImageUrl = $0.1.author?.profileImageURL else {
+                    return
+                }
+                
+                $0.0.userNameLabel.text = name
                 $0.0.profileImageView.kf.setImage(
-                    with: URL(string: author.profileImageURL ?? ""),
+                    with: URL(string: profileImageUrl),
                     options: [
                         .transition(.fade(0.15))
                     ]
@@ -211,6 +215,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
         }
         
         profileImageView.do {
+            $0.backgroundColor = .gray300
             $0.contentMode = .scaleAspectFill
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 34.0 / 2.0
@@ -221,6 +226,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
         }
         
         postImageView.do {
+            $0.backgroundColor = .gray300
             $0.clipsToBounds = true
             $0.layer.cornerRadius = Layout.PostImageView.cornerRadius
         }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -20,7 +20,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     
     private let profileStackView = UIStackView()
     private let profileImageView = UIImageView()
-    private let nickNameLabel = BibbiLabel(.caption, textColor: .gray200)
+    private let userNameLabel = BibbiLabel(.caption, textColor: .gray200)
     
     private let postImageView = UIImageView()
     /// 이모지를 선택하기 위한 버튼을 모아둔 stackView
@@ -51,6 +51,12 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        userNameLabel.text = nil
+        profileImageView.image = nil
+        postImageView.image = nil
     }
     
     override func bind(reactor: EmojiReactor) {
@@ -126,10 +132,9 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
                 )
                 
                 guard let author = $0.1.author else { return }
-                guard let profileImageUrl = $0.1.author?.profileImageURL else { return }
-                $0.0.nickNameLabel.text = author.name
+                $0.0.userNameLabel.text = author.name
                 $0.0.profileImageView.kf.setImage(
-                    with: URL(string: profileImageUrl),
+                    with: URL(string: author.profileImageURL ?? ""),
                     options: [
                         .transition(.fade(0.15))
                     ]
@@ -147,7 +152,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     override func setupUI() {
         super.setupUI()
         addSubviews(profileStackView, postImageView, showSelectableEmojiButton, emojiCountStackView, selectableEmojiStackView)
-        profileStackView.addArrangedSubviews(profileImageView, nickNameLabel)
+        profileStackView.addArrangedSubviews(profileImageView, userNameLabel)
         postImageView.addSubview(contentCollectionView)
     }
 
@@ -206,13 +211,12 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
         }
         
         profileImageView.do {
-            $0.image = DesignSystemAsset.emoji1.image
             $0.contentMode = .scaleAspectFill
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 34.0 / 2.0
         }
         
-        nickNameLabel.do {
+        userNameLabel.do {
             $0.text = "(알 수 없음)"
         }
         

--- a/14th-team5-iOS/Domain/Sources/Family/InviteFamily/UseCases/InviteFamilyViewUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/InviteFamily/UseCases/InviteFamilyViewUseCase.swift
@@ -9,13 +9,13 @@ import Foundation
 
 import RxSwift
 
-public protocol InviteFamilyViewUseCaseProtocol {
+public protocol FamilyViewUseCaseProtocol {
     func executeCreateFamily() -> Observable<FamilyResponse?>
     func executeFetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?>
     func executeFetchFamilyMembers() -> Observable<PaginationResponseFamilyMemberProfile?>
 }
 
-public final class InviteFamilyViewUseCase: InviteFamilyViewUseCaseProtocol {
+public final class InviteFamilyViewUseCase: FamilyViewUseCaseProtocol {
     private let familyRepository: FamilyRepositoryProtocol
     
     public init(familyRepository: FamilyRepositoryProtocol) {
@@ -32,6 +32,5 @@ public final class InviteFamilyViewUseCase: InviteFamilyViewUseCaseProtocol {
     
     public func executeFetchFamilyMembers() -> Observable<PaginationResponseFamilyMemberProfile?> {
         return familyRepository.fetchFamilyMembers()
-    }
-    
+    }    
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 가족 초대 링크 터치 가능 영역 수정
- 캘린더 화면 진입 시, 가족 정보를 불러와 `UserDefaults`에 저장하도록 로직 추가
- 캘린더 피드 셀이 실제 작성자와 인적 사항이 매치되지 않는 문제 수정 (추가 확인 필요)


