### PR TITLE
feat: 댓글 delete 로직 및 시트 동작 구현

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -190,7 +190,6 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
                     } else {
                         sheet.detents = [.medium(), .large()]
                     }
-                    sheet.prefersGrabberVisible = true
                     sheet.prefersScrollingExpandsWhenScrolledToEdge = false
                 }
                 

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -179,6 +179,21 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
                     postId: $0.1.0,
                     commentCount: $0.1.1
                 ).makeViewController()
+                
+                if let sheet = postCommentVC.sheetPresentationController {
+                    if #available(iOS 16.0, *) {
+                        let customId = UISheetPresentationController.Detent.Identifier("customId")
+                        let customDetents = UISheetPresentationController.Detent.custom(identifier: customId) {
+                            return $0.maximumDetentValue * 0.85
+                        }
+                        sheet.detents = [customDetents, .large()]
+                    } else {
+                        sheet.detents = [.medium(), .large()]
+                    }
+                    sheet.prefersGrabberVisible = true
+                    sheet.prefersScrollingExpandsWhenScrolledToEdge = false
+                }
+                
                 $0.0.present(postCommentVC, animated: true)
             }
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
@@ -178,6 +178,7 @@ final public class PostCommentViewReactor: Reactor {
             }
             dataSource.items.append(reactor)
             newState.displayComment = [dataSource]
+            newState.commentCount = dataSource.items.count
             
         case let .removePostComment(commentId):
             guard var dataSource = newState.displayComment.first else {
@@ -187,6 +188,7 @@ final public class PostCommentViewReactor: Reactor {
                 $0.currentState.commentId == commentId
             })
             newState.displayComment = [dataSource]
+            newState.commentCount = dataSource.items.count
             
         case .scrollToLast:
             guard var dataSource = newState.displayComment.first else {

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
@@ -171,6 +171,7 @@ final public class PostCommentViewReactor: Reactor {
             
         case let .injectPostComment(reactor):
             newState.displayComment = [.init(model: .none, items: reactor)]
+            newState.commentCount = reactor.count
             
         case let .appendPostComment(reactor):
             guard var dataSource = newState.displayComment.first else {

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/View/PostCommentTopBarView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/View/PostCommentTopBarView.swift
@@ -13,6 +13,8 @@ import SnapKit
 
 final class PostCommentTopBarView: UIView {
     // MARK: - Views
+    private let grabber: UIView = UIView()
+    
     private let titleLabel: BibbiLabel = BibbiLabel(.body1Bold)
     private let barDividerView: UIView = UIView()
     
@@ -30,12 +32,20 @@ final class PostCommentTopBarView: UIView {
     
     // MARK: - Helpers
     func setupUI() {
-        self.addSubviews(titleLabel, barDividerView)
+        self.addSubviews(grabber, titleLabel, barDividerView)
     }
     
     func setupAutoLayout() {
+        grabber.snp.makeConstraints {
+            $0.width.equalTo(36)
+            $0.height.equalTo(5.08)
+            $0.centerX.equalToSuperview()
+            $0.top.equalToSuperview().offset(6)
+        }
+        
         titleLabel.snp.makeConstraints {
-            $0.center.equalToSuperview()
+            $0.centerX.equalToSuperview()
+            $0.bottom.equalToSuperview().offset(-12)
         }
         
         barDividerView.snp.makeConstraints {
@@ -46,12 +56,18 @@ final class PostCommentTopBarView: UIView {
     }
     
     func setupAttributes() {
+        grabber.do {
+            $0.layer.masksToBounds = true
+            $0.layer.cornerRadius = 5.08 / 2.0
+            $0.backgroundColor = UIColor.gray500
+        }
+        
         titleLabel.do {
             $0.text = "댓글"
         }
         
         barDividerView.do {
-            $0.backgroundColor = .gray700
+            $0.backgroundColor = UIColor.gray700
         }
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
@@ -52,13 +52,16 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        commentTableView.rx.tap
-            .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
-            .withUnretained(self)
-            .subscribe {
-                $0.0.commentTextField.resignFirstResponder()
-            }
-            .disposed(by: disposeBag)
+        Observable.merge(
+            commentTableView.rx.tap.asObservable(),
+            noCommentLabel.rx.tap.asObservable()
+        )
+        .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
+        .withUnretained(self)
+        .subscribe {
+            $0.0.commentTextField.resignFirstResponder()
+        }
+        .disposed(by: disposeBag)
         
         commentTextField.rx.text.orEmpty
             .skip(while: { $0.isEmpty })

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
@@ -98,7 +98,7 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
     }
     
     private func bindOutput(reactor: PostCommentViewReactor) {
-        reactor.state.map { $0.commentCount >= 0 }
+        reactor.state.map { $0.commentCount != 0 }
             .distinctUntilChanged()
             .bind(to: noCommentLabel.rx.isHidden)
             .disposed(by: disposeBag)
@@ -174,8 +174,8 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
         super.setupAutoLayout()
         
         navigationBarView.snp.makeConstraints {
-            $0.height.equalTo(42)
-            $0.top.equalTo(view.safeAreaLayoutGuide).offset(18)
+            $0.height.equalTo(60)
+            $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
         

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/EmojiReactor.swift
@@ -110,7 +110,7 @@ extension EmojiReactor {
 
         case .tappedCommentButton:
             let postId: String = currentState.post.postId
-            let commentCount: Int = 3
+            let commentCount: Int = currentState.post.commentCount
             provider.postGlobalState.presentPostCommentSheet(postId, commentCount: commentCount)
             return Observable<Mutation>.empty()
         }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostReactor.swift
@@ -32,7 +32,7 @@ final class PostReactor: Reactor {
         let originPostLists: PostSection.Model
         
         var isPop: Bool = false
-        var selectedPost: PostListData = .init(postId: "", author: .init(memberId: "", profileImageURL: "", name: ""), emojiCount: 0, imageURL: "", content: "", time: "")
+        var selectedPost: PostListData = .init(postId: "", author: .init(memberId: "", profileImageURL: "", name: ""), commentCount: 0, emojiCount: 0, imageURL: "", content: "", time: "")
         
         @Pulse var fetchedPost: PostData? = nil
         @Pulse var reactionMemberIds: [String] = []

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyAuthorizationTableViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyAuthorizationTableViewCell.swift
@@ -42,7 +42,7 @@ public final class PrivacyAuthorizationTableViewCell: BaseTableViewCell<PrivacyC
         
         arrowAccessView.do {
             $0.contentMode = .scaleToFill
-            $0.image = DesignSystemAsset.arrow.image
+            $0.image = DesignSystemAsset.arrowLeft.image
         }
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyTableViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/Cell/PrivacyTableViewCell.swift
@@ -36,7 +36,7 @@ public final class PrivacyTableViewCell: BaseTableViewCell<PrivacyCellReactor> {
         
         arrowAccessView.do {
             $0.contentMode = .scaleToFill
-            $0.image = DesignSystemAsset.arrow.image
+            $0.image = DesignSystemAsset.arrowLeft.image
         }
         
         descrptionLabel.do {

--- a/14th-team5-iOS/Core/Sources/GlobalState/PostGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/GlobalState/PostGlobalState.swift
@@ -14,17 +14,27 @@ public enum PostEvent {
 }
 
 public protocol PostGlobalStateType {
+    var input: BehaviorSubject<(String, String)> { get }
     var event: PublishSubject<PostEvent> { get }
     
     @discardableResult
     func presentPostCommentSheet(_ postId: String, commentCount: Int) -> Observable<Int>
+    @discardableResult
+    func storeCommentText(_ postId: String, text: String) -> Observable<(String, String)>
 }
 
 final public class PostGlobalState: BaseGlobalState, PostGlobalStateType {
+    public var input: BehaviorSubject<(String, String)> = BehaviorSubject<(String, String)>(value: ("", ""))
     public var event: PublishSubject<PostEvent> = PublishSubject<PostEvent>()
     
     public func presentPostCommentSheet(_ postId: String, commentCount: Int) -> Observable<Int> {
         event.onNext(.presentPostCommentSheet(postId, commentCount))
         return Observable<Int>.just(commentCount)
+    }
+    
+    public func storeCommentText(_ postId: String, text: String) -> Observable<(String, String)> {
+        debugPrint("텍스트 저장됨 \(postId), \(text)")
+        input.onNext((postId, text))
+        return Observable<(String, String)>.just((postId, text))
     }
 }

--- a/14th-team5-iOS/Data/Sources/Post/PostList/DTO/PostListDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Post/PostList/DTO/PostListDTO.swift
@@ -29,7 +29,15 @@ struct PostListDTO: Codable {
 extension PostListDTO {
     func toDomain() -> PostListData {
         let author = FamilyUserDefaults.loadMemberFromUserDefaults(memberId: authorId)
-        return .init(postId: postId, author: author, emojiCount: emojiCount, imageURL: imageUrl, content: content, time: createdAt)
+        return .init(
+            postId: postId,
+            author: author,
+            commentCount: commentCount,
+            emojiCount: emojiCount,
+            imageURL: imageUrl,
+            content: content,
+            time: createdAt
+        )
     }
 }
 

--- a/14th-team5-iOS/Domain/Sources/Post/PostList/Entities/PostListData.swift
+++ b/14th-team5-iOS/Domain/Sources/Post/PostList/Entities/PostListData.swift
@@ -10,14 +10,16 @@ import Foundation
 public struct PostListData: Equatable {
     public let postId: String
     public let author: ProfileData?
+    public let commentCount: Int
     public let emojiCount: Int
     public let imageURL: String
     public let content: String?
     public let time: String
     
-    public init(postId: String, author: ProfileData?, emojiCount: Int, imageURL: String, content: String?, time: String) {
+    public init(postId: String, author: ProfileData?, commentCount: Int, emojiCount: Int, imageURL: String, content: String?, time: String) {
         self.postId = postId
         self.author = author
+        self.commentCount = commentCount
         self.emojiCount = emojiCount
         self.imageURL = imageURL
         self.content = content

--- a/Bibbi.xcworkspace/contents.xcworkspacedata
+++ b/Bibbi.xcworkspace/contents.xcworkspacedata
@@ -75,6 +75,9 @@
          location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/kakao-ios-sdk/KakaoOpenSDK.xcodeproj">
       </FileRef>
       <FileRef
+         location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/lottie-ios/Lottie.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/mixpanel-swift/Mixpanel.xcodeproj">
       </FileRef>
       <FileRef

--- a/Bibbi.xcworkspace/xcshareddata/xcschemes/Bibbi-Workspace.xcscheme
+++ b/Bibbi.xcworkspace/xcshareddata/xcschemes/Bibbi-Workspace.xcscheme
@@ -560,6 +560,34 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "11789D24A0490E463CDA3C81"
+               BuildableName = "Lottie.framework"
+               BlueprintName = "Lottie"
+               ReferencedContainer = "container:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/lottie-ios/Lottie.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2BF4F5BDA824781BEE220881"
+               BuildableName = "Lottie_Lottie.bundle"
+               BlueprintName = "Lottie_Lottie"
+               ReferencedContainer = "container:Tuist/Dependencies/SwiftPackageManager/.build/checkouts/lottie-ios/Lottie.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "0A4E95A8DF53D3C3DEDA2BCF"
                BuildableName = "Mixpanel.framework"
                BlueprintName = "Mixpanel"

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -23,7 +23,8 @@ let dependencies = Dependencies(
         .kingFisher,
         .fsCalendar,
         .keyChainWrapper,
-        .mixPanel
+        .mixPanel,
+        .lottie
     ], productTypes: [
         "FSCalendar": .framework,
         "Firebase": .framework

--- a/Tuist/ProjectDescriptionHelpers/ModuleType+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/ModuleType+Templates.swift
@@ -45,7 +45,8 @@ public enum ModuleLayer: String, CaseIterable, ModuleType {
                 .external(name: "Mixpanel"),
                 .with(.Core),
                 .with(.Data),
-                .external(name: "ReactorKit")
+                .external(name: "ReactorKit"),
+                .external(name: "Lottie")
             ]
         case .Data:
             return [

--- a/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Package+Templates.swift
@@ -28,4 +28,5 @@ extension Package {
     public static let fsCalendar = Package.remote(repo: "WenchaoD/FSCalendar", version: "2.8.3")
     public static let keyChainWrapper = Package.remote(repo: "jrendel/SwiftKeychainWrapper", version: "4.0.0")
     public static let mixPanel = Package.remote(repo: "mixpanel/mixpanel-swift", version: "4.2.0")
+    public static let lottie = Package.remote(repo: "airbnb/lottie-ios", version: "4.4.0")
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 댓글 delete 로직 구현
- 댓글 시트 Detent 동작 구현, Comment 텍스트필드 제약 조건 수정
- 특정 조건에서 댓글 테이블 뷰가 ScrollToLast 로직을 수행하도록 구현
- Comment 텍스트필드에 작성한 텍스트 저장 로직 구현 (최대 이전 1개)

- 댓글이 없으면 NoCommentLabel이 뜨지 않는 문제 수정

## 스크린샷 📷

| 이미지 | 이미지 |
| :--: | :-------: |
|   |           |

## 테스트 케이스 ✅

- [x] 내가 작성한 댓글이 제대로 삭제가 되는지
- [x] 시트의 동작이 정확한지, UI가 올바르게 배치되었는지

develop_MVP로 머지함
close #317 