### PR TITLE
fix: CameraDiplayViewController 텍스트 입력 이슈 or ProfileView Feed 강제 Crash 수정

### DIFF
--- a/14th-team5-iOS/App/Project.swift
+++ b/14th-team5-iOS/App/Project.swift
@@ -19,7 +19,7 @@ private let targets: [Target] = [
                 "CFBundleDisplayName": .string("Bibbi"),
                 "CFBundleVersion": .string("1"),
                 "CFBuildVersion": .string("0"),
-                "CFBundleShortVersionString": .string("1.1.6"),
+                "CFBundleShortVersionString": .string("1.1.7"),
                 "UILaunchStoryboardName": .string("LaunchScreen.storyboard"),
                 "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),
                 "UIUserInterfaceStyle": .string("Light"),

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -60,16 +60,16 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
             }
             .disposed(by: disposeBag)
         
-        App.Repository.member.familyCreatedAt
+        
+        Observable<Date>
+            .just(Date())
             .map {
-                guard let createdAt = $0 else {
-                    return Date.for20230101.createDateStringArray()
-                }
-                return createdAt.createDateStringArray()
+                return $0.createDateStringArray()
             }
-            .map { Reactor.Action.addCalendarItem($0) }
+            .map { Reactor.Action.addCalendarItem($0)}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+         
 
         navigationBarView.rx.didTapLeftBarButton
             .map { _ in Reactor.Action.popViewController }

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
@@ -231,12 +231,19 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
         
         displayEditTextField.rx
             .text.orEmpty
-            .distinctUntilChanged()
             .filter { !$0.isEmpty }
             .filter { $0.count <= 8 && !$0.contains(" ") }
             .observe(on: MainScheduler.instance)
+            .distinctUntilChanged()
             .map { Reactor.Action.fetchDisplayImage($0) }
             .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        displayEditTextField.rx
+            .text.orEmpty
+            .filter { $0.contains(" ")}
+            .map { $0.trimmingCharacters(in: .whitespaces)}
+            .bind(to: displayEditTextField.rx.text)
             .disposed(by: disposeBag)
         
         displayEditTextField.rx

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/Reactor/PrivacyViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/Reactor/PrivacyViewReactor.swift
@@ -64,7 +64,7 @@ public final class PrivacyViewReactor: Reactor {
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .viewDidLoad:
-            let appKey: String = "32215db9-5bd3-48d4-8f06-243ae1eb6352"
+            let appKey: String = "7c5aaa36-570e-491f-b18a-26a1a0b72959"
             let bibbiAppInfoParameter: BibbiAppInfoParameter = BibbiAppInfoParameter(appKey: appKey)
             return .concat(
                 .just(.setLoading(true)),

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
@@ -247,7 +247,6 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
         
         profileFeedCollectionView.rx.itemSelected
             .withLatestFrom(reactor.pulse(\.$feedResultItem)) { indexPath, feedResultItem in
-                print("Index path Selected: \(indexPath) or feedResultItem: \(feedResultItem)")
                 return (indexPath, feedResultItem)
             }
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
@@ -263,7 +262,7 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
             )
             .withUnretained(self)
             .filter { !$0.1.0.items.isEmpty }
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
             .subscribe {
                 guard let indexPath = $0.1.1 else { return }
                 let postListViewController = PostListsDIContainer().makeViewController(postLists: $0.1.0, selectedIndex: indexPath)

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -219,7 +219,6 @@ public final class ProfileViewReactor: Reactor {
                     paginationItems.forEach {
                         sectionItem.append(.feedCategoryItem(ProfileFeedCellReactor(imageURL: $0.imageUrl, emojiCount: $0.emojiCount, date: $0.createdAt.toDate(with: "yyyy-MM-dd'T'HH:mm:ssZ").relativeFormatter(), commentCount: $0.commentCount, content: $0.content.map { "\($0)"})))
                     }
-                    print("current 페이지네이션 Item: \(paginationItems)")
                     return .concat(
                         .just(.setLoading(false)),
                         .just(.setProfilePostItems(entity)),
@@ -259,8 +258,6 @@ public final class ProfileViewReactor: Reactor {
                     )
                 )
             }
-            print("postSection: \(postSection)")
-
             return .just(.setProfileData(postSection, indexPath))
         }
     }
@@ -277,7 +274,6 @@ public final class ProfileViewReactor: Reactor {
             newState.feedSection[sectionIndex] = .feedCategory(section)
         case let .setProfilePostItems(entity):
             newState.profilePostEntity = entity
-            print("profilePost Entity: \(newState.profilePostEntity)")
         case let .setProfileMemberItems(entity):
             provider.profileGlobalState.refreshFamilyMembers()
             newState.profileMemberEntity = entity
@@ -291,7 +287,6 @@ public final class ProfileViewReactor: Reactor {
             
         case let .setFeedResultItems(feedResultItem):
             newState.feedResultItem = feedResultItem
-            print("Feed ResultItems: \(feedResultItem)")
         }
         
         return newState

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -25,13 +25,14 @@ public final class ProfileViewReactor: Reactor {
         case fetchMorePostItems(Bool)
         case didSelectPHAssetsImage(Data)
         case didTapInitProfile
-        case didTapProfilePost(IndexPath, ProfilePostResponse)
+        case didTapProfilePost(IndexPath, [ProfilePostResultResponse])
     }
     
     public enum Mutation {
         case setLoading(Bool)
         case setProfilePresingedURL(CameraDisplayImageResponse?)
         case setFeedCategroySection([ProfileFeedSectionItem])
+        case setFeedResultItems([ProfilePostResultResponse])
         case setProfileMemberItems(ProfileMemberResponse?)
         case setProfilePostItems(ProfilePostResponse)
         case setProfileData(PostSection.Model, IndexPath)
@@ -43,6 +44,7 @@ public final class ProfileViewReactor: Reactor {
         var isUser: Bool
         @Pulse var profileData: PostSection.Model
         @Pulse var selectedIndexPath: IndexPath?
+        @Pulse var feedResultItem: [ProfilePostResultResponse]
         @Pulse var feedSection: [ProfileFeedSectionModel]
         @Pulse var profileMemberEntity: ProfileMemberResponse?
         @Pulse var profilePostEntity: ProfilePostResponse?
@@ -60,7 +62,8 @@ public final class ProfileViewReactor: Reactor {
             profileData: PostSection.Model(
                 model: 0, items: []
             ),
-            selectedIndexPath: nil,
+            selectedIndexPath: nil, 
+            feedResultItem: [],
             feedSection: [.feedCategory([])],
             profileMemberEntity: nil,
             profilePresingedURLEntity: nil
@@ -100,10 +103,11 @@ public final class ProfileViewReactor: Reactor {
                         }
                         return .concat(
                             .just(.setProfilePostItems(entity)),
+                            .just(.setFeedResultItems(entity.results)),
                             .just(.setFeedCategroySection(sectionItem)),
                             .just(.setLoading(true))
                         )
-
+                        
                     }
             )
         case let .updateNickNameProfile(nickNameFileData):
@@ -132,7 +136,7 @@ public final class ProfileViewReactor: Reactor {
                                                 .just(.setProfilePresingedURL(entity)),
                                                 .just(.setProfileMemberItems(memberEntity)),
                                                 .just(.setLoading(true))
-                                            
+                                                
                                             )
                                         }
                                 } else {
@@ -154,10 +158,10 @@ public final class ProfileViewReactor: Reactor {
                                 .just(.setLoading(true))
                             )
                     }
-            
+                
             )
             
-        
+            
             
             
         case let .didSelectPHAssetsImage(fileData):
@@ -186,7 +190,7 @@ public final class ProfileViewReactor: Reactor {
                                                 .just(.setProfilePresingedURL(entity)),
                                                 .just(.setProfileMemberItems(memberEntity)),
                                                 .just(.setLoading(true))
-                                            
+                                                
                                             )
                                         }
                                     
@@ -203,7 +207,6 @@ public final class ProfileViewReactor: Reactor {
         case let .fetchMorePostItems(isPagination):
             query.page += 1
             guard self.currentState.profilePostEntity?.hasNext == true && isPagination else { return .empty() }
-
             return profileUseCase.executeProfilePostItems(query: query, parameters: parameters)
                 .asObservable()
                 .flatMap { entity -> Observable<ProfileViewReactor.Mutation> in
@@ -216,9 +219,11 @@ public final class ProfileViewReactor: Reactor {
                     paginationItems.forEach {
                         sectionItem.append(.feedCategoryItem(ProfileFeedCellReactor(imageURL: $0.imageUrl, emojiCount: $0.emojiCount, date: $0.createdAt.toDate(with: "yyyy-MM-dd'T'HH:mm:ssZ").relativeFormatter(), commentCount: $0.commentCount, content: $0.content.map { "\($0)"})))
                     }
-                    
+                    print("current 페이지네이션 Item: \(paginationItems)")
                     return .concat(
                         .just(.setLoading(false)),
+                        .just(.setProfilePostItems(entity)),
+                        .just(.setFeedResultItems(paginationItems)),
                         .just(.setFeedCategroySection(sectionItem)),
                         .just(.setLoading(true))
                     )
@@ -239,7 +244,7 @@ public final class ProfileViewReactor: Reactor {
         case let .didTapProfilePost(indexPath, postEntity):
             guard let profleEntity = currentState.profileMemberEntity else { return .empty() }
             var postSection: PostSection.Model = .init(model: 0, items: [])
-            postEntity.results.forEach {
+            postEntity.forEach {
                 postSection.items.append(
                     .main(
                         PostListData(
@@ -254,7 +259,7 @@ public final class ProfileViewReactor: Reactor {
                     )
                 )
             }
-            
+            print("postSection: \(postSection)")
 
             return .just(.setProfileData(postSection, indexPath))
         }
@@ -270,9 +275,9 @@ public final class ProfileViewReactor: Reactor {
         case let .setFeedCategroySection(section):
             let sectionIndex = getSection(.feedCategory([]))
             newState.feedSection[sectionIndex] = .feedCategory(section)
-            
         case let .setProfilePostItems(entity):
             newState.profilePostEntity = entity
+            print("profilePost Entity: \(newState.profilePostEntity)")
         case let .setProfileMemberItems(entity):
             provider.profileGlobalState.refreshFamilyMembers()
             newState.profileMemberEntity = entity
@@ -284,6 +289,9 @@ public final class ProfileViewReactor: Reactor {
             newState.profileData = profileData
             newState.selectedIndexPath = indexPath
             
+        case let .setFeedResultItems(feedResultItem):
+            newState.feedResultItem = feedResultItem
+            print("Feed ResultItems: \(feedResultItem)")
         }
         
         return newState

--- a/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyService.swift
+++ b/14th-team5-iOS/App/WidgetExtension/Sources/FamilyWidget/FamilyService.swift
@@ -13,7 +13,7 @@ struct FamilyService {
     func fetchInfo(completion: @escaping (Result<Family?, Error>) -> Void) {
         
         let token = App.Repository.token.keychain.string(forKey: "accessToken")
-        let appKey = "32215db9-5bd3-48d4-8f06-243ae1eb6352"
+        let appKey = "7c5aaa36-570e-491f-b18a-26a1a0b72959"
 #if PRD
         var hostApi: String = "https://api.no5ing.kr/v1"
 #else

--- a/14th-team5-iOS/Data/Sources/API/API.swift
+++ b/14th-team5-iOS/Data/Sources/API/API.swift
@@ -51,7 +51,7 @@ enum BibbiAPI {
         var value: String {
             switch self {
             case .auth(let value): return "Bearer \(value)"
-            case .xAppKey: return "32215db9-5bd3-48d4-8f06-243ae1eb6352"
+            case .xAppKey: return "7c5aaa36-570e-491f-b18a-26a1a0b72959"
             case .xAuthToken(let value): return "\(value)"
             case .contentForm: return "application/x-www-form-urlencoded"
             case .contentJson: return "application/json"


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- ProfileViewReactor setFeedResultItems Mutation 추가, Feed Cell Pagination시 setFeedResultItems Mutation 방출 코드 추가
- CameraDisplayViewController TextField 공백 제거 로직 추가, 이벤트 중복 방출 예외 처리 추가

## 변경 로직 ⚒️

- ProfileViewReactor에서 FeedCell Pagination시 PostListsDIContainer 에 대한 Entity가 없어서 Crash 오류가 발생 하였습니다. 때문에 Pagination 될 경우 `setFeedResultItems` setProfilePostItems 방출하도록 추가하였습니다.
- `CameraDisplayViewController` 에 TextField 공백 제거 로직 추가 하였으며 이벤트 중복 방출로 인해 `UIEdgeInsets` 값이 중복 변경 되었습니다.
