### PR TITLE
fix: 캘린더 피드 셀에서 프로필이 제대로 출력되지 않는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -57,6 +57,7 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     
     override func prepareForReuse() {
         userNameLabel.text = "알 수 없음"
+        firstNameLabel.text = "알"
         profileImageView.image = nil
         postImageView.image = nil
     }
@@ -142,20 +143,18 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
                     ]
                 )
                 
-                guard let name = $0.1.author?.name,
-                      let profileImageUrl = $0.1.author?.profileImageURL else {
-                    $0.0.userNameLabel.text = "알 수 없음"
-                    $0.0.firstNameLabel.text = "알"
-                    return
+                if let imageUrl = $0.1.author?.profileImageURL {
+                    $0.0.profileImageView.kf.setImage(
+                        with: URL(string: imageUrl),
+                        options: [
+                            .transition(.fade(0.15))
+                        ]
+                    )
                 }
                 
-                $0.0.userNameLabel.text = name
-                $0.0.profileImageView.kf.setImage(
-                    with: URL(string: profileImageUrl),
-                    options: [
-                        .transition(.fade(0.15))
-                    ]
-                )
+                if let name = $0.1.author?.name {
+                    $0.0.userNameLabel.text = name
+                }
             }
             .disposed(by: disposeBag)
         
@@ -250,6 +249,10 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
         
         userNameLabel.do {
             $0.text = "알 수 없음"
+        }
+        
+        firstNameLabel.do {
+            $0.text = "알"
         }
         
         postImageView.do {

--- a/14th-team5-iOS/Domain/Sources/Profile/DataMapping/ProfileMemberDTO.swift
+++ b/14th-team5-iOS/Domain/Sources/Profile/DataMapping/ProfileMemberDTO.swift
@@ -7,12 +7,13 @@
 
 import Foundation
 
+import Core
 
 public struct ProfileMemberDTO: Decodable {
     public var memberId: String?
     public var name: String?
     public var imageUrl: String?
-    public var dayOfBirth: Date
+    public var dayOfBirth: String
 }
 
 extension ProfileMemberDTO {
@@ -31,7 +32,7 @@ extension ProfileMemberDTO {
             memberId: memberId ?? "",
             profileImageURL: imageUrl ?? "",
             name: name ?? "",
-            dayOfBirth: dayOfBirth
+            dayOfBirth: dayOfBirth.toDate()
         )
     }
     


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- ProfileMemberDTO 파싱 에러 수정
- 캘린더 피드 셀에서 프로필이 이미지가 없으면 이름과 프로필 이미지가 제대로 출력되지 않는 문제 수정