### PR TITLE
Fix/#289 fix 위젯 서버 통신 이미지 방향수정

### DIFF
--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyService.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyService.swift
@@ -14,7 +14,12 @@ struct FamilyService {
         
         let token = App.Repository.token.keychain.string(forKey: "accessToken")
         let appKey = "9c61cc7b-0fe9-40eb-976e-6a74c8cb9092"
-        let urlString = "https://api.no5ing.kr/v1/widgets/single-recent-family-post"
+#if PRD
+        var hostApi: String = "https://api.no5ing.kr/v1"
+#else
+        var hostApi: String = "https://dev.api.no5ing.kr/v1"
+#endif
+        let urlString = "\(hostApi)/widgets/single-recent-family-post"
         
         var request = URLRequest(url: URL(string: urlString)!)
         request.addValue("application/json", forHTTPHeaderField: "accept")

--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyWidgetView.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyWidgetView.swift
@@ -133,6 +133,7 @@ private struct NetworkImageView: View {
         if let url = url, let imageData = try? Data(contentsOf: url), let uiImage = UIImage(data: imageData) {
             Image(uiImage: uiImage)
                 .resizable()
+                .rotationEffect(.degrees(90))
         } else {
             Color.white // 추후 변경해야할 사항
         }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 위젯 이미지 정상 출력 (회전되지 않음)
- 서버주소 DEV, PRD 분리 

## 테스트 케이스 ✅
- [ ] 위젯 출력 여부 
- [ ] 위젯 이미지 회전 정상작동 


close #289 


