### PR TITLE
feat: 가족 생성 날짜 API 호출 로직 구현, 캘린더 생성 로직 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarViewReactor.swift
@@ -17,7 +17,7 @@ public final class CalendarViewReactor: Reactor {
     // MARK: - Action
     public enum Action {
         case popViewController
-        case addYearMonthItem(String)
+        case addCalendarItem([String])
     }
     
     // MARK: - Mutation
@@ -25,7 +25,7 @@ public final class CalendarViewReactor: Reactor {
         case popViewController
         case pushCalendarPostVC(Date)
         case makeCalendarPopoverVC(UIView)
-        case injectYearMonthItem(String)
+        case injectYearMonthItem([String])
     }
     
     // MARK: - State
@@ -79,7 +79,7 @@ public final class CalendarViewReactor: Reactor {
             provider.toastGlobalState.clearLastSelectedDate()
             return Observable<Mutation>.just(.popViewController)
             
-        case let .addYearMonthItem(yearMonth):
+        case let .addCalendarItem(yearMonth):
             return Observable<Mutation>.just(.injectYearMonthItem(yearMonth))
             
         }
@@ -98,16 +98,14 @@ public final class CalendarViewReactor: Reactor {
         case let .makeCalendarPopoverVC(sourceView):
             newState.shouldPresnetInfoPopover = sourceView
             
-        case let .injectYearMonthItem(yearMonth):
+        case let .injectYearMonthItem(dateArray):
             guard let datasource: SectionOfMonthlyCalendar = state.displayCalendar.first else {
                 return state
             }
             
-            let oldItems = datasource.items
-            let newItems = SectionOfMonthlyCalendar(items: [yearMonth])
             let newDatasource = SectionOfMonthlyCalendar(
                 original: datasource,
-                items: oldItems + newItems.items
+                items: dateArray
             )
             newState.displayCalendar = [newDatasource]
         }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -67,7 +67,7 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        let previousNextMonths: [String] = reactor.currentState.selectedDate.generatePreviousNextYearMonth()
+        let previousNextMonths: [String] = reactor.currentState.selectedDate.createPreviousNextDateStringArray()
         Observable<String>.from(previousNextMonths)
             .map { Reactor.Action.fetchCalendarResponse($0) }
             .bind(to: reactor.action)

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -369,7 +369,6 @@ extension CalendarPostViewController {
             if fractionPart <= 0.0 {
                 let index: Int = Int(floorPosition)
                 cellIndexRelay.accept(index)
-                debugPrint("cellIndexRelay: \(index)")
             }
         }
         
@@ -390,15 +389,14 @@ extension CalendarPostViewController {
     }
     
     private func setupBlurEffect() {
-        let blurEffect = UIBlurEffect(style: .systemThickMaterialDark)
+        let blurEffect = UIBlurEffect(style: .systemThinMaterialDark)
         let visualEffectView = UIVisualEffectView(effect: blurEffect)
-        visualEffectView.alpha = 0.95
         visualEffectView.frame = view.frame
         blurImageView.insertSubview(visualEffectView, at: 0)
     }
     
     private func setupNavigationTitle(_ date: Date) {
-        navigationBarView.navigationTitle = DateFormatter.yyyyMM.string(from: date)
+        navigationBarView.navigationTitle = date.toFormatString(with: .yyyyM)
     }
     
     private func adjustWeeklyCalendarRect(_ bounds: CGRect) {

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -5,9 +5,9 @@
 //  Created by 김건우 on 12/6/23.
 //
 
+import Core
 import UIKit
 
-import Core
 import FSCalendar
 import ReactorKit
 import RxCocoa
@@ -60,16 +60,16 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
             }
             .disposed(by: disposeBag)
         
-        let yearMonthArray: [String] = Date.for20240101.generateYearMonthStringsToToday()
-        Observable<String>.from(yearMonthArray)
-            .map { Reactor.Action.addYearMonthItem($0) }
+        App.Repository.member.familyCreatedAt
+            .map {
+                guard let createdAt = $0 else {
+                    return Date.for20230101.createDateStringArray()
+                }
+                return createdAt.createDateStringArray()
+            }
+            .map { Reactor.Action.addCalendarItem($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-//        Observable<Void>.just(())
-//            .map { Reactor.Action.fetchFamilyMembers }
-//            .bind(to: reactor.action)
-//            .disposed(by: disposeBag)
 
         navigationBarView.rx.didTapLeftBarButton
             .map { _ in Reactor.Action.popViewController }

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/InputFamilyLinkReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/InputFamilyLinkReactor.swift
@@ -62,6 +62,7 @@ extension InputFamilyLinkReactor {
             
             let commonLogic: (JoinFamilyResponse) -> Observable<InputFamilyLinkReactor.Mutation> = { joinFamilyData in
                 App.Repository.member.familyId.accept(joinFamilyData.familyId)
+                App.Repository.member.familyCreatedAt.accept(joinFamilyData.createdAt)
                 return Observable.just(Mutation.setShowHome(true))
             }
 

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/InputFamilyLinkReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/InputFamilyLinkReactor.swift
@@ -61,8 +61,8 @@ extension InputFamilyLinkReactor {
             let body = JoinFamilyRequest(inviteCode: String(code))
             
             let commonLogic: (JoinFamilyResponse) -> Observable<InputFamilyLinkReactor.Mutation> = { joinFamilyData in
-                App.Repository.member.familyId.accept(joinFamilyData.familyId)
-                App.Repository.member.familyCreatedAt.accept(joinFamilyData.createdAt)
+//                App.Repository.member.familyId.accept(joinFamilyData.familyId)
+//                App.Repository.member.familyCreatedAt.accept(joinFamilyData.createdAt)
                 return Observable.just(Mutation.setShowHome(true))
             }
 

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/JoinFamilyReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/JoinFamilyReactor.swift
@@ -7,6 +7,7 @@
 
 import Core
 import Domain
+import Foundation
 
 import ReactorKit
 
@@ -51,6 +52,7 @@ extension JoinFamilyReactor {
                     guard let familyResponse: CreateFamilyResponse = $0 else {
                         return Observable.just(Mutation.setShowHome(false))
                     }
+                    App.Repository.member.familyCreatedAt.accept(familyResponse.createdAt)
                     App.Repository.member.familyId.accept(familyResponse.familyId)
                     return Observable.just(Mutation.setShowHome(true))
                 }

--- a/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/JoinFamilyReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/JoinFamily/Reactor/JoinFamilyReactor.swift
@@ -52,8 +52,8 @@ extension JoinFamilyReactor {
                     guard let familyResponse: CreateFamilyResponse = $0 else {
                         return Observable.just(Mutation.setShowHome(false))
                     }
-                    App.Repository.member.familyCreatedAt.accept(familyResponse.createdAt)
-                    App.Repository.member.familyId.accept(familyResponse.familyId)
+//                    App.Repository.member.familyCreatedAt.accept(familyResponse.createdAt)
+//                    App.Repository.member.familyId.accept(familyResponse.familyId)
                     return Observable.just(Mutation.setShowHome(true))
                 }
         case .joinFamily:

--- a/14th-team5-iOS/App/Sources/Presentation/Splash/Dependency/SplashDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Splash/Dependency/SplashDIContainer.swift
@@ -26,7 +26,15 @@ public final class SplashDIContainer {
         return MeUseCase(meRepository: makeMeRepository())
     }
     
+    public func makeFamilyRepository() -> FamilyRepositoryProtocol {
+        return FamilyRepository()
+    }
+    
+    public func makeFamilyUseCase() -> FamilyUseCaseProtocol {
+        return FamilyUseCase(familyRepository: makeFamilyRepository())
+    }
+    
     public func makeReactor() -> Reactor {
-        return SplashViewReactor(meRepository: makeMeUseCase())
+        return SplashViewReactor(meRepository: makeMeUseCase(), familyUseCase: makeFamilyUseCase())
     }
 }

--- a/14th-team5-iOS/Core/Sources/Extensions/Date+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Date+Ext.swift
@@ -136,44 +136,32 @@ extension Date {
 }
 
 extension Date {
-    public func generatePreviousNextYearMonth() -> [String] {
-        var yearMonthStrings: [String] = []
+    public func createDateStringArray(to date: Date = Date()) -> [String] {
+        var dateArray: [String] = []
         
-        for month in -1...1 {
-            if let date = calendar.date(
-                byAdding: .month,
-                value: month,
-                to: self
-            ) {
+        let interval = self.interval([.month], to: date)[.month]!
+        
+        for month in 0...interval {
+            if let date = calendar.date(byAdding: .month, value: month, to: self) {
                 let yyyyMM = date.toFormatString(with: .dashYyyyMM)
-                yearMonthStrings.append(yyyyMM)
+                dateArray.append(yyyyMM)
             }
         }
-        
-        return yearMonthStrings
+
+        return dateArray
     }
     
-    public func generateYearMonthStringsToToday() -> [String] {
-        let currentDate: Date = Date()
+    public func createPreviousNextDateStringArray() -> [String] {
+        var dateArray: [String] = []
         
-        var yearMonthStrings: [String] = []
-        
-        let monthInterval = self.interval(
-            [.month],
-            to: currentDate
-        )[.month]!
-        for month in 0...monthInterval {
-            if let date = calendar.date(
-                byAdding: .month,
-                value: month,
-                to: self
-            ) {
+        for month in -1...1 {
+            if let date = calendar.date(byAdding: .month, value: month, to: self) {
                 let yyyyMM = date.toFormatString(with: .dashYyyyMM)
-                yearMonthStrings.append(yyyyMM)
+                dateArray.append(yyyyMM)
             }
         }
         
-        return yearMonthStrings
+        return dateArray
     }
 }
 

--- a/14th-team5-iOS/Core/Sources/Extensions/DateFormatter+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/DateFormatter+Ext.swift
@@ -52,7 +52,9 @@ extension DateFormatter {
 
 extension DateFormatter {
     public enum format {
+        case m
         case mm
+        case yyyyM
         case yyyyMM
         case yyyyMMdd
         case dashYyyyMM
@@ -63,8 +65,12 @@ extension DateFormatter {
         
         public var type: String {
             switch self {
+            case .m:
+                return "M월"
             case .mm:
                 return "MM월"
+            case .yyyyM:
+                return "yyyy년 M월"
             case .yyyyMM:
                 return "yyyy년 MM월"
             case .yyyyMMdd:

--- a/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
@@ -80,9 +80,9 @@ extension Reactive where Base: UILabel {
         Binder(self.base) { label, date in
             var formatString: String = .none
             if date.isEqual([.year], with: Date()) {
-                formatString = date.toFormatString(with: .mm)
+                formatString = date.toFormatString(with: .m)
             } else {
-                formatString = date.toFormatString(with: .yyyyMM)
+                formatString = date.toFormatString(with: .yyyyM)
             }
             label.text = formatString
         }

--- a/14th-team5-iOS/Data/Sources/Family/FamilyAPI/DataMapping/JoinFamilyResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Family/FamilyAPI/DataMapping/JoinFamilyResponseDTO.swift
@@ -15,6 +15,9 @@ struct JoinFamilyResponseDTO: Decodable {
 
 extension JoinFamilyResponseDTO {
     func toDomain() -> JoinFamilyResponse {
-        return .init(familyId: familyId)
+        return .init(
+            familyId: familyId,
+            createdAt: createdAt.iso8601ToDate()
+        )
     }
 }

--- a/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
@@ -35,7 +35,10 @@ extension FamilyRepository {
     public func joinFamily(body: JoinFamilyRequest) -> Observable<JoinFamilyResponse?> {
         let body = JoinFamilyRequestDTO(inviteCode: body.inviteCode)
         return familyApiWorker.joinFamily(body: body)
-            .do(onSuccess: { App.Repository.member.familyId.accept($0?.familyId) })
+            .do(onSuccess: { 
+                App.Repository.member.familyId.accept($0?.familyId)
+                App.Repository.member.familyCreatedAt.accept($0?.createdAt)
+            })
             .asObservable()
     }
     
@@ -46,6 +49,10 @@ extension FamilyRepository {
     
     public func createFamily() -> Observable<CreateFamilyResponse?> {
         return familyApiWorker.createFamily()
+            .do(onSuccess: {
+                App.Repository.member.familyId.accept($0?.familyId)
+                App.Repository.member.familyCreatedAt.accept($0?.createdAt)
+            })
             .asObservable()
     }
     

--- a/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Family/Repository/FamilyRepository.swift
@@ -55,6 +55,12 @@ extension FamilyRepository {
             .asObservable()
     }
     
+    public func fetchFamilyCreatedAt(_ familyId: String) -> Observable<FamilyCreatedAtResponse?> {
+        return familyApiWorker.fetchFamilyCreatedAt(familyId: familyId)
+            .do(onSuccess: { App.Repository.member.familyCreatedAt.accept($0?.createdAt) })
+            .asObservable()
+    }
+    
     public func fetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?> {
         return familyApiWorker.fetchInvitationUrl(familyId: familyId)
             .asObservable()

--- a/14th-team5-iOS/Domain/Sources/Family/Entities/JoinFamilyResponse.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/Entities/JoinFamilyResponse.swift
@@ -9,8 +9,10 @@ import Foundation
 
 public struct JoinFamilyResponse {
     public var familyId: String
+    public var createdAt: Date
     
-    public init(familyId: String) {
+    public init(familyId: String, createdAt: Date) {
         self.familyId = familyId
+        self.createdAt = createdAt
     }
 }

--- a/14th-team5-iOS/Domain/Sources/Family/Interfaces/Repositories/FamilyRepository.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/Interfaces/Repositories/FamilyRepository.swift
@@ -16,6 +16,7 @@ public protocol FamilyRepositoryProtocol {
     func resignFamily() -> Observable<AccountFamilyResignResponse?>
     func createFamily() -> Observable<CreateFamilyResponse?>
     func fetchFamilyCreatedAt() -> Observable<FamilyCreatedAtResponse?>
+    func fetchFamilyCreatedAt(_ familyId: String) -> Observable<FamilyCreatedAtResponse?>
     func fetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?>
     func fetchPaginationFamilyMembers(query: FamilyPaginationQuery) -> Observable<PaginationResponseFamilyMemberProfile?>
     func fetchPaginationFamilyMembers(memberIds: [String]) -> [ProfileData]

--- a/14th-team5-iOS/Domain/Sources/Family/UseCases/FamilyUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Family/UseCases/FamilyUseCase.swift
@@ -14,6 +14,7 @@ public protocol FamilyUseCaseProtocol {
     func executeResignFamily() -> Observable<AccountFamilyResignResponse?>
     func executeCreateFamily() -> Observable<CreateFamilyResponse?>
     func executeFetchCreatedAtFamily() -> Observable<FamilyCreatedAtResponse?>
+    func executeFetchCreatedAtFamily(_ familyId: String) -> Observable<FamilyCreatedAtResponse?>
     func executeFetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?>
     func executeFetchPaginationFamilyMembers(query: FamilyPaginationQuery) -> Observable<PaginationResponseFamilyMemberProfile?>
     func executeFetchPaginationFamilyMembers(memberIds: [String]) -> [ProfileData]
@@ -40,6 +41,10 @@ public final class FamilyUseCase: FamilyUseCaseProtocol {
     
     public func executeFetchCreatedAtFamily() -> Observable<FamilyCreatedAtResponse?> {
         return familyRepository.fetchFamilyCreatedAt()
+    }
+    
+    public func executeFetchCreatedAtFamily(_ familyId: String) -> Observable<FamilyCreatedAtResponse?> {
+        return familyRepository.fetchFamilyCreatedAt(familyId)
     }
     
     public func executeFetchInvitationUrl() -> Observable<FamilyInvitationLinkResponse?> {


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- Splash 화면에 가족 생성 날짜 API 호출 로직 구현
- JoinFamily 화면에서 가족 생성 및 참여 시 가족 생성 날짜를 저장하도록 로직 구현
- Calendar 화면에서 캘린더 생성 로직 수정

## 테스트 케이스 ✅

- [x] 스플래시가 문제없이 잘 작동하는지
- [x] 캘린더가 의도한대로 제대로 생성되는지

close #397 
close #409


