### PR TITLE
feat: 댓글 Fetch 및 Create 통신 로직 및 임시 댓글 버튼 구현

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -27,7 +27,7 @@ public final class CalendarPostViewReactor: Reactor {
     public enum Mutation {
         case setupBlurImageView(Int)
         case setupToastMessageView(Bool)
-        case setupPostCommentSheet(Int)
+        case setupPostCommentSheet(String, Int)
         case injectCalendarResponse(String, ArrayResponseCalendarResponse)
         case injectPostResponse([PostListData])
     }
@@ -39,7 +39,7 @@ public final class CalendarPostViewReactor: Reactor {
         @Pulse var displayPost: [PostListSectionModel]
         @Pulse var displayCalendarResponse: [String: [CalendarResponse]] // (월: [일자 데이터]) 형식으로 불러온 데이터를 저장
         @Pulse var shouldPresentToastMessageView: Bool
-        @Pulse var shouldPresentPostCommentSheet: Int
+        @Pulse var shouldPresentPostCommentSheet: (String, Int)
     }
     
     // MARK: - Properties
@@ -65,7 +65,7 @@ public final class CalendarPostViewReactor: Reactor {
             displayPost: [],
             displayCalendarResponse: [:],
             shouldPresentToastMessageView: false,
-            shouldPresentPostCommentSheet: 0
+            shouldPresentPostCommentSheet: (.none, 0)
         )
         
         self.calendarUseCase = calendarUseCase
@@ -86,8 +86,8 @@ public final class CalendarPostViewReactor: Reactor {
         let postMutation = provider.postGlobalState.event
             .flatMap {
                 switch $0 {
-                case let .presentPostCommentSheet(commentCount):
-                    return Observable<Mutation>.just(.setupPostCommentSheet(commentCount))
+                case let .presentPostCommentSheet(postId, commentCount):
+                    return Observable<Mutation>.just(.setupPostCommentSheet(postId, commentCount))
                 }
             }
         
@@ -166,8 +166,8 @@ public final class CalendarPostViewReactor: Reactor {
         case let .setupToastMessageView(uploaded):
             newState.shouldPresentToastMessageView = uploaded
             
-        case let .setupPostCommentSheet(commentCount):
-            newState.shouldPresentPostCommentSheet = commentCount
+        case let .setupPostCommentSheet(psotId, commentCount):
+            newState.shouldPresentPostCommentSheet = (psotId, commentCount)
             
         case let .injectCalendarResponse(yearMonth, arrayCalendarResponse):
             newState.displayCalendarResponse[yearMonth] = arrayCalendarResponse.results

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -27,6 +27,7 @@ public final class CalendarPostViewReactor: Reactor {
     public enum Mutation {
         case setupBlurImageView(Int)
         case setupToastMessageView(Bool)
+        case setupPostCommentSheet(Int)
         case injectCalendarResponse(String, ArrayResponseCalendarResponse)
         case injectPostResponse([PostListData])
     }
@@ -38,6 +39,7 @@ public final class CalendarPostViewReactor: Reactor {
         @Pulse var displayPost: [PostListSectionModel]
         @Pulse var displayCalendarResponse: [String: [CalendarResponse]] // (월: [일자 데이터]) 형식으로 불러온 데이터를 저장
         @Pulse var shouldPresentToastMessageView: Bool
+        @Pulse var shouldPresentPostCommentSheet: Int
     }
     
     // MARK: - Properties
@@ -62,7 +64,8 @@ public final class CalendarPostViewReactor: Reactor {
             selectedDate: selection,
             displayPost: [],
             displayCalendarResponse: [:],
-            shouldPresentToastMessageView: false
+            shouldPresentToastMessageView: false,
+            shouldPresentPostCommentSheet: 0
         )
         
         self.calendarUseCase = calendarUseCase
@@ -80,7 +83,15 @@ public final class CalendarPostViewReactor: Reactor {
                 }
             }
         
-        return Observable<Mutation>.merge(mutation, eventMutation)
+        let postMutation = provider.postGlobalState.event
+            .flatMap {
+                switch $0 {
+                case let .presentPostCommentSheet(commentCount):
+                    return Observable<Mutation>.just(.setupPostCommentSheet(commentCount))
+                }
+            }
+        
+        return Observable<Mutation>.merge(mutation, eventMutation, postMutation)
     }
     
     // MARK: - Mutate
@@ -154,6 +165,9 @@ public final class CalendarPostViewReactor: Reactor {
             
         case let .setupToastMessageView(uploaded):
             newState.shouldPresentToastMessageView = uploaded
+            
+        case let .setupPostCommentSheet(commentCount):
+            newState.shouldPresentPostCommentSheet = commentCount
             
         case let .injectCalendarResponse(yearMonth, arrayCalendarResponse):
             newState.displayCalendarResponse[yearMonth] = arrayCalendarResponse.results

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -172,6 +172,14 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             }
             .disposed(by: disposeBag)
         
+        reactor.pulse(\.$shouldPresentPostCommentSheet)
+            .withUnretained(self)
+            .subscribe {
+                let postCommentVC = PostCommentDIContainer(commentCount: $0.1).makeViewController()
+                $0.0.present(postCommentVC, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
         // 뷰 생성 시, 주간 캘린더 위치를 조정하기 위함
         reactor.state.map { $0.selectedDate }
             .distinctUntilChanged()

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -175,7 +175,10 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
         reactor.pulse(\.$shouldPresentPostCommentSheet)
             .withUnretained(self)
             .subscribe {
-                let postCommentVC = PostCommentDIContainer(commentCount: $0.1).makeViewController()
+                let postCommentVC = PostCommentDIContainer(
+                    postId: $0.1.0,
+                    commentCount: $0.1.1
+                ).makeViewController()
                 $0.0.present(postCommentVC, animated: true)
             }
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/DataSource/PostCommentSectionModel.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/DataSource/PostCommentSectionModel.swift
@@ -42,9 +42,9 @@ extension PostCommentSectionModel {
             PostCommentSectionModel(
                 model: .none,
                 items: [
-                    CommentCellReactor(comment1),
-                    CommentCellReactor(comment2),
-                    CommentCellReactor(comment3)
+//                    CommentCellReactor(comment1),
+//                    CommentCellReactor(comment2),
+//                    CommentCellReactor(comment3)
                 ]
             )
         ]

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Dependency/PostCommentDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Dependency/PostCommentDIContainer.swift
@@ -6,6 +6,8 @@
 //
 
 import Core
+import Data
+import Domain
 import UIKit
 
 public final class PostCommentDIContainer {
@@ -17,10 +19,12 @@ public final class PostCommentDIContainer {
         return appDelegate.globalStateProvider
     }
     
+    private var postId: String
     private var commentCount: Int
     
     // MARK: - Intializer
-    public init(commentCount: Int) {
+    public init(postId: String, commentCount: Int) {
+        self.postId = postId
         self.commentCount = commentCount
     }
     
@@ -29,9 +33,20 @@ public final class PostCommentDIContainer {
         return PostCommentViewController(reactor: makeReactor())
     }
     
+    public func makePostCommentRespository() -> PostCommentRepositoryProtocol {
+        return PostCommentRepository()
+    }
+    
+    public func makePostCommentUseCase() -> PostCommentUseCaseProtocol {
+        return PostCommentUseCase(postCommentRepository: makePostCommentRespository())
+    }
+    
+    
     public func makeReactor() -> PostCommentViewReactor {
         return PostCommentViewReactor(
+            postId: postId,
             commentCount: commentCount,
+            postCommentUseCase: makePostCommentUseCase(),
             provider: globalState
         )
     }

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/CommentCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/CommentCellReactor.swift
@@ -17,11 +17,14 @@ final public class CommentCellReactor: Reactor {
     // MARK: - Action
     public enum Action { 
         case fetchUserName
-        case fetch
+        case fetchProfileImageUrlString
     }
     
     // MARK: - Mutation
-    public enum Mutation { }
+    public enum Mutation { 
+        case injectUserName(String)
+        case injectProfileImageUrlString(String)
+    }
     
     // MARK: - State
     public struct State { 
@@ -30,20 +33,32 @@ final public class CommentCellReactor: Reactor {
         let memberId: String
         let comment: String
         let createdAt: Date
+        
+        var userName: String
+        var profileImageUrlString: String
     }
     
     // MARK: - Properties
     public var initialState: State
     
+    public var postCommentUseCase: PostCommentUseCaseProtocol
+    
     // MARK: - Intializer
-    public init(_ commentResponse: PostCommentResponse) {
+    public init(
+        _ commentResponse: PostCommentResponse,
+        postCommentUseCase: PostCommentUseCaseProtocol
+    ) {
         self.initialState = State(
             commentId: commentResponse.commentId,
             postId: commentResponse.postId,
             memberId: commentResponse.memberId,
             comment: commentResponse.comment,
-            createdAt: commentResponse.createdAt
+            createdAt: commentResponse.createdAt,
+            userName: .none,
+            profileImageUrlString: .none
         )
+        
+        self.postCommentUseCase = postCommentUseCase
     }
 }
 

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/CommentCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/CommentCellReactor.swift
@@ -60,6 +60,30 @@ final public class CommentCellReactor: Reactor {
         
         self.postCommentUseCase = postCommentUseCase
     }
+    
+    // MARK: - Mutate
+    public func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .fetchUserName:
+            let userName = postCommentUseCase.executeFetchUserName(memberId: initialState.memberId)
+            return Observable<Mutation>.just(.injectUserName(userName))
+        case .fetchProfileImageUrlString:
+            let urlString = postCommentUseCase.executeFetchProfileImageUrlString(memberId: initialState.memberId)
+            return Observable<Mutation>.just(.injectProfileImageUrlString(urlString))
+        }
+    }
+    
+    // MARK: - Reduce
+    public func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case let .injectUserName(userName):
+            newState.userName = userName
+        case let .injectProfileImageUrlString(urlString):
+            newState.profileImageUrlString = urlString
+        }
+        return newState
+    }
 }
 
 extension CommentCellReactor: IdentifiableType, Equatable {

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
@@ -6,6 +6,7 @@
 //
 
 import Core
+import Domain
 import Foundation
 
 import ReactorKit
@@ -13,37 +14,83 @@ import RxSwift
 
 final public class PostCommentViewReactor: Reactor {
     // MARK: - Action
-    public enum Action { }
+    public enum Action { 
+        case fetchPostComment
+        case createPostComment
+        case deletePostComment
+    }
     
     // MARK: - Mutation
-    public enum Mutation { }
+    public enum Mutation { 
+        case injectPostComment([CommentCellReactor])
+        case appendPostComment(CommentCellReactor)
+        case removePostComment(Bool)
+    }
     
     // MARK: - State
     public struct State {
+        var postId: String
         var commentCount: Int
+        @Pulse var displayComment: [PostCommentSectionModel]
     }
     
     // MARK: - Properties
     public var initialState: State
     
+    public var postCommentUseCase: PostCommentUseCaseProtocol
     public var provider: GlobalStateProviderProtocol
     
     // MARK: - Intializer
-    public init(commentCount: Int, provider: GlobalStateProviderProtocol) {
+    public init(
+        postId: String,
+        commentCount: Int,
+        postCommentUseCase: PostCommentUseCaseProtocol,
+        provider: GlobalStateProviderProtocol
+    ) {
         self.initialState = State(
-            commentCount: commentCount
+            postId: postId,
+            commentCount: commentCount,
+            displayComment: [.init(model: .none, items: [])]
         )
         
+        self.postCommentUseCase = postCommentUseCase
         self.provider = provider
     }
     
     // MARK: - Mutate
     public func mutate(action: Action) -> Observable<Mutation> {
-        return Observable<Mutation>.empty()
+        switch action {
+        case .fetchPostComment:
+            let postId = currentState.postId
+            let query = PostCommentPaginationQuery(page: 1)
+            return postCommentUseCase.executeFetchPostComment(postId: postId, query: query)
+                .map {
+                    guard let postCommentResponse = $0 else {
+                        return .injectPostComment([])
+                    }
+                    debugPrint("== 가져온 댓글: \(postCommentResponse)")
+                    let reactors = postCommentResponse.results.map { CommentCellReactor($0, postCommentUseCase: self.postCommentUseCase)
+                    }
+                    return .injectPostComment(reactors)
+                }
+        case .createPostComment:
+            return Observable<Mutation>.empty()
+        case .deletePostComment:
+            return Observable<Mutation>.empty()
+        }
     }
     
     // MARK: - Reduce
     public func reduce(state: State, mutation: Mutation) -> State {
-        return state
+        var newState = state
+        switch mutation {
+        case let .injectPostComment(reactor):
+            newState.displayComment = [.init(model: .none, items: reactor)]
+        case let .appendPostComment(reactor):
+            break
+        case let .removePostComment(success):
+            break
+        }
+        return newState
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
@@ -25,6 +25,7 @@ final public class PostCommentViewReactor: Reactor {
         case injectPostComment([CommentCellReactor])
         case appendPostComment(CommentCellReactor)
         case removePostComment(Bool)
+        case clearCommentTextField
     }
     
     // MARK: - State
@@ -32,6 +33,7 @@ final public class PostCommentViewReactor: Reactor {
         var postId: String
         var commentCount: Int
         @Pulse var displayComment: [PostCommentSectionModel]
+        @Pulse var shouldClearCommentTextField: Bool
     }
     
     // MARK: - Properties
@@ -50,7 +52,8 @@ final public class PostCommentViewReactor: Reactor {
         self.initialState = State(
             postId: postId,
             commentCount: commentCount,
-            displayComment: [.init(model: .none, items: [])]
+            displayComment: [.init(model: .none, items: [])],
+            shouldClearCommentTextField: false
         )
         
         self.postCommentUseCase = postCommentUseCase
@@ -82,7 +85,10 @@ final public class PostCommentViewReactor: Reactor {
                         return Observable<Mutation>.empty()
                     }
                     let reactor = CommentCellReactor(commentResponse, postCommentUseCase: self.postCommentUseCase)
-                    return Observable<Mutation>.just(.appendPostComment(reactor))
+                    return Observable.concat(
+                        Observable<Mutation>.just(.clearCommentTextField),
+                        Observable<Mutation>.just(.appendPostComment(reactor))
+                    )
                 }
         case .deletePostComment:
             return Observable<Mutation>.empty()
@@ -104,6 +110,8 @@ final public class PostCommentViewReactor: Reactor {
             newState.displayComment = [dataSource]
         case let .removePostComment(success):
             break
+        case .clearCommentTextField:
+            newState.shouldClearCommentTextField = true
         }
         return newState
     }

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/View/Cell/CommentCell.swift
@@ -22,7 +22,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     private let userNameLabel: BibbiLabel = BibbiLabel(.body2Bold, textColor: .gray100)
     private let createdAtLabel: BibbiLabel = BibbiLabel(.body2Regular, textColor: .gray500)
     
-    private let contentLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray100)
+    private let commentLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray100)
     
     // MARK: - Properties
     static var id: String = "CommentCell"
@@ -54,6 +54,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
+    
     private func bindOutput(reactor: CommentCellReactor) {
         reactor.state.map { $0.userName }
             .distinctUntilChanged()
@@ -64,12 +65,23 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             .distinctUntilChanged()
             .bind(to: profileImageView.rx.kingfisherImage)
             .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.createdAt }
+            .distinctUntilChanged()
+            .map { $0.relativeFormatter() }
+            .bind(to: createdAtLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.comment }
+            .distinctUntilChanged()
+            .bind(to: commentLabel.rx.text)
+            .disposed(by: disposeBag)
     }
     
     public override func setupUI() {
         super.setupUI()
         
-        contentView.addSubviews(profileImageView, userNameStack, contentLabel)
+        contentView.addSubviews(profileImageView, userNameStack, commentLabel)
         userNameStack.addArrangedSubviews(userNameLabel, createdAtLabel)
     }
     
@@ -87,7 +99,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             $0.leading.equalTo(profileImageView.snp.trailing).offset(18)
         }
         
-        contentLabel.snp.makeConstraints {
+        commentLabel.snp.makeConstraints {
             $0.top.equalTo(userNameStack.snp.bottom).offset(8)
             $0.leading.equalTo(userNameStack.snp.leading)
             $0.trailing.equalToSuperview().offset(-8)
@@ -117,17 +129,8 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             $0.alignment = .fill
         }
         
-        userNameLabel.do {
-            $0.text = "테스트"
-        }
-        
-        createdAtLabel.do {
-            $0.text = "1시간 전"
-        }
-        
-        contentLabel.do {
+        commentLabel.do {
             $0.numberOfLines = 0
-            $0.text = "테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트테스트"
         }
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/View/Cell/CommentCell.swift
@@ -43,8 +43,27 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         bindOutput(reactor: reactor)
     }
     
-    private func bindInput(reactor: CommentCellReactor) { }
+    private func bindInput(reactor: CommentCellReactor) { 
+        Observable<Void>.just(())
+            .map { Reactor.Action.fetchUserName }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        Observable<Void>.just(())
+            .map { Reactor.Action.fetchProfileImageUrlString }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+    }
     private func bindOutput(reactor: CommentCellReactor) {
+        reactor.state.map { $0.userName }
+            .distinctUntilChanged()
+            .bind(to: userNameLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.profileImageUrlString }
+            .distinctUntilChanged()
+            .bind(to: profileImageView.rx.kingfisherImage)
+            .disposed(by: disposeBag)
     }
     
     public override func setupUI() {

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
@@ -30,6 +30,7 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
     // MARK: - LifeCycles
     public override func viewDidLoad() {
         super.viewDidLoad()
+        commentTextField.becomeFirstResponder()
     }
     
     public override func viewWillAppear(_ animated: Bool) {
@@ -72,6 +73,13 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
                     button.isEnabled = true
                 }
             }
+            .disposed(by: disposeBag)
+        
+        createCommentButton.rx.tap
+            .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
+            .withUnretained(self)
+            .map { Reactor.Action.createPostComment($0.0.commentTextField.text) }
+            .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
@@ -94,6 +94,15 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
             .bind(to: noCommentLabel.rx.isHidden)
             .disposed(by: disposeBag)
         
+        reactor.pulse(\.$shouldClearCommentTextField)
+            .withUnretained(self)
+            .subscribe {
+                if $0.1 {
+                    $0.0.commentTextField.text = ""
+                }
+            }
+            .disposed(by: disposeBag)
+        
         let keyboardWillShow = NotificationCenter.default.rx.notification(UIResponder.keyboardWillShowNotification)
             .flatMap { notification in
                 guard let value = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
@@ -26,6 +26,7 @@ final class EmojiReactor: Reactor {
         case fetchEmojiList
         case fetchDisplayContent(String)
         case longPressedEmojiCountButton(Int)
+        case tappedCommentButton
     }
     
     enum Mutation {
@@ -107,6 +108,10 @@ extension EmojiReactor {
             return provider.reactionSheetGloablState.showReactionMemberSheet(emojiList.emojis_memberIds[index - 1].memberIds)
                 .flatMap { _ in Observable<Mutation>.empty() }
 
+        case .tappedCommentButton:
+            let commentCount: Int = 3
+            provider.postGlobalState.presentPostCommentSheet(commentCount)
+            return Observable<Mutation>.empty()
         }
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
@@ -109,8 +109,9 @@ extension EmojiReactor {
                 .flatMap { _ in Observable<Mutation>.empty() }
 
         case .tappedCommentButton:
+            let postId: String = currentState.post.postId
             let commentCount: Int = 3
-            provider.postGlobalState.presentPostCommentSheet(commentCount)
+            provider.postGlobalState.presentPostCommentSheet(postId, commentCount: commentCount)
             return Observable<Mutation>.empty()
         }
     }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostReactor.swift
@@ -24,7 +24,7 @@ final class PostReactor: Reactor {
         case setSelectedPostIndex(Int)
         case fetchedPost(PostData?)
         case showReactionSheet([String])
-        case presentPostCommentSheet(Int)
+        case presentPostCommentSheet(String, Int)
     }
     
     struct State {
@@ -36,7 +36,7 @@ final class PostReactor: Reactor {
         
         @Pulse var fetchedPost: PostData? = nil
         @Pulse var reactionMemberIds: [String] = []
-        @Pulse var shouldPresentPostCommentSheet: Int = 0
+        @Pulse var shouldPresentPostCommentSheet: (String, Int) = (.none, 0)
     }
     
     let initialState: State
@@ -66,8 +66,8 @@ extension PostReactor {
         let postMutation = provider.postGlobalState.event
             .flatMap { event -> Observable<Mutation> in
                 switch event {
-                case let .presentPostCommentSheet(commentCount):
-                    return Observable<Mutation>.just(.presentPostCommentSheet(commentCount))
+                case let .presentPostCommentSheet(postId, commentCount):
+                    return Observable<Mutation>.just(.presentPostCommentSheet(postId, commentCount))
                 }
             }
         
@@ -104,8 +104,8 @@ extension PostReactor {
             case let .showReactionSheet(memberIds):
                 newState.reactionMemberIds = memberIds
                 
-            case let .presentPostCommentSheet(commentCount):
-                newState.shouldPresentPostCommentSheet = commentCount
+            case let .presentPostCommentSheet(postId, commentCount):
+                newState.shouldPresentPostCommentSheet = (postId, commentCount)
             }
             return newState
         }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostReactor.swift
@@ -24,6 +24,7 @@ final class PostReactor: Reactor {
         case setSelectedPostIndex(Int)
         case fetchedPost(PostData?)
         case showReactionSheet([String])
+        case presentPostCommentSheet(Int)
     }
     
     struct State {
@@ -35,6 +36,7 @@ final class PostReactor: Reactor {
         
         @Pulse var fetchedPost: PostData? = nil
         @Pulse var reactionMemberIds: [String] = []
+        @Pulse var shouldPresentPostCommentSheet: Int = 0
     }
     
     let initialState: State
@@ -61,7 +63,15 @@ extension PostReactor {
                 }
             }
         
-        return Observable<Mutation>.merge(mutation, eventMutation)
+        let postMutation = provider.postGlobalState.event
+            .flatMap { event -> Observable<Mutation> in
+                switch event {
+                case let .presentPostCommentSheet(commentCount):
+                    return Observable<Mutation>.just(.presentPostCommentSheet(commentCount))
+                }
+            }
+        
+        return Observable<Mutation>.merge(mutation, eventMutation, postMutation)
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -93,6 +103,9 @@ extension PostReactor {
                 newState.isPop = true
             case let .showReactionSheet(memberIds):
                 newState.reactionMemberIds = memberIds
+                
+            case let .presentPostCommentSheet(commentCount):
+                newState.shouldPresentPostCommentSheet = commentCount
             }
             return newState
         }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
@@ -78,6 +78,14 @@ final class PostViewController: BaseViewController<PostReactor> {
             })
             .disposed(by: disposeBag)
         
+        reactor.pulse(\.$shouldPresentPostCommentSheet)
+            .withUnretained(self)
+            .subscribe {
+                let postCommentVC = PostCommentDIContainer(commentCount: $0.1).makeViewController()
+                $0.0.present(postCommentVC, animated: true)
+            }
+            .disposed(by: disposeBag)
+        
         collectionView.rx
             .contentOffset
             .map { [unowned self] in self.calculateCurrentPage(offset: $0) }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
@@ -81,7 +81,10 @@ final class PostViewController: BaseViewController<PostReactor> {
         reactor.pulse(\.$shouldPresentPostCommentSheet)
             .withUnretained(self)
             .subscribe {
-                let postCommentVC = PostCommentDIContainer(commentCount: $0.1).makeViewController()
+                let postCommentVC = PostCommentDIContainer(
+                    postId: $0.1.0,
+                    commentCount: $0.1.1
+                ).makeViewController()
                 $0.0.present(postCommentVC, animated: true)
             }
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostCollectionViewCell.swift
@@ -39,6 +39,10 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
     private let collectionViewFlowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
     private lazy var contentDatasource = createContentDataSource()
     
+    // 임시 코드 --------
+    private let commentButton = UIButton(type: .system)
+    // ----------------
+    
     convenience init(reacter: EmojiReactor? = nil) {
         self.init(frame: .zero)
         self.reactor = reacter
@@ -160,6 +164,14 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             .map { $0.fetchedDisplayContent }
             .bind(to: contentCollectionView.rx.items(dataSource: contentDatasource))
             .disposed(by: disposeBag)
+        
+        // 임시 코드 --------
+        commentButton.rx.tap
+            .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
+            .map { Reactor.Action.tappedCommentButton }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        // ----------------
     }
     
     
@@ -169,6 +181,10 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
         containerView.addSubviews(firstNameLabel, profileImageView)
         profileStackView.addArrangedSubviews(containerView, userNameLabel)
         postImageView.addSubview(contentCollectionView)
+        
+        // 임시 코드 --------
+        self.addSubview(commentButton)
+        // ----------------
     }
 
     override func setupAutoLayout() {
@@ -222,6 +238,13 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             $0.top.equalTo(emojiCountStackView.snp.bottom).offset(Layout.SelectableEmojiStackView.topOffset)
             $0.height.equalTo(Layout.SelectableEmojiStackView.height)
         }
+        
+        // 임시 코드 --------
+        commentButton.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.bottom.equalTo(safeAreaLayoutGuide.snp.bottom)
+        }
+        // ----------------
     }
     
     override func setupAttributes() {
@@ -297,6 +320,13 @@ final class PostCollectionViewCell: BaseCollectionViewCell<EmojiReactor> {
             $0.spacing = Layout.EmojiCountStackView.spacing
             $0.layer.cornerRadius = Layout.EmojiCountStackView.cornerRadius
         }
+        
+        // 임시 코드 --------
+        commentButton.do {
+            $0.setTitle("댓글", for: .normal)
+            $0.tintColor = UIColor.mainGreen
+        }
+        // ----------------
     }
 }
 

--- a/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
@@ -8,6 +8,7 @@
 import UIKit
 import WebKit
 
+import Kingfisher
 import RxCocoa
 import RxSwift
 
@@ -83,5 +84,18 @@ extension Reactive where Base: WKWebView {
             webView.load(request)
         }
         
+    }
+}
+
+extension Reactive where Base: UIImageView {
+    public var kingfisherImage: Binder<String> {
+        Binder(self.base) { imageView, urlString in
+            imageView.kf.setImage(
+                with: URL(string: urlString),
+                options: [
+                    .transition(.fade(0.15))
+                ]
+            )
+        }
     }
 }

--- a/14th-team5-iOS/Core/Sources/Extensions/String+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/String+Ext.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension String {
     public static var none: String { "" }
+    public static var unknown: String { "알 수 없음" }
 }
 
 extension String {

--- a/14th-team5-iOS/Core/Sources/GlobalState/GlobalStateProvider.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/GlobalStateProvider.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 public protocol GlobalStateProviderProtocol: AnyObject {
+    var postGlobalState: PostGlobalStateType { get }
     var activityGlobalState: ActivityGlobalStateType { get }
     var calendarGlabalState: CalendarGlobalStateType { get }
     var toastGlobalState: ToastMessageGlobalStateType { get }
@@ -15,6 +16,7 @@ public protocol GlobalStateProviderProtocol: AnyObject {
 }
 
 final public class GlobalStateProvider: GlobalStateProviderProtocol {
+    public lazy var postGlobalState: PostGlobalStateType = PostGlobalState(provider: self)
     public lazy var activityGlobalState: ActivityGlobalStateType = ActivityGlobalState(provider: self)
     public lazy var calendarGlabalState: CalendarGlobalStateType = CalendarGlobalState(provider: self)
     public lazy var toastGlobalState: ToastMessageGlobalStateType = ToastMessageGlobalState(provider: self)

--- a/14th-team5-iOS/Core/Sources/GlobalState/PostGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/PostGlobalState.swift
@@ -10,21 +10,21 @@ import Foundation
 import RxSwift
 
 public enum PostEvent {
-    case presentPostCommentSheet(Int)
+    case presentPostCommentSheet(String, Int)
 }
 
 public protocol PostGlobalStateType {
     var event: PublishSubject<PostEvent> { get }
     
     @discardableResult
-    func presentPostCommentSheet(_ commentCount: Int) -> Observable<Int>
+    func presentPostCommentSheet(_ postId: String, commentCount: Int) -> Observable<Int>
 }
 
 final public class PostGlobalState: BaseGlobalState, PostGlobalStateType {
     public var event: PublishSubject<PostEvent> = PublishSubject<PostEvent>()
     
-    public func presentPostCommentSheet(_ commentCount: Int) -> Observable<Int> {
-        event.onNext(.presentPostCommentSheet(commentCount))
+    public func presentPostCommentSheet(_ postId: String, commentCount: Int) -> Observable<Int> {
+        event.onNext(.presentPostCommentSheet(postId, commentCount))
         return Observable<Int>.just(commentCount)
     }
 }

--- a/14th-team5-iOS/Core/Sources/GlobalState/PostGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/PostGlobalState.swift
@@ -1,0 +1,30 @@
+//
+//  PostGlobalState.swift
+//  Core
+//
+//  Created by 김건우 on 1/22/24.
+//
+
+import Foundation
+
+import RxSwift
+
+public enum PostEvent {
+    case presentPostCommentSheet(Int)
+}
+
+public protocol PostGlobalStateType {
+    var event: PublishSubject<PostEvent> { get }
+    
+    @discardableResult
+    func presentPostCommentSheet(_ commentCount: Int) -> Observable<Int>
+}
+
+final public class PostGlobalState: BaseGlobalState, PostGlobalStateType {
+    public var event: PublishSubject<PostEvent> = PublishSubject<PostEvent>()
+    
+    public func presentPostCommentSheet(_ commentCount: Int) -> Observable<Int> {
+        event.onNext(.presentPostCommentSheet(commentCount))
+        return Observable<Int>.just(commentCount)
+    }
+}

--- a/14th-team5-iOS/Data/Sources/PostComment/PostCommentAPI/Repository/PostCommentRepository.swift
+++ b/14th-team5-iOS/Data/Sources/PostComment/PostCommentAPI/Repository/PostCommentRepository.swift
@@ -42,10 +42,10 @@ extension PostCommentRepository {
     }
     
     public func fetchUserName(memberId: String) -> String {
-        return FamilyUserDefaults.loadMemberFromUserDefaults(memberId: memberId)?.name ?? .none
+        return FamilyUserDefaults.loadMemberFromUserDefaults(memberId: memberId)?.name ?? .unknown
     }
     
     public func fetchProfileImageUrlString(memberId: String) -> String {
-        return FamilyUserDefaults.loadMemberFromUserDefaults(memberId: memberId)?.profileImageURL ?? .none
+        return FamilyUserDefaults.loadMemberFromUserDefaults(memberId: memberId)?.profileImageURL ?? .unknown
     }
 }

--- a/14th-team5-iOS/Data/Sources/PostComment/PostCommentAPI/Repository/PostCommentRepository.swift
+++ b/14th-team5-iOS/Data/Sources/PostComment/PostCommentAPI/Repository/PostCommentRepository.swift
@@ -40,4 +40,12 @@ extension PostCommentRepository {
         return postCommentApiWorker.deletePostComment(postId: postId, commentId: commentId)
             .asObservable()
     }
+    
+    public func fetchUserName(memberId: String) -> String {
+        return FamilyUserDefaults.loadMemberFromUserDefaults(memberId: memberId)?.name ?? .none
+    }
+    
+    public func fetchProfileImageUrlString(memberId: String) -> String {
+        return FamilyUserDefaults.loadMemberFromUserDefaults(memberId: memberId)?.profileImageURL ?? .none
+    }
 }

--- a/14th-team5-iOS/Domain/Sources/PostComment/Entities/PostCommentPaginationQuery.swift
+++ b/14th-team5-iOS/Domain/Sources/PostComment/Entities/PostCommentPaginationQuery.swift
@@ -13,7 +13,7 @@ public struct PostCommentPaginationQuery {
     public var sort: PostCommentPaginationQuery.Sort
     
     public init(
-        page: Int = 1,
+        page: Int,
         size: Int = 100,
         sort: PostCommentPaginationQuery.Sort = .desc
     ) {

--- a/14th-team5-iOS/Domain/Sources/PostComment/Entities/PostCommentPaginationQuery.swift
+++ b/14th-team5-iOS/Domain/Sources/PostComment/Entities/PostCommentPaginationQuery.swift
@@ -15,7 +15,7 @@ public struct PostCommentPaginationQuery {
     public init(
         page: Int,
         size: Int = 100,
-        sort: PostCommentPaginationQuery.Sort = .desc
+        sort: PostCommentPaginationQuery.Sort = .asc
     ) {
         self.page = page
         self.size = size

--- a/14th-team5-iOS/Domain/Sources/PostComment/Interfaces/Repositories/PostCommentRepository.swift
+++ b/14th-team5-iOS/Domain/Sources/PostComment/Interfaces/Repositories/PostCommentRepository.swift
@@ -16,4 +16,6 @@ public protocol PostCommentRepositoryProtocol {
     func createPostComment(postId: String, body: CreatePostCommentBody) -> Observable<PostCommentResponse?>
     func updatePostComment(postId: String, commentId: String, body: UpdatePostCommentBody) -> Observable<PostCommentResponse?>
     func deletePostComment(postId: String, commentId: String) -> Observable<PostCommentDeleteResponse?>
+    func fetchUserName(memberId: String) -> String
+    func fetchProfileImageUrlString(memberId: String) -> String
 }

--- a/14th-team5-iOS/Domain/Sources/PostComment/UseCase/PostCommentUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/PostComment/UseCase/PostCommentUseCase.swift
@@ -13,6 +13,8 @@ public protocol PostCommentUseCaseProtocol {
     func executeFetchPostComment(postId: String, query: PostCommentPaginationQuery) -> Observable<PaginationResponsePostCommentResponse?>
     func executeCreatePostComment(postId: String, body: CreatePostCommentBody) -> Observable<PostCommentResponse?>
     func executeDeletePostComment(postId: String, commentId: String) -> Observable<PostCommentDeleteResponse?>
+    func executeFetchUserName(memberId: String) -> String
+    func executeFetchProfileImageUrlString(memberId: String) -> String
 }
 
 public final class PostCommentUseCase: PostCommentUseCaseProtocol {
@@ -32,5 +34,13 @@ public final class PostCommentUseCase: PostCommentUseCaseProtocol {
     
     public func executeDeletePostComment(postId: String, commentId: String) -> Observable<PostCommentDeleteResponse?> {
         return postCommentRepository.deletePostComment(postId: postId, commentId: commentId)
+    }
+    
+    public func executeFetchUserName(memberId: String) -> String {
+        return postCommentRepository.fetchUserName(memberId: memberId)
+    }
+    
+    public func executeFetchProfileImageUrlString(memberId: String) -> String {
+        return postCommentRepository.fetchProfileImageUrlString(memberId: memberId)
     }
 }

--- a/14th-team5-iOS/Domain/Sources/PostComment/UseCase/PostCommentUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/PostComment/UseCase/PostCommentUseCase.swift
@@ -1,0 +1,36 @@
+//
+//  PostCommentUseCase.swift
+//  Domain
+//
+//  Created by 김건우 on 1/22/24.
+//
+
+import Foundation
+
+import RxSwift
+
+public protocol PostCommentUseCaseProtocol {
+    func executeFetchPostComment(postId: String, query: PostCommentPaginationQuery) -> Observable<PaginationResponsePostCommentResponse?>
+    func executeCreatePostComment(postId: String, body: CreatePostCommentBody) -> Observable<PostCommentResponse?>
+    func executeDeletePostComment(postId: String, commentId: String) -> Observable<PostCommentDeleteResponse?>
+}
+
+public final class PostCommentUseCase: PostCommentUseCaseProtocol {
+    private let postCommentRepository: PostCommentRepositoryProtocol
+    
+    public init(postCommentRepository: PostCommentRepositoryProtocol) {
+        self.postCommentRepository = postCommentRepository
+    }
+    
+    public func executeFetchPostComment(postId: String, query: PostCommentPaginationQuery) -> Observable<PaginationResponsePostCommentResponse?> {
+        return postCommentRepository.fetchPostComment(postId: postId, query: query)
+    }
+    
+    public func executeCreatePostComment(postId: String, body: CreatePostCommentBody) -> Observable<PostCommentResponse?> {
+        return postCommentRepository.createPostComment(postId: postId, body: body)
+    }
+    
+    public func executeDeletePostComment(postId: String, commentId: String) -> Observable<PostCommentDeleteResponse?> {
+        return postCommentRepository.deletePostComment(postId: postId, commentId: commentId)
+    }
+}


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 임시 댓글 버튼 구현(홈 및 캘린더, 각 셀의 좌측 하단)
- 댓글 Fetch 및 Create 통신 로직 구현

## 스크린샷 📷

| 이미지 | 이미지 |
| :--: | :-------: |
|  ![IMG_0275](https://github.com/depromeet/14th-team5-iOS/assets/21079970/1826ba27-e01f-4040-8f75-4a679d0fcbf7) |   ![IMG_0274](https://github.com/depromeet/14th-team5-iOS/assets/21079970/7b36bb12-15f8-4355-92bd-ce2786794111)        |

## 테스트 케이스 ✅

- [ ] 댓글 시트를 열 때, 댓글이 잘 불러와지는지
- [ ] 코멘트를 입력하면 '등록' 버튼을 클릭하면 제대로 업로드가 되는지

develop_MVP로 머지함
close #310


