### PR TITLE
fix: 토스트 메시지 심볼 및 Width 값 수정, 캘린더 피드의 프로필 이미지 Placeholder 추가

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -35,7 +35,7 @@ public final class CalendarPostViewReactor: Reactor {
     public struct State {
         var selectedDate: Date
         var blurImageUrl: String?
-        var displayPost: [PostListSectionModel]
+        @Pulse var displayPost: [PostListSectionModel]
         var displayCalendar: [String: [CalendarResponse]] // (월: [일자 데이터]) 형식으로 불러온 데이터를 저장
         @Pulse var shouldPresentToastMessageView: Bool
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -235,7 +235,7 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             }
             .disposed(by: disposeBag)
 
-        reactor.state.map { $0.displayPost }
+        reactor.pulse(\.$displayPost)
             .bind(to: collectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
         

--- a/14th-team5-iOS/App/Sources/Presentation/FamilyManagement/ViewController/FamilyManagementViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/FamilyManagement/ViewController/FamilyManagementViewController.swift
@@ -102,7 +102,7 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
                 $0.0.makeBibbiToastView(
                     text: FamilyManagementStrings.sucessCopyInvitationUrlText,
                     designSystemImage: DesignSystemAsset.link.image,
-                    width: 210
+                    width: 220
                 )
             }
             .disposed(by: disposeBag)
@@ -114,7 +114,7 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
                 $0.0.makeBibbiToastView(
                     text: FamilyManagementStrings.fetchFailInvitationUrlText,
                     designSystemImage: DesignSystemAsset.warning.image,
-                    width: 230
+                    width: 240
                 )
             }
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -216,9 +216,9 @@ public final class HomeViewController: BaseViewController<HomeViewReactor> {
             .withUnretained(self)
             .subscribe {
                 $0.0.makeBibbiToastView(
-                    text: "링크가 복사되었어요",
-                    symbol: "link",
-                    width: 210
+                    text: FamilyManagementStrings.sucessCopyInvitationUrlText,
+                    designSystemImage: DesignSystemAsset.link.image,
+                    width: 220
                 )
             }
             .disposed(by: disposeBag)
@@ -228,10 +228,9 @@ public final class HomeViewController: BaseViewController<HomeViewReactor> {
             .withUnretained(self)
             .subscribe {
                 $0.0.makeBibbiToastView(
-                    text: "잠시 후에 다시 시도해주세요",
-                    symbol: "exclamationmark.triangle.fill",
-                    palletteColors: [UIColor.systemYellow],
-                    width: 230
+                    text: FamilyManagementStrings.fetchFailInvitationUrlText,
+                    designSystemImage: DesignSystemAsset.warning.image,
+                    width: 240
                 )
             }
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -19,7 +19,9 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     static let id = "postCollectionViewCell"
     
     private let profileStackView = UIStackView()
+    private let containerView = UIView()
     private let profileImageView = UIImageView()
+    private let firstNameLabel = BibbiLabel(.caption, textColor: .bibbiWhite)
     private let userNameLabel = BibbiLabel(.caption, textColor: .gray200)
     
     private let postImageView = UIImageView()
@@ -103,6 +105,11 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             })
             .disposed(by: disposeBag)
         
+        reactor.state.map { $0.post.author?.name[0] }
+            .distinctUntilChanged()
+            .bind(to: firstNameLabel.rx.text)
+            .disposed(by: disposeBag)
+        
         reactor.state
             .map { $0.type }
             .distinctUntilChanged()
@@ -155,7 +162,8 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     override func setupUI() {
         super.setupUI()
         addSubviews(profileStackView, postImageView, showSelectableEmojiButton, emojiCountStackView, selectableEmojiStackView)
-        profileStackView.addArrangedSubviews(profileImageView, userNameLabel)
+        containerView.addSubviews(firstNameLabel, profileImageView)
+        profileStackView.addArrangedSubviews(containerView, userNameLabel)
         postImageView.addSubview(contentCollectionView)
     }
 
@@ -168,8 +176,16 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             $0.height.equalTo(34)
         }
         
+        containerView.snp.makeConstraints {
+            $0.size.equalTo(34)
+        }
+        
+        firstNameLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+        
         profileImageView.snp.makeConstraints {
-            $0.width.height.equalTo(34)
+            $0.size.equalTo(34)
         }
         
         contentCollectionView.snp.makeConstraints {
@@ -213,8 +229,13 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             $0.isHidden = true
         }
         
+        containerView.do {
+            $0.layer.masksToBounds = true
+            $0.layer.cornerRadius = 34 / 2
+            $0.backgroundColor = .gray800
+        }
+        
         profileImageView.do {
-            $0.backgroundColor = .gray300
             $0.contentMode = .scaleAspectFill
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 34.0 / 2.0
@@ -226,7 +247,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
         
         postImageView.do {
             $0.clipsToBounds = true
-            $0.backgroundColor = .gray300
+            $0.backgroundColor = .gray100
             $0.contentMode = .scaleAspectFill
             $0.layer.cornerRadius = Layout.PostImageView.cornerRadius
         }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 캘린더 피드의 프로필 이미지 Placeholder(이름 첫 글자) 추가
- 가족 초대 링크 성공 여부를 알려주는 토스트 메시지 심볼 및 Width 값 수정(홈, 친구 초대 화면)
- 캘린더 피드 스크롤 시, 이모지가 깜박거릴 수 있는 문제 수정

close #269 