### PR TITLE
fix: 가족 페이지 네비게이션 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeFamilyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeFamilyViewController.swift
@@ -13,7 +13,7 @@ import Domain
 import RxDataSources
 
 final class HomeFamilyViewController: BaseViewController<HomeFamilyViewReactor> {
-    private let inviteFamilyView: UIView = InviteFamilyView()
+    private let inviteFamilyView: InviteFamilyView = InviteFamilyView()
     private let familyCollectionViewLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
     private let familyCollectionView: UICollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     private let refreshControl: UIRefreshControl = UIRefreshControl()
@@ -59,6 +59,10 @@ final class HomeFamilyViewController: BaseViewController<HomeFamilyViewReactor> 
             $0.register(FamilyCollectionViewCell.self, forCellWithReuseIdentifier: FamilyCollectionViewCell.id)
             $0.backgroundColor = .clear
             $0.collectionViewLayout = familyCollectionViewLayout
+        }
+        
+        inviteFamilyView.do {
+            $0.setLabel(caption: "이런, 아직 아무도 없군요!", title: "가족 초대하기")
         }
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -242,6 +242,7 @@ extension HomeViewController {
             .bind(onNext: { [weak postCollectionView] isRefreshing in
                 if let refreshControl = postCollectionView?.refreshControl {
                     refreshControl.endRefreshing()
+                    postCollectionView?.reloadData()
                 }
             })
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Views/FeedCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Views/FeedCollectionViewCell.swift
@@ -24,7 +24,6 @@ final class FeedCollectionViewCell: BaseCollectionViewCell<HomeViewReactor> {
     
     override func setupUI() {
         addSubviews(imageView, stackView)
-        
         stackView.addArrangedSubviews(nameLabel, timeLabel)
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/InputFamilyLinkViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/InputFamilyLinkViewController.swift
@@ -152,7 +152,8 @@ final class InputFamilyLinkViewController: BaseViewController<InputFamilyLinkRea
 
 extension InputFamilyLinkViewController {
     private func showHomeViewController() {
-        let homeViewController = HomeDIContainer().makeViewController()
-        self.navigationController?.pushViewController(homeViewController, animated: true)
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+        sceneDelegate.window?.makeKeyAndVisible()
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/JoinFamilyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/ViewController/JoinFamilyViewController.swift
@@ -129,8 +129,9 @@ extension JoinFamilyViewController {
     private func showHomeViewController(_ isShow: Bool) {
         guard isShow else { return }
         
-        let homeViewController = HomeDIContainer().makeViewController()
-        self.navigationController?.pushViewController(homeViewController, animated: true)
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: HomeDIContainer().makeViewController())
+        sceneDelegate.window?.makeKeyAndVisible()
     }
     
     private func showInputLinkViewController(_ isShow: Bool) {


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 가족 페이지 네비게이션 수정하여 홈에서 가족 초대,입장 화면으로 되돌아갈 수 없게 수정하였습니다.

- 홈화면에서 가족 refresh control 제거하였습니다.


