### PR TITLE
feat:  가족생성 및 초대화면 추가에 따른 기존 로직 수정 및 추가 개발

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
+++ b/14th-team5-iOS/App/Sources/Application/SceneDelegate.swift
@@ -36,6 +36,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         
+        // UserDefaults.standard.inviteUrl = String("\(incomingURL)")
         guard let path = components.path else {
             return
         }

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
@@ -139,10 +139,11 @@ extension AccountSignInViewController {
             let container = UINavigationController(rootViewController: AccountSignUpDIContainer().makeViewController())
             container.modalPresentationStyle = .fullScreen
             present(container, animated: false)
-        } else {
-            let container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
-            container.modalPresentationStyle = .fullScreen
-            present(container, animated: false)
+            return
         }
+        
+        let container = UINavigationController(rootViewController: OnBoardingDIContainer().makeViewController())
+        container.modalPresentationStyle = .fullScreen
+        present(container, animated: false)
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/InputFamilyLinkViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/InputFamilyLinkViewController.swift
@@ -70,7 +70,8 @@ final class InputFamilyLinkViewController: BaseViewController<InputFamilyLinkRea
         }
         
         linkTextField.do {
-            $0.makePlaceholderAttributedString("https://no5ing.kr/", attributed: [
+            $0.makePlaceholderAttributedString(UserDefaults.standard.inviteUrl ?? "https://no5ing.kr/",
+                                               attributed: [
                 .font: UIFont(font: DesignSystemFontFamily.Pretendard.bold, size: 36)!,
                 .foregroundColor: DesignSystemAsset.gray700.color
             ])
@@ -123,9 +124,7 @@ final class InputFamilyLinkViewController: BaseViewController<InputFamilyLinkRea
             .filter { $0 }
             .distinctUntilChanged()
             .withUnretained(self)
-            .bind(onNext: {
-                $0.0.showHomeViewController()
-            })
+            .bind(onNext: { $0.0.showHomeViewController() })
             .disposed(by: disposeBag)
         
         reactor.state

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/JoinFamilyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/JoinFamilyViewController.swift
@@ -67,7 +67,7 @@ final class JoinFamilyViewController: BaseViewController<JoinFamilyReactor> {
         super.setupAttributes()
         
         titleLabel.do {
-            $0.text = "엄마님, 가족 중 첫 번째로\n방을 생성해보세요"
+            $0.text = "\(UserDefaults.standard.nickname ?? "삐삐")님, 가족 중 첫 번째로\n방을 생성해보세요"
             $0.numberOfLines = 2
         }
         

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
@@ -142,8 +142,13 @@ final public class OnBoardingViewController: BaseViewController<OnBoardingReacto
         guard show else { return }
         guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
         
-        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: JoinFamilyDIContainer().makeViewController())
-        sceneDelegate.window?.makeKeyAndVisible()
+        if App.Repository.member.familyId.value == nil {
+            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: JoinFamilyDIContainer().makeViewController())
+            sceneDelegate.window?.makeKeyAndVisible()
+        } else {
+            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+            sceneDelegate.window?.makeKeyAndVisible()
+        }
     }
 }
 

