### PR TITLE
fix: 회원 가입시 Presigned-url Path 경로 Bug 수정

### DIFF
--- a/14th-team5-iOS/Core/Sources/Extensions/Notification+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Notification+Ext.swift
@@ -11,6 +11,7 @@ import Foundation
 extension Notification.Name {
     public static let AVCapturePhotoOutputDidFinishProcessingPhotoNotification: Notification.Name = Notification.Name("AVCapturePhotoOutputDidFinishProcessingPhotoNotification")
     public static let PHPickerAssetsDidFinishPickingProcessingPhotoNotification: Notification.Name = Notification.Name("PHPickerAssetsDidFinishPickingProcessingPhotoNotification")
+    public static let AccountDefaultProfilePresignedURLNotification = Notification.Name("AccountDefaultProfilePresignedURLNotification")
     public static let AccountViewPresignURLDismissNotification = Notification.Name("AccountViewPresignURLDismissNotification")
     public static let AppVersionsCheckWithRedirectStore = Notification.Name("AppVersionsCheckWithRedirectStore")
     public static let ProfileImageInitializationUpdate = Notification.Name("ProfileImageInitializationUpdate")


### PR DESCRIPTION
## 작업 내용 🧑‍💻
- AccountProfileViewController DefaultProfileView Upload Code 추가 or NotificationCenter Name 추가 및 분기처리
- Notification Name AccountDefaultProfilePresignedURLNotification 추가
- AccountSignUpReactor QueryParam String 문자열 제거 코드 추가

## 변경 로직 ⚒️

- 기본 이미지 업로드 할 경우 NotificationCenter를 통해 기본 이미지를 Data로 변환 시켜 업로드 하도록 로직 추가하였습니다 
- 기존 AccountSignUpReactor에서 PreSigned URL 그대로 넘겨주어서 Image가 제대로 업로드 되지 않았습니다. Query Param 부분 제거하여 확장자 까지만 register에 Parameter에 넘겨주도록 변경 하였습니다.



## 테스트 케이스 ✅

- [ ] 기본 이미지로 업로드 할경우 업로드가 잘 되는지 확인
- [ ] bucket에 image가 Upload 되는지 확인 (PHAssets, Camera)