--- a/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
@@ -101,7 +101,7 @@ public final class SplashViewController: BaseViewController<SplashViewReactor> {
         guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
         let container: UINavigationController
         
-        if let _ = member?.memberId {
+        if let _ = member?.familyId {
             var container: UINavigationController
             if UserDefaults.standard.finishTutorial {
                 container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
@@ -126,11 +126,7 @@ public final class SplashViewController: BaseViewController<SplashViewReactor> {
             sceneDelegate.window?.makeKeyAndVisible()
             return
         } else {
-            if UserDefaults.standard.finishTutorial {
-                container = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
-            } else {
-                container = UINavigationController(rootViewController: OnBoardingDIContainer().makeViewController())
-            }
+            container = UINavigationController(rootViewController: OnBoardingDIContainer().makeViewController())
         }
         
         sceneDelegate.window?.rootViewController = container

--- a/14th-team5-iOS/Core/Sources/Extensions/UserDefaults+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/UserDefaults+Ext.swift
@@ -15,6 +15,9 @@ extension UserDefaults {
         
         case familyId
         case memberId
+        case nickname
+        
+        case inviteUrl
         case inviteCode
         
         case profileImage
@@ -48,9 +51,19 @@ extension UserDefaults {
         set { UserDefaults.standard.set(newValue, forKey: Key.memberId.value) }
     }
     
+    public var nickname: String? {
+        get { UserDefaults.standard.string(forKey: Key.nickname.value) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.nickname.value) }
+    }
+    
     public var inviteCode: String? {
         get { UserDefaults.standard.string(forKey: Key.inviteCode.value) }
         set { UserDefaults.standard.set(newValue, forKey: Key.inviteCode.value) }
+    }
+    
+    public var inviteUrl: String? {
+        get { UserDefaults.standard.string(forKey: Key.inviteUrl.value) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.inviteUrl.value) }
     }
     
     public var profileImage: Data? {

--- a/14th-team5-iOS/Core/Sources/Member/MemberRepository.swift
+++ b/14th-team5-iOS/Core/Sources/Member/MemberRepository.swift
@@ -13,6 +13,7 @@ import RxCocoa
 public class MemberRepository: RxObject {
     public let familyId = BehaviorRelay<String?>(value: nil)
     public let memberID = BehaviorRelay<String?>(value: nil)
+    public let nickname = BehaviorRelay<String?>(value: nil)
     public let inviteCode = BehaviorRelay<String?>(value: nil)
     
     override public func bind() {
@@ -24,6 +25,11 @@ public class MemberRepository: RxObject {
         familyId
             .withUnretained(self)
             .bind(onNext: { $0.0.saveFamilyId(with: $0.1) })
+            .disposed(by: disposeBag)
+    
+        nickname
+            .withUnretained(self)
+            .bind(onNext: { $0.0.saveNicknmae(with: $0.1) })
             .disposed(by: disposeBag)
         
         inviteCode
@@ -45,6 +51,11 @@ public class MemberRepository: RxObject {
     private func saveInviteCode(with code: String?) {
         guard let code = code else { return }
         UserDefaults.standard.inviteCode = code
+    }
+    
+    private func saveNicknmae(with nickname: String?) {
+        guard let nickname = nickname else { return }
+        UserDefaults.standard.nickname = nickname
     }
     
     override public func unbind() {

--- a/14th-team5-iOS/Data/Sources/Account/MeAPI/MeAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Account/MeAPI/MeAPIWorker.swift
@@ -88,15 +88,6 @@ extension MeAPIWorker: MeRepositoryProtocol, JoinFamilyRepository {
             .asSingle()
     }
     
-    private func saveMemberInfo(_ memberInfo: MemberInfo) {
-        App.Repository.member.memberID.accept(memberInfo.memberId)
-        App.Repository.member.familyId.accept(memberInfo.familyId)
-        
-        let member: ProfileData = ProfileData(memberId: memberInfo.memberId, profileImageURL: memberInfo.imageUrl, name: memberInfo.name)
-        FamilyUserDefaults.saveMyMemberId(memberId: memberInfo.memberId)
-        FamilyUserDefaults.saveMemberToUserDefaults(familyMember: member)
-    }
-    
     private func getMemberInfo(spec: APISpec, headers: [APIHeader]?) -> Single<MemberInfo?> {
         
         return request(spec: spec, headers: headers)
@@ -108,10 +99,6 @@ extension MeAPIWorker: MeRepositoryProtocol, JoinFamilyRepository {
             })
             .map(MemberInfo.self)
             .catchAndReturn(nil)
-            .do {
-                guard let memberInfo = $0 else { return }
-                self.saveMemberInfo(memberInfo)
-            }
             .asSingle()
     }
     


### PR DESCRIPTION
## 작업 내용 🧑‍💻
- 가족 초대화면 추가에 따른 화면 분기 로직 추가 

첫 진입 
1. 첫 사용자 (SNS 로그인)
2. 로그인만 하고 나간 사람 (회원가입, 닉네임 화면)
3. 온보딩 안보고 나간 사람 (온보딩 화면)
4. 가족 가입 안하고 나간 사람 (온보딩 화면)
5. 가족 가입이 되어 있는 사람 (홈 화면)

<일반 사용자>
- SNS 로그인 -> 회원가입 -> 온보딩 -> 가족초대 및 가입 -> 홈 화면 
- SNS 로그인 -> 회원가입 -> 온보딩 -> 가족초대 및 가입 -> 링크입력 -> 홈 화면 

<일반 사용자 (링크 진입)>
- SNS 로그인 -> 회원가입 -> 온보딩 -> 홈 화면  (가족 가입 되어있는 상태)

<기존 사용자 (앱 제거 진입)>
1. 가족 존재하는 경우
- SNS 로그인  -> 온보딩 -> 홈 화면  
2. 가족 존재하지 않는 경우  
- SNS 로그인  -> 온보딩 -> 가족 초대 및 가입 -> 홈 화면  
- SNS 로그인  -> 온보딩 -> 가족 초대 및 가입 -> 링크입력 -> 홈 화면

## 변경 로직 ⚒️
- saveMember 함수 worker쪽에서 Repository로 이동 
- 초대링크 입력화면에 닉네임 추가 
- 초대링크 입력화면에서, 코드가 존재하는 경우 기본 값 지정 

## 테스트 케이스 ✅

- [ ] 모든 회원가입 프로세스 및 가족생성 케이스 
- [ ] 링크로 가입한 사용자가 가족에 잘 가입되는지 여부 

close #282


