### PR TITLE
refactor: 네비게이션바 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountNicknameViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountNicknameViewController.swift
@@ -18,7 +18,6 @@ import Then
 fileprivate typealias _Str = AccountSignUpStrings.Nickname
 public final class AccountNicknameViewController: BaseViewController<AccountSignUpReactor> {
     // MARK: SubViews
-    private let navigationBar: BibbiNavigationBarView = BibbiNavigationBarView()
     private let titleLabel = BibbiLabel(.head2Bold, textColor: .gray300)
     private let inputFielView = UITextField()
     private let errorLabel = BibbiLabel(.body1Regular, textColor: .warningRed)
@@ -37,6 +36,7 @@ public final class AccountNicknameViewController: BaseViewController<AccountSign
     }
     
     public override func bind(reactor: AccountSignUpReactor) {
+        super.bind(reactor: reactor)
         bindInput(reactor: reactor)
         bindOutput(reactor: reactor)
     }
@@ -69,11 +69,6 @@ public final class AccountNicknameViewController: BaseViewController<AccountSign
             .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
             .map { Reactor.Action.didTapNickNameButton($0)}
             .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        navigationBar.rx.didTapLeftBarButton
-            .withUnretained(self)
-            .subscribe { $0.0.navigationController?.popViewController(animated: true) }
             .disposed(by: disposeBag)
     }
     
@@ -108,26 +103,19 @@ public final class AccountNicknameViewController: BaseViewController<AccountSign
             .filter { $0 == .account }
             .distinctUntilChanged()
             .withUnretained(self)
-            .bind(onNext: { $0.0.navigationBar.isHidden = true  })
+            .bind(onNext: { $0.0.navigationBarView.isHidden = true  })
             .disposed(by: disposeBag)
     }
     
     public override func setupUI() {
         super.setupUI()
         
-        view.addSubviews(navigationBar, titleLabel, inputFielView, errorStackView, descLabel, nextButton)
+        view.addSubviews(titleLabel, inputFielView, errorStackView, descLabel, nextButton)
         errorStackView.addArrangedSubviews(errorImage, errorLabel)
     }
     
     public override func setupAutoLayout() {
         super.setupAutoLayout()
-        
-        navigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(42)
-        }
-        
         titleLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview().inset(20)
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(130)
@@ -156,9 +144,8 @@ public final class AccountNicknameViewController: BaseViewController<AccountSign
     }
     
     public override func setupAttributes() {
-        navigationBar.do {
-            $0.navigationTitle = "닉네임 변경"
-            $0.leftBarButtonItem = .arrowLeft
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("닉네임 변경"), rightItem: .empty)
         }
         
         titleLabel.do {

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountSignUpViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignUp/ViewControllers/AccountSignUpViewController.swift
@@ -11,8 +11,6 @@ import DesignSystem
 
 fileprivate typealias _Str = AccountSignUpStrings
 public final class AccountSignUpViewController: BasePageViewController<AccountSignUpReactor> {
-    
-    private let navigationBar: BibbiNavigationBarView = BibbiNavigationBarView()
     private let nextButton = UIButton()
     
     private var pages = [UIViewController]()
@@ -22,22 +20,16 @@ public final class AccountSignUpViewController: BasePageViewController<AccountSi
         super.viewDidLoad()
         
         dataSource = self
+        navigationBarView.isHidden = true
         setViewControllers([pages[initalPage]], direction: .forward, animated: true)
         isPagingEnabled = false
-        navigationBar.isHidden = true
-    }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        navigationController?.navigationBar.isHidden = true
     }
     
     public override func bind(reactor: AccountSignUpReactor) {
-        navigationBar.rx
-            .didTapLeftBarButton
+        super.bind(reactor: reactor)
+        
+        navigationBarView.rx.leftButtonTap
             .observe(on: Schedulers.main)
-            .throttle(.milliseconds(300), scheduler: Schedulers.main)
             .withUnretained(self)
             .bind { $0.0.goToPrevPage() }
             .disposed(by: disposeBag)
@@ -65,27 +57,18 @@ public final class AccountSignUpViewController: BasePageViewController<AccountSi
         pages.append(nicknamePage)
         pages.append(datePage)
         pages.append(profilePage)
-        
-        view.addSubviews(navigationBar)
     }
     
     public override func setupAttributes() {
         super.setupAttributes()
         
-        navigationBar.do {
-            $0.leftBarButtonItem = .arrowLeft
-            $0.leftBarButtonItemTintColor = .gray300
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, rightItem: .empty)
         }
     }
     
     public override func setupAutoLayout() {
         super.setupAutoLayout()
-        
-        navigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
-        }
     }
 }
 
@@ -116,9 +99,9 @@ extension AccountSignUpViewController: UIPageViewControllerDataSource {
         guard let currentIndex = pages.firstIndex(of: viewController) else { return nil }
 
         if currentIndex == 1 {
-            navigationBar.isHidden = true
+            navigationBarView.isHidden = true
         } else {
-            navigationBar.isHidden = false
+            navigationBarView.isHidden = false
         }
         
         guard currentIndex > 0 else { return nil }
@@ -128,7 +111,7 @@ extension AccountSignUpViewController: UIPageViewControllerDataSource {
     public func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard let currentIndex = pages.firstIndex(of: viewController) else { return nil }
         
-        navigationBar.isHidden = false
+        navigationBarView.isHidden = false
         
         guard currentIndex < pages.count - 1 else { return nil }
         return pages[currentIndex + 1]

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -22,7 +22,6 @@ import Then
 fileprivate typealias _Str = CalendarStrings
 public final class CalendarPostViewController: BaseViewController<CalendarPostViewReactor> {
     // MARK: - Views
-    private let navigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     private let blurImageView: UIImageView = UIImageView()
 
     private let calendarView: FSCalendar = FSCalendar()
@@ -41,11 +40,6 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
     // MARK: - Lifecycles
     public override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.navigationBar.isHidden = true
     }
 
     // MARK: - Helpers
@@ -73,7 +67,7 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        navigationBarView.rx.didTapLeftBarButton
+        navigationBarView.rx.leftButtonTap
             .map { _ in Reactor.Action.popViewController }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -227,23 +221,23 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             .subscribe(onNext: { _ in Haptic.selection() })
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$shouldPopViewController)
-            .filter { $0 }
-            .withUnretained(self)
-            .subscribe { $0.0.navigationController?.popViewController(animated: true) }
-            .disposed(by: disposeBag)
-        
+//        reactor.pulse(\.$shouldPopViewController)
+//            .filter { $0 }
+//            .withUnretained(self)
+//            .subscribe { $0.0.navigationController?.popViewController(animated: true) }
+//            .disposed(by: disposeBag)
+//        
         didTapProfileImageNotificationHandler()
         didTapSelectableCameraButtonNotifcationHandler()
     }
     
     public override func setupUI() {
-        super.setupUI()
+//        super.setupUI()
         view.addSubviews(
-            navigationBarView, blurImageView
+            blurImageView, navigationBarView
         )
         blurImageView.addSubviews(
-            navigationBarView, calendarView, postCollectionView
+            calendarView, postCollectionView
         )
         view.addSubview(fireLottieView)
         
@@ -256,12 +250,6 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
         super.setupAutoLayout()
         blurImageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
-        }
-        
-        navigationBarView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(42)
         }
         
         calendarView.snp.makeConstraints {
@@ -296,7 +284,7 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
         }
         
         navigationBarView.do {
-            $0.leftBarButtonItem = .arrowLeft
+            $0.setNavigationView(leftItem: .arrowLeft, rightItem: .empty)
         }
         
         calendarView.do {
@@ -396,7 +384,7 @@ extension CalendarPostViewController {
     }
     
     private func setupNavigationTitle(_ date: Date) {
-        navigationBarView.navigationTitle = date.toFormatString(with: .yyyyM)
+        navigationBarView.setNavigationTitle(title: date.toFormatString(with: .yyyyM))
     }
     
     private func adjustWeeklyCalendarRect(_ bounds: CGRect) {

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -19,7 +19,6 @@ import Then
 fileprivate typealias _Str = CalendarStrings
 public final class CalendarViewController: BaseViewController<CalendarViewReactor> {
     // MARK: - Views
-    private let navigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     private lazy var calendarCollectionView: UICollectionView = UICollectionView(
         frame: .zero,
         collectionViewLayout: orthogonalCompositionalLayout
@@ -31,11 +30,6 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
     // MARK: - Lifecycles
     public override func viewDidLoad() {
         super.viewDidLoad()
-    }
-    
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        navigationController?.navigationBar.isHidden = true
     }
     
     // MARK: - Helpers
@@ -74,7 +68,7 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
             .disposed(by: disposeBag)
          
 
-        navigationBarView.rx.didTapLeftBarButton
+        navigationBarView.rx.leftButtonTap
             .map { _ in Reactor.Action.popViewController }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -83,14 +77,6 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
     private func bindOutput(reactor: CalendarViewReactor) {
         reactor.pulse(\.$displayCalendar)
             .bind(to: calendarCollectionView.rx.items(dataSource: dataSource))
-            .disposed(by: disposeBag)
-        
-        reactor.pulse(\.$shouldPopCalendarVC)
-            .distinctUntilChanged()
-            .withUnretained(self)
-            .subscribe {
-                if $0.1 { $0.0.navigationController?.popViewController(animated: true) }
-            }
             .disposed(by: disposeBag)
         
         reactor.pulse(\.$shouldPushCalendarPostVC).compactMap { $0 }
@@ -114,18 +100,11 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
     
     public override func setupUI() {
         super.setupUI()
-        view.addSubviews(
-            navigationBarView, calendarCollectionView
-        )
+        view.addSubviews(calendarCollectionView)
     }
     
     public override func setupAutoLayout() {
         super.setupAutoLayout()
-        navigationBarView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(42)
-        }
         
         calendarCollectionView.snp.makeConstraints {
             $0.top.equalTo(navigationBarView.snp.bottom)
@@ -136,9 +115,9 @@ public final class CalendarViewController: BaseViewController<CalendarViewReacto
     
     public override func setupAttributes() {
         super.setupAttributes()
+        
         navigationBarView.do {
-            $0.navigationTitle = _Str.mainTitle
-            $0.leftBarButtonItem = .arrowLeft
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label(_Str.mainTitle), rightItem: .empty)
         }
         
         calendarCollectionView.do {

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
@@ -22,7 +22,6 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
     private let displayView: UIImageView = UIImageView()
     private let confirmButton: UIButton = UIButton(configuration: .plain())
     private let displayIndicatorView: BibbiLoadingView = BibbiLoadingView()
-    private let displayNavigationBar: BibbiNavigationBarView = BibbiNavigationBarView()
     private let backButton: UIButton = UIButton(frame: CGRect(origin: .zero, size: CGSize(width: 52, height: 52)))
     private let titleView: BibbiLabel = BibbiLabel(.head2Bold, textColor: .gray200)
     private let displayEditButton: UIButton = UIButton()
@@ -53,7 +52,7 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
     //MARK: Configure
     public override func setupUI() {
         super.setupUI()
-        view.addSubviews(displayView, confirmButton, archiveButton, displayEditTextField, displayEditCollectionView, displayIndicatorView ,displayNavigationBar)
+        view.addSubviews(displayView, confirmButton, archiveButton, displayEditTextField, displayEditCollectionView, displayIndicatorView)
         displayView.addSubviews(displayEditButton)
     }
     
@@ -65,10 +64,8 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
             $0.minimumInteritemSpacing = 4
         }
         
-        displayNavigationBar.do {
-            $0.navigationTitle = "사진 올리기"
-            $0.leftBarButtonItem = .arrowLeft
-            $0.leftBarButtonItemTintColor = .gray300
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("사진 올리기"), rightItem: .empty)
         }
         
         archiveButton.do {
@@ -146,12 +143,6 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
     public override func setupAutoLayout() {
         super.setupAutoLayout()
         
-        displayNavigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
-        }
-        
         displayEditTextField.snp.makeConstraints {
             $0.height.equalTo(0)
             $0.left.right.equalToSuperview()
@@ -198,6 +189,8 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
     
     
     public override func bind(reactor: CameraDisplayViewReactor) {
+        super.bind(reactor: reactor)
+        
         archiveButton
             .rx.tap
             .throttle(.seconds(1), scheduler: MainScheduler.instance)
@@ -211,15 +204,9 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
             .subscribe { owner, _ in
                 MPEvent.Camera.photoText.track(with: nil)
                 owner.displayEditTextField.becomeFirstResponder()
-            }.disposed(by: disposeBag)
-        
-        
-        displayNavigationBar.rx.didTapLeftBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
-            .bind { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
+            }
+            .disposed(by: disposeBag)
+  
         
         displayEditTextField
             .rx.text.changed

--- a/14th-team5-iOS/App/Sources/Presentation/FamilyManagement/ViewController/FamilyManagementViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/FamilyManagement/ViewController/FamilyManagementViewController.swift
@@ -19,7 +19,6 @@ import Then
 fileprivate typealias _Str = FamilyManagementStrings
 public final class FamilyManagementViewController: BaseViewController<FamilyManagementViewReactor> {
     // MARK: - Views
-    private let navigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     
     private let shareContainerview: InvitationUrlContainerView = InvitationUrlContainerDIContainer().makeView()
     private let dividerView: UIView = UIView()
@@ -61,8 +60,7 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        navigationBarView.rx.didTapRightBarButton
-            .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
+        navigationBarView.rx.rightButtonTap
             .map { _ in Reactor.Action.didTapPrivacyBarButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -85,11 +83,6 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
     }
     
     private func bindOutput(reactor: FamilyManagementViewReactor) {
-        navigationBarView.rx.didTapLeftBarButton
-            .withUnretained(self)
-            .subscribe {$0.0.navigationController?.popViewController(animated: true) }
-            .disposed(by: disposeBag)
-        
         reactor.pulse(\.$shouldPushPrivacyVC)
             .filter { !$0.isEmpty }
             .withUnretained(self)
@@ -182,7 +175,7 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
     public override func setupUI() {
         super.setupUI()
         view.addSubviews(
-            navigationBarView, shareContainerview,
+            shareContainerview,
             dividerView, headerStack, familyTableView
         )
         headerStack.addArrangedSubviews(
@@ -193,13 +186,6 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
     
     public override func setupAutoLayout() {
         super.setupAutoLayout()
-        
-        navigationBarView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.horizontalEdges.equalToSuperview()
-            $0.height.equalTo(42)
-        }
-        
         shareContainerview.snp.makeConstraints {
             $0.top.equalTo(navigationBarView.snp.bottom).offset(24)
             $0.horizontalEdges.equalToSuperview().inset(20)
@@ -238,13 +224,7 @@ public final class FamilyManagementViewController: BaseViewController<FamilyMana
     public override func setupAttributes() {
         super.setupAttributes()
         navigationBarView.do {
-            $0.navigationTitle = _Str.mainTitle
-            
-            $0.leftBarButtonItem = .arrowLeft
-            
-            $0.rightBarButtonItem = .setting
-            $0.rightBarButtonItemScale = 1.2
-            $0.hiddenRightBarButtonBackground = true
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label(_Str.mainTitle), rightItem: .setting)
          }
         
         dividerView.do {

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
@@ -18,7 +18,7 @@ import SnapKit
 fileprivate typealias _Str = PostCommentStrings
 final public class PostCommentViewController: BaseViewController<PostCommentViewReactor> {
     // MARK: - Views
-    private let navigationBarView: PostCommentTopBarView = PostCommentTopBarView()
+    private let commentNavigationBarView: PostCommentTopBarView = PostCommentTopBarView()
     
     private let noCommentLabel: NoCommentLabel = NoCommentLabel()
     private let commentTableView: UITableView = UITableView()
@@ -258,7 +258,7 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
     public override func setupUI() {
         super.setupUI()
         
-        view.addSubviews(navigationBarView, commentTableView, textFieldContainerView)
+        view.addSubviews(commentNavigationBarView, commentTableView, textFieldContainerView)
         commentTableView.addSubviews(bibbiLottieView, noCommentLabel, fetchFailureView)
         textFieldContainerView.addSubviews(commentTextField)
     }
@@ -266,20 +266,20 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
     public override func setupAutoLayout() {
         super.setupAutoLayout()
         
-        navigationBarView.snp.makeConstraints {
+        commentNavigationBarView.snp.makeConstraints {
             $0.height.equalTo(60)
             $0.top.equalToSuperview()
             $0.horizontalEdges.equalToSuperview()
         }
         
         noCommentLabel.snp.makeConstraints {
-            $0.top.equalTo(navigationBarView.snp.bottom).offset(74)
+            $0.top.equalTo(commentNavigationBarView.snp.bottom).offset(74)
             $0.bottom.equalTo(textFieldContainerView.snp.top).offset(-5)
             $0.horizontalEdges.equalToSuperview()
         }
         
         commentTableView.snp.makeConstraints {
-            $0.top.equalTo(navigationBarView.snp.bottom)
+            $0.top.equalTo(commentNavigationBarView.snp.bottom)
             $0.horizontalEdges.equalToSuperview()
         }
         

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/PrivacyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/PrivacyViewController.swift
@@ -19,7 +19,6 @@ import Then
 public final class PrivacyViewController: BaseViewController<PrivacyViewReactor> {
     //MARK: Views
     private let privacyTableView: UITableView = UITableView(frame: .zero, style: .grouped)
-    private let privacyNavigationBar: BibbiNavigationBarView = BibbiNavigationBarView()
     private let privacyIndicatorView: UIActivityIndicatorView = UIActivityIndicatorView(style: .medium)
     private let privacyTableViewDataSources: RxTableViewSectionedReloadDataSource<PrivacySectionModel> = .init { dataSoruces, tableView, indexPath, sectionItem in
         switch sectionItem {
@@ -41,26 +40,18 @@ public final class PrivacyViewController: BaseViewController<PrivacyViewReactor>
         super.viewDidLoad()
     }
     
-    public override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = true
-    }
-    
     //MARK: Configure
     public override func setupUI() {
         super.setupUI()
-        view.addSubviews(privacyTableView, privacyIndicatorView, privacyNavigationBar)
+        view.addSubviews(privacyTableView, privacyIndicatorView)
     }
     
     public override func setupAttributes() {
         super.setupAttributes()
         
-        privacyNavigationBar.do {
-            $0.navigationTitle = "설정 및 개인정보"
-            $0.leftBarButtonItem = .arrowLeft
-            $0.leftBarButtonItemTintColor = .gray300
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("설정 및 개인정보"), rightItem: .empty)
         }
-        
         
         privacyTableView.do {
             $0.backgroundColor = DesignSystemAsset.black.color
@@ -80,14 +71,9 @@ public final class PrivacyViewController: BaseViewController<PrivacyViewReactor>
     
     public override func setupAutoLayout() {
         super.setupAutoLayout()
-        privacyNavigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
-        }
         
         privacyTableView.snp.makeConstraints {
-            $0.top.equalTo(privacyNavigationBar.snp.bottom).offset(24)
+            $0.top.equalTo(navigationBarView.snp.bottom).offset(24)
             $0.left.bottom.right.equalToSuperview()
             
         }
@@ -99,6 +85,8 @@ public final class PrivacyViewController: BaseViewController<PrivacyViewReactor>
     
     
     public override func bind(reactor: PrivacyViewReactor) {
+        super.bind(reactor: reactor)
+        
         privacyTableView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)
@@ -135,16 +123,7 @@ public final class PrivacyViewController: BaseViewController<PrivacyViewReactor>
             .map { _ in Reactor.Action.didTapFamilyUserResign }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        
-        privacyNavigationBar.rx
-            .didTapLeftBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
-            .bind { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
-        
+
         privacyTableView.rx
             .itemSelected
             .withUnretained(self)

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileDetailViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileDetailViewController.swift
@@ -15,7 +15,6 @@ import SnapKit
 import Then
 
 final class ProfileDetailViewController: BaseViewController<ProfileDetailViewReactor> {
-    private let navigationBar: BibbiNavigationBarView = BibbiNavigationBarView()
     private let profileImageView: UIImageView = UIImageView()
     private let nickNameLabel: BibbiLabel = BibbiLabel(.head1, alignment: .center, textColor: .gray200)
     private let blurView: UIVisualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: .systemChromeMaterialDark))
@@ -24,20 +23,16 @@ final class ProfileDetailViewController: BaseViewController<ProfileDetailViewRea
         super.viewDidLoad()
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = true
-    }
-    
     override func setupUI() {
-        super.setupUI()
-        view.addSubviews(blurView, profileImageView, nickNameLabel, navigationBar)
+//        super.setupUI()
+        view.addSubviews(blurView, profileImageView, nickNameLabel, navigationBarView)
     }
     
     override func setupAttributes() {
-
+        super.setupAttributes()
+        
         blurView.do {
-            $0.frame = view.bounds
+            $0.layer.zPosition = -100
             $0.backgroundColor = DesignSystemAsset.black.color.withAlphaComponent(0.9)
             $0.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         }
@@ -48,19 +43,18 @@ final class ProfileDetailViewController: BaseViewController<ProfileDetailViewRea
             $0.clipsToBounds = true
         }
         
-        navigationBar.do {
-            $0.leftBarButtonItem = .arrowLeft
-            $0.leftBarButtonItemTintColor = .gray300
+        navigationBarView.do {
+            $0.layer.zPosition = 100
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label(nil), rightItem: .empty)
         }
     
     }
     
     override func setupAutoLayout() {
-
-        navigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.topMargin)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
+        super.setupAutoLayout()
+        
+        blurView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         profileImageView.snp.makeConstraints {
@@ -75,6 +69,8 @@ final class ProfileDetailViewController: BaseViewController<ProfileDetailViewRea
     }
     
     override func bind(reactor: ProfileDetailViewReactor) {
+        super.bind(reactor: reactor)
+        
         reactor.pulse(\.$profileURL)
             .filter { $0.isFileURL }
             .withUnretained(self)
@@ -97,13 +93,5 @@ final class ProfileDetailViewController: BaseViewController<ProfileDetailViewRea
             .map { "\($0)" }
             .bind(to: nickNameLabel.rx.text)
             .disposed(by: disposeBag)
-        
-        navigationBar
-            .rx.didTapLeftBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
-            .bind { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileViewController.swift
@@ -36,7 +36,6 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
 
     private let profileIndicatorView: BlurAiraplaneLottieView = BlurAiraplaneLottieView()
     private lazy var profileView: BibbiProfileView = BibbiProfileView(cornerRadius: 50)
-    private let profileNavigationBar: BibbiNavigationBarView = BibbiNavigationBarView()
     private let profileLineView: UIView = UIView()
     private lazy var profilePickerController: PHPickerViewController = PHPickerViewController(configuration: pickerConfiguration)
     private let profileFeedCollectionViewLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
@@ -58,7 +57,6 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = true
         self.profileIndicatorView.isHidden = false
     }
     
@@ -73,7 +71,7 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
     
     public override func setupUI() {
         super.setupUI()
-        view.addSubviews(profileView, profileLineView, profileFeedCollectionView, profileIndicatorView, profileNavigationBar)
+        view.addSubviews(profileView, profileLineView, profileFeedCollectionView, profileIndicatorView)
     }
     
     public override func setupAttributes() {
@@ -91,14 +89,9 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
             $0.backgroundColor = .separator
         }
         
-        profileNavigationBar.do {
-            $0.navigationTitle = "활동"
-            $0.leftBarButtonItem = .arrowLeft
-            $0.rightBarButtonItem = .setting
-            $0.leftBarButtonItemTintColor = .gray300
-            $0.rightBarButtonItemTintColor = .gray400
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("활동"), rightItem: .setting)
         }
-        
         
         profileFeedCollectionView.do {
             $0.register(ProfileFeedCollectionViewCell.self, forCellWithReuseIdentifier: "ProfileFeedCollectionViewCell")
@@ -111,15 +104,8 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
     
     public override func setupAutoLayout() {
         super.setupAutoLayout()
-        
-        profileNavigationBar.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
-        }
-        
         profileView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.topMargin)
+            $0.top.equalTo(navigationBarView.snp.bottom)
             $0.left.right.equalToSuperview()
             $0.height.equalTo(200)
         }
@@ -143,7 +129,8 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
     
     
     public override func bind(reactor: ProfileViewReactor) {
-
+        super.bind(reactor: reactor)
+        
         Observable.just(())
             .map { Reactor.Action.viewDidLoad}
             .bind(to: reactor.action)
@@ -315,16 +302,8 @@ public final class ProfileViewController: BaseViewController<ProfileViewReactor>
             .map { Reactor.Action.fetchMorePostItems($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        profileNavigationBar.rx.didTapLeftBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
-            .bind { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
-        
-        profileNavigationBar.rx.didTapRightBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+    
+        navigationBarView.rx.rightButtonTap
             .withLatestFrom(reactor.state.map { $0.memberId })
             .withUnretained(self)
             .bind { owner, memberId in

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
@@ -18,6 +18,7 @@ import Then
 final class AccountResignViewCotroller: BaseViewController<AccountResignViewReactor> {
     
     //TODO: 텍스트 컬러, 폰트 정해지면 수정
+    private let resignNavigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     private let resignDesrptionLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray400)
     private let resignReasonLabel: BibbiLabel = BibbiLabel(.head1, textColor: .gray200)
     private let resignExampleLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray400)
@@ -25,19 +26,27 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     private let confirmButton: UIButton = UIButton()
     private let bibbiTermsView: BibbiCheckBoxView = BibbiCheckBoxView(frame: .zero)
     
+    override func viewWillAppear(_ animated: Bool) {
+          super.viewWillAppear(animated)
+          self.navigationController?.navigationBar.isHidden = true
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
+    
     override func setupUI() {
         super.setupUI()
-        view.addSubviews(resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
+        view.addSubviews(resignNavigationBarView, resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
     }
-    
+
     override func setupAttributes() {
         super.setupAttributes()
-        navigationBarView.do {
-            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("회원 탈퇴"), rightItem: .empty)
+        resignNavigationBarView.do {
+            $0.leftBarButtonItem = .arrowLeft
+            $0.leftBarButtonItemTintColor = .gray300
+            $0.navigationTitle = "회원 탈퇴"
         }
         
         resignDesrptionLabel.do {
@@ -75,19 +84,23 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     }
     
     override func setupAutoLayout() {
-        super.setupAutoLayout()
-        
+        resignNavigationBarView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.left.right.equalToSuperview()
+            $0.height.equalTo(42)
+        }
+
         bibbiTermsView.snp.makeConstraints {
             $0.top.equalTo(resignExampleLabel.snp.bottom).offset(16)
             $0.left.equalToSuperview()
             $0.height.equalTo(260)
-            $0.centerX.equalTo(navigationBarView)
+            $0.centerX.equalTo(resignNavigationBarView)
         }
-        
+
         resignDesrptionLabel.snp.makeConstraints {
-            $0.top.equalTo(navigationBarView.snp.bottom).offset(26)
+            $0.top.equalTo(resignNavigationBarView.snp.bottom).offset(26)
             $0.left.equalToSuperview().offset(16)
-            $0.centerX.equalTo(navigationBarView)
+            $0.centerX.equalTo(resignNavigationBarView)
             $0.height.equalTo(18)
         }
         
@@ -102,7 +115,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             $0.top.equalTo(resignReasonLabel.snp.bottom).offset(24)
             $0.left.equalToSuperview().offset(12)
             $0.height.equalTo(18)
-            $0.centerX.equalTo(navigationBarView)
+            $0.centerX.equalTo(resignNavigationBarView)
         }
         
         confirmButton.snp.makeConstraints {
@@ -160,6 +173,13 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             .map { _ in Reactor.Action.didTapResignButton}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
+        
+        resignNavigationBarView.rx.didTapLeftBarButton
+                    .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+                    .withUnretained(self)
+                    .bind { owner, _ in
+                        owner.navigationController?.popViewController(animated: true)
+                    }.disposed(by: disposeBag)
 
         reactor.state.map { $0.isSuccess }
             .distinctUntilChanged()

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
@@ -18,7 +18,6 @@ import Then
 final class AccountResignViewCotroller: BaseViewController<AccountResignViewReactor> {
     
     //TODO: 텍스트 컬러, 폰트 정해지면 수정
-    private let resignNavigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     private let resignDesrptionLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray400)
     private let resignReasonLabel: BibbiLabel = BibbiLabel(.head1, textColor: .gray200)
     private let resignExampleLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray400)
@@ -26,27 +25,19 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     private let confirmButton: UIButton = UIButton()
     private let bibbiTermsView: BibbiCheckBoxView = BibbiCheckBoxView(frame: .zero)
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = true
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
-    
     override func setupUI() {
         super.setupUI()
-        view.addSubviews(resignNavigationBarView, resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
+        view.addSubviews(resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
     }
     
     override func setupAttributes() {
         super.setupAttributes()
-        resignNavigationBarView.do {
-            $0.leftBarButtonItem = .arrowLeft
-            $0.leftBarButtonItemTintColor = .gray300
-            $0.navigationTitle = "회원 탈퇴"
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("회원 탈퇴"), rightItem: .empty)
         }
         
         resignDesrptionLabel.do {
@@ -85,23 +76,18 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     
     override func setupAutoLayout() {
         super.setupAutoLayout()
-        resignNavigationBarView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
-        }
         
         bibbiTermsView.snp.makeConstraints {
             $0.top.equalTo(resignExampleLabel.snp.bottom).offset(16)
             $0.left.equalToSuperview()
             $0.height.equalTo(260)
-            $0.centerX.equalTo(resignNavigationBarView)
+            $0.centerX.equalTo(navigationBarView)
         }
         
         resignDesrptionLabel.snp.makeConstraints {
-            $0.top.equalTo(resignNavigationBarView.snp.bottom).offset(26)
+            $0.top.equalTo(navigationBarView.snp.bottom).offset(26)
             $0.left.equalToSuperview().offset(16)
-            $0.centerX.equalTo(resignNavigationBarView)
+            $0.centerX.equalTo(navigationBarView)
             $0.height.equalTo(18)
         }
         
@@ -116,7 +102,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             $0.top.equalTo(resignReasonLabel.snp.bottom).offset(24)
             $0.left.equalToSuperview().offset(12)
             $0.height.equalTo(18)
-            $0.centerX.equalTo(resignNavigationBarView)
+            $0.centerX.equalTo(navigationBarView)
         }
         
         confirmButton.snp.makeConstraints {
@@ -128,6 +114,8 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     }
     
     override func bind(reactor: AccountResignViewReactor) {
+        super.bind(reactor: reactor)
+        
         Observable.just(())
             .map{ Reactor.Action.viewDidLoad }
             .bind(to: reactor.action)
@@ -145,7 +133,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
         .map { Reactor.Action.didTapCheckButton($0)}
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
-        
+
         
         confirmButton
             .rx.tap
@@ -172,14 +160,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             .map { _ in Reactor.Action.didTapResignButton}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        resignNavigationBarView.rx.didTapLeftBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
-            .bind { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
-        
+
         reactor.state.map { $0.isSuccess }
             .distinctUntilChanged()
             .filter { $0 }

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
@@ -18,7 +18,6 @@ import Then
 final class AccountResignViewCotroller: BaseViewController<AccountResignViewReactor> {
     
     //TODO: 텍스트 컬러, 폰트 정해지면 수정
-    private let resignNavigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     private let resignDesrptionLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray400)
     private let resignReasonLabel: BibbiLabel = BibbiLabel(.head1, textColor: .gray200)
     private let resignExampleLabel: BibbiLabel = BibbiLabel(.body1Regular, textColor: .gray400)
@@ -26,26 +25,19 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     private let confirmButton: UIButton = UIButton()
     private let bibbiTermsView: BibbiCheckBoxView = BibbiCheckBoxView(frame: .zero)
     
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.navigationBar.isHidden = true
-    }
-    
     override func viewDidLoad() {
         super.viewDidLoad()
     }
     
     override func setupUI() {
         super.setupUI()
-        view.addSubviews(resignNavigationBarView, resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
+        view.addSubviews(resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
     }
     
     override func setupAttributes() {
         super.setupAttributes()
-        resignNavigationBarView.do {
-            $0.leftBarButtonItem = .arrowLeft
-            $0.leftBarButtonItemTintColor = .gray300
-            $0.navigationTitle = "회원 탈퇴"
+        navigationBarView.do {
+            $0.setNavigationView(leftItem: .arrowLeft, centerItem: .label("회원 탈퇴"), rightItem: .empty)
         }
         
         resignDesrptionLabel.do {
@@ -84,23 +76,18 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     
     override func setupAutoLayout() {
         super.setupAutoLayout()
-        resignNavigationBarView.snp.makeConstraints {
-            $0.top.equalTo(view.safeAreaLayoutGuide)
-            $0.left.right.equalToSuperview()
-            $0.height.equalTo(42)
-        }
         
         bibbiTermsView.snp.makeConstraints {
             $0.top.equalTo(resignExampleLabel.snp.bottom).offset(16)
             $0.left.equalToSuperview()
             $0.height.equalTo(260)
-            $0.centerX.equalTo(resignNavigationBarView)
+            $0.centerX.equalTo(navigationBarView)
         }
         
         resignDesrptionLabel.snp.makeConstraints {
-            $0.top.equalTo(resignNavigationBarView.snp.bottom).offset(26)
+            $0.top.equalTo(navigationBarView.snp.bottom).offset(26)
             $0.left.equalToSuperview().offset(16)
-            $0.centerX.equalTo(resignNavigationBarView)
+            $0.centerX.equalTo(navigationBarView)
             $0.height.equalTo(18)
         }
         
@@ -115,7 +102,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             $0.top.equalTo(resignReasonLabel.snp.bottom).offset(24)
             $0.left.equalToSuperview().offset(12)
             $0.height.equalTo(18)
-            $0.centerX.equalTo(resignNavigationBarView)
+            $0.centerX.equalTo(navigationBarView)
         }
         
         confirmButton.snp.makeConstraints {
@@ -127,7 +114,8 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     }
     
     override func bind(reactor: AccountResignViewReactor) {
-
+        super.bind(reactor: reactor)
+        
         Observable.just(())
             .map{ Reactor.Action.viewDidLoad }
             .bind(to: reactor.action)
@@ -172,29 +160,20 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             .map { _ in Reactor.Action.didTapResignButton}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        resignNavigationBarView.rx.didTapLeftBarButton
-            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-            .withUnretained(self)
-            .bind { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            }.disposed(by: disposeBag)
-        
+
         reactor.state.map { $0.isSuccess }
             .distinctUntilChanged()
+            .filter { $0 }
             .withUnretained(self)
             .bind { owner, isSuccess in
                 App.Repository.token.clearAccessToken()
                 owner.makeRootViewController()
             }.disposed(by: disposeBag)
-        
     }
-    
 }
 
 
 extension AccountResignViewCotroller {
-    
     private func setupButton(isSelected: Bool) {
         confirmButton.backgroundColor = isSelected ? DesignSystemAsset.mainYellow.color : DesignSystemAsset.mainYellow.color.withAlphaComponent(0.2)
         confirmButton.isEnabled = isSelected

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
@@ -27,8 +27,8 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     private let bibbiTermsView: BibbiCheckBoxView = BibbiCheckBoxView(frame: .zero)
     
     override func viewWillAppear(_ animated: Bool) {
-          super.viewWillAppear(animated)
-          self.navigationController?.navigationBar.isHidden = true
+        super.viewWillAppear(animated)
+        self.navigationController?.navigationBar.isHidden = true
     }
     
     override func viewDidLoad() {
@@ -40,7 +40,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
         super.setupUI()
         view.addSubviews(resignNavigationBarView, resignDesrptionLabel, resignReasonLabel, resignExampleLabel, confirmButton, resignIndicatorView, bibbiTermsView)
     }
-
+    
     override func setupAttributes() {
         super.setupAttributes()
         resignNavigationBarView.do {
@@ -89,14 +89,14 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             $0.left.right.equalToSuperview()
             $0.height.equalTo(42)
         }
-
+        
         bibbiTermsView.snp.makeConstraints {
             $0.top.equalTo(resignExampleLabel.snp.bottom).offset(16)
             $0.left.equalToSuperview()
             $0.height.equalTo(260)
             $0.centerX.equalTo(resignNavigationBarView)
         }
-
+        
         resignDesrptionLabel.snp.makeConstraints {
             $0.top.equalTo(resignNavigationBarView.snp.bottom).offset(26)
             $0.left.equalToSuperview().offset(16)
@@ -146,7 +146,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
         .map { Reactor.Action.didTapCheckButton($0)}
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
-
+        
         
         confirmButton
             .rx.tap
@@ -175,12 +175,12 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
             .disposed(by: disposeBag)
         
         resignNavigationBarView.rx.didTapLeftBarButton
-                    .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
-                    .withUnretained(self)
-                    .bind { owner, _ in
-                        owner.navigationController?.popViewController(animated: true)
-                    }.disposed(by: disposeBag)
-
+            .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
+            .withUnretained(self)
+            .bind { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            }.disposed(by: disposeBag)
+        
         reactor.state.map { $0.isSuccess }
             .distinctUntilChanged()
             .filter { $0 }

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/AccountResignViewCotroller.swift
@@ -84,6 +84,7 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     }
     
     override func setupAutoLayout() {
+        super.setupAutoLayout()
         resignNavigationBarView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
             $0.left.right.equalToSuperview()
@@ -127,8 +128,6 @@ final class AccountResignViewCotroller: BaseViewController<AccountResignViewReac
     }
     
     override func bind(reactor: AccountResignViewReactor) {
-        super.bind(reactor: reactor)
-        
         Observable.just(())
             .map{ Reactor.Action.viewDidLoad }
             .bind(to: reactor.action)

--- a/14th-team5-iOS/Core/Sources/Base/BasePageViewController.swift
+++ b/14th-team5-iOS/Core/Sources/Base/BasePageViewController.swift
@@ -16,6 +16,7 @@ open class BasePageViewController<R>: UIPageViewController, ReactorKit.View wher
     
     // MARK: - Properties
     public var disposeBag: RxSwift.DisposeBag = DisposeBag()
+    public let navigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     
     // MARK: - Intializer
     public init() {
@@ -39,19 +40,33 @@ open class BasePageViewController<R>: UIPageViewController, ReactorKit.View wher
         setupAttributes()
     }
     
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        navigationController?.navigationBar.isHidden = true
+    }
+    
+    
     // MARK: - Helpers
     /// 리액터와 바인딩을 위한 메서드
     open func bind(reactor: R) { }
     
     /// 서브 뷰 추가를 위한 메서드
-    open func setupUI() { }
+    open func setupUI() {
+        view.addSubview(navigationBarView)
+    }
     
     /// 오토레이아웃 설정을 위한 메서드
-    open func setupAutoLayout() { }
+    open func setupAutoLayout() {
+        navigationBarView.snp.makeConstraints {
+            $0.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(42)
+        }
+    }
     
     /// 뷰의 속성 설정을 위한 메서드
     open func setupAttributes() {
-        // assets 정해지면 바꿀게요.
-        view.backgroundColor = DesignSystemAsset.black.color
+        view.backgroundColor = .bibbiBlack
+        navigationController?.navigationBar.isHidden = true
     }
 }

--- a/14th-team5-iOS/Core/Sources/Base/BaseViewController.swift
+++ b/14th-team5-iOS/Core/Sources/Base/BaseViewController.swift
@@ -13,10 +13,11 @@ import RxSwift
 
 open class BaseViewController<R>: UIViewController, ReactorKit.View where R: Reactor {
     public typealias Reactor = R
-    
+
     // MARK: - Properties
     public var disposeBag: RxSwift.DisposeBag = DisposeBag()
-    
+    public let navigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
+
     // MARK: - Intializer
     public init() {
         super.init(nibName: nil, bundle: nil)
@@ -41,17 +42,41 @@ open class BaseViewController<R>: UIViewController, ReactorKit.View where R: Rea
     
     // MARK: - Helpers
     /// 리액터와 바인딩을 위한 메서드
-    open func bind(reactor: R) { }
+    open func bind(reactor: R) {
+        navigationBarView.rx.leftButtonTap
+            .observe(on: MainScheduler.instance)
+            .withUnretained(self)
+            .bind(onNext: {
+                switch $0.1 {
+                case .arrowLeft:
+                    self.navigationController?.popViewController(animated: true)
+                case .xmark:
+                    self.navigationController?.popViewController(animated: true)
+//                    self.dismiss(animated: true) { self.dismissCompletion() }
+                default: break
+                }
+            })
+            .disposed(by: disposeBag)
+    }
     
     /// 서브 뷰 추가를 위한 메서드
-    open func setupUI() { }
+    open func setupUI() { 
+        view.addSubview(navigationBarView)
+    }
     
     /// 오토레이아웃 설정을 위한 메서드
-    open func setupAutoLayout() { }
+    open func setupAutoLayout() {
+        navigationBarView.snp.makeConstraints {
+            $0.horizontalEdges.top.equalTo(view.safeAreaLayoutGuide)
+            $0.height.equalTo(52)
+        }
+    }
     
     /// 뷰의 속성 설정을 위한 메서드
-    open func setupAttributes() { 
-        // assets 정해지면 바꿀게요.
-        view.backgroundColor = DesignSystemAsset.black.color
+    open func setupAttributes() {
+        view.backgroundColor = .bibbiBlack
+        navigationController?.navigationBar.isHidden = true
     }
+    
+    open func dismissCompletion() { }
 }

--- a/14th-team5-iOS/Core/Sources/Views/BibbiNavigationBarView/BibbiNavigationBarView.swift
+++ b/14th-team5-iOS/Core/Sources/Views/BibbiNavigationBarView/BibbiNavigationBarView.swift
@@ -21,126 +21,130 @@ public final class BibbiNavigationBarView: UIView {
     private let navigationTitleLabel: BibbiLabel = BibbiLabel(.head2Bold, textColor: .gray200)
     private var navigationImageView: UIImageView = UIImageView()
     
-    private let leftBarButton: UIButton = UIButton(type: .system)
-    private let rightBarButton: UIButton = UIButton(type: .system)
+    fileprivate let leftBarButton: UIButton = UIButton(type: .system)
+    fileprivate let rightBarButton: UIButton = UIButton(type: .system)
+    
+    private let disposeBag = DisposeBag()
+    
+    var leftBarItem: LeftBarItem?
     
     // MARK: - Properties
-    weak public var delegate: BibbiNavigationBarViewDelegate?
+//    weak public var delegate: BibbiNavigationBarViewDelegate?
     
-    public var navigationTitle: String? {
-        didSet {
-            navigationImageView.isHidden = true
-            navigationTitleLabel.isHidden = false
-            
-            navigationTitleLabel.text = navigationTitle
-        }
-    }
+//    public var navigationTitle: String? {
+//        didSet {
+//            navigationImageView.isHidden = true
+//            navigationTitleLabel.isHidden = false
+//            
+//            navigationTitleLabel.text = navigationTitle
+//        }
+//    }
     
-    public var navigationImage: UIImage.TopBarImageType? {
-        didSet {
-            navigationImageView.isHidden = false
-            navigationTitleLabel.isHidden = true
-            
-            navigationImageView.image = navigationImage?.barImage
-        }
-    }
+//    public var navigationImage: UIImage.TopBarImageType? {
+//        didSet {
+//            navigationImageView.isHidden = false
+//            navigationTitleLabel.isHidden = true
+//            
+//            navigationImageView.image = navigationImage?.barImage
+//        }
+//    }
     
-    public var leftBarButtonItem: UIImage.TopBarIconType?   {
-        didSet {
-            leftBarButton.setImage(
-                leftBarButtonItem?.barButtonImage,
-                for: .normal
-            )
-            setupButtonBackground(leftBarButton, type: leftBarButtonItem)
-        }
-    }
+//    public var leftBarButtonItem: UIImage.TopBarIconType?   {
+//        didSet {
+//            leftBarButton.setImage(
+//                leftBarButtonItem?.barButtonImage,
+//                for: .normal
+//            )
+////            setupButtonBackground(leftBarButton, type: leftBarButtonItem)
+//        }
+//    }
     
-    public var rightBarButtonItem: UIImage.TopBarIconType? {
-        didSet {
-            rightBarButton.setImage(
-                rightBarButtonItem?.barButtonImage,
-                for: .normal
-            )
-            setupButtonBackground(rightBarButton, type: leftBarButtonItem)
-        }
-    }
+//    public var rightBarButtonItem: UIImage.TopBarIconType? {
+//        didSet {
+//            rightBarButton.setImage(
+//                rightBarButtonItem?.barButtonImage,
+//                for: .normal
+//            )
+////            setupButtonBackground(rightBarButton, type: leftBarButtonItem)
+//        }
+//    }
+//    
+//    public var navigationImageScale: CGFloat = 1.0 {
+//        didSet {
+//            setupNavigationImageScale(navigationImageScale)
+//        }
+//    }
+//    
+//    public var leftBarButtonItemScale: CGFloat = 1.0 {
+//        didSet {
+//            setupLeftButtonImageScale(leftBarButtonItemScale)
+//        }
+//    }
+//    
+//    public var rightBarButtonItemScale: CGFloat = 1.0 {
+//        didSet {
+//            setupRightButtonImageScale(rightBarButtonItemScale)
+//        }
+//    }
+//    
+//    public var navigationTitleTextColor: UIColor = UIColor.gray200 {
+//        didSet {
+//            navigationTitleLabel.textColor = navigationTitleTextColor
+//        }
+//    }
     
-    public var navigationImageScale: CGFloat = 1.0 {
-        didSet {
-            setupNavigationImageScale(navigationImageScale)
-        }
-    }
-    
-    public var leftBarButtonItemScale: CGFloat = 1.0 {
-        didSet {
-            setupLeftButtonImageScale(leftBarButtonItemScale)
-        }
-    }
-    
-    public var rightBarButtonItemScale: CGFloat = 1.0 {
-        didSet {
-            setupRightButtonImageScale(rightBarButtonItemScale)
-        }
-    }
-    
-    public var navigationTitleTextColor: UIColor = UIColor.gray200 {
-        didSet {
-            navigationTitleLabel.textColor = navigationTitleTextColor
-        }
-    }
-    
-    public var leftBarButtonItemTintColor: UIColor = UIColor.gray300 {
-        didSet {
-            leftBarButton.tintColor = leftBarButtonItemTintColor
-        }
-    }
-    
-    public var rightBarButtonItemTintColor: UIColor = UIColor.gray300 {
-        didSet {
-            rightBarButton.tintColor = rightBarButtonItemTintColor
-        }
-    }
-    
-    public var leftBarButtonItemYOffset: CGFloat = 0.0 {
-        didSet {
-            leftBarButton.snp.updateConstraints {
-                $0.leading.equalTo(leftBarButtonItemYOffset)
-            }
-        }
-    }
-    
-    public var rightBarButtonItemYOffset: CGFloat = 0.0 {
-        didSet {
-            rightBarButton.snp.updateConstraints {
-                $0.trailing.equalTo(rightBarButtonItemYOffset)
-            }
-            rightBarButton.layoutIfNeeded()
-        }
-    }
-    
-    public var hiddenLeftBarButtonBackground: Bool? {
-        didSet {
-            if let hidden = hiddenLeftBarButtonBackground {
-                if hidden {
-                    leftBarButton.backgroundColor = UIColor.clear
-                } else {
-                    leftBarButton.backgroundColor = UIColor.gray900
-                }
-            }
-        }
-    }
-    
-    public var hiddenRightBarButtonBackground: Bool? {
-        didSet {
-            if let hidden = hiddenRightBarButtonBackground {
-                if hidden {
-                    rightBarButton.backgroundColor = UIColor.clear
-                } else {
-                    rightBarButton.backgroundColor = UIColor.gray900
-                }
-            }
-        }
-    }
+//    public var leftBarButtonItemTintColor: UIColor = UIColor.gray300 {
+//        didSet {
+//            leftBarButton.tintColor = leftBarButtonItemTintColor
+//        }
+//    }
+//    
+//    public var rightBarButtonItemTintColor: UIColor = UIColor.gray300 {
+//        didSet {
+//            rightBarButton.tintColor = rightBarButtonItemTintColor
+//        }
+//    }
+//    
+//    public var leftBarButtonItemYOffset: CGFloat = 0.0 {
+//        didSet {
+//            leftBarButton.snp.updateConstraints {
+//                $0.leading.equalTo(leftBarButtonItemYOffset)
+//            }
+//        }
+//    }
+//    
+//    public var rightBarButtonItemYOffset: CGFloat = 0.0 {
+//        didSet {
+//            rightBarButton.snp.updateConstraints {
+//                $0.trailing.equalTo(rightBarButtonItemYOffset)
+//            }
+//            rightBarButton.layoutIfNeeded()
+//        }
+//    }
+//    
+//    public var hiddenLeftBarButtonBackground: Bool? {
+//        didSet {
+//            if let hidden = hiddenLeftBarButtonBackground {
+//                if hidden {
+//                    leftBarButton.backgroundColor = UIColor.clear
+//                } else {
+//                    leftBarButton.backgroundColor = UIColor.gray900
+//                }
+//            }
+//        }
+//    }
+//    
+//    public var hiddenRightBarButtonBackground: Bool? {
+//        didSet {
+//            if let hidden = hiddenRightBarButtonBackground {
+//                if hidden {
+//                    rightBarButton.backgroundColor = UIColor.clear
+//                } else {
+//                    rightBarButton.backgroundColor = UIColor.gray900
+//                }
+//            }
+//        }
+//    }
     
     // MARK: - Intializer
     public override init(frame: CGRect) {
@@ -162,15 +166,15 @@ public final class BibbiNavigationBarView: UIView {
         )
     }
     
-    func setupAutolayout() {
+    private func setupAutolayout() {
         containerView.snp.makeConstraints {
             $0.edges.equalToSuperview()
         }
         
         navigationImageView.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.width.equalTo(self.snp.width).multipliedBy(0.15)
-            $0.height.equalTo(self.snp.height)
+            $0.width.equalToSuperview().multipliedBy(0.15)
+            $0.height.equalToSuperview()
         }
         
         navigationTitleLabel.snp.makeConstraints {
@@ -178,19 +182,19 @@ public final class BibbiNavigationBarView: UIView {
         }
         
         leftBarButton.snp.makeConstraints {
-            $0.leading.equalTo(0.0)
-            $0.centerY.equalTo(self.snp.centerY)
-            $0.width.height.equalTo(52.0)
+            $0.leading.top.equalToSuperview()
+//            $0.centerY.equalToSuperview()
+            $0.size.equalTo(52.0)
         }
         
         rightBarButton.snp.makeConstraints {
-            $0.trailing.equalTo(0.0)
-            $0.centerY.equalTo(self.snp.centerY)
-            $0.width.height.equalTo(52.0)
+            $0.trailing.top.equalToSuperview()
+//            $0.centerY.equalToSuperview()
+            $0.size.equalTo(52.0)
         }
     }
     
-    func setupAttributes() {
+    private func setupAttributes() {
         containerView.do {
             $0.backgroundColor = UIColor.clear
         }
@@ -202,71 +206,165 @@ public final class BibbiNavigationBarView: UIView {
         leftBarButton.do {
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 10.0
-            $0.tintColor = DesignSystemAsset.gray300.color
-            
-            $0.addTarget(
-                self,
-                action: #selector(didTapLeftButton),
-                for: .touchUpInside
-            )
-            
+            $0.tintColor = .gray300
+//            
+//            $0.addTarget(
+//                self,
+//                action: #selector(didTapLeftButton),
+//                for: .touchUpInside
+//            )
+//            
         }
         
         rightBarButton.do {
             $0.layer.masksToBounds = true
             $0.layer.cornerRadius = 10.0
-            $0.tintColor = DesignSystemAsset.gray300.color
-            
-            $0.addTarget(
-                self,
-                action: #selector(didTapRightButton),
-                for: .touchUpInside
-            )
+            $0.tintColor = .gray300
+//            $0.contentScaleFactor = 2.0
+//
+//            $0.addTarget(
+//                self,
+//                action: #selector(didTapRightButton),
+//                for: .touchUpInside
+//            )
         }
         
-        setupNavigationImageScale(navigationImageScale)
-        setupLeftButtonImageScale(leftBarButtonItemScale)
-        setupRightButtonImageScale(rightBarButtonItemScale)
+//        setupNavigationImageScale(navigationImageScale)
+//        setupLeftButtonImageScale(leftBarButtonItemScale)
+//        setupRightButtonImageScale(rightBarButtonItemScale)
     }
 }
 
 // MARK: - Extensions
 extension BibbiNavigationBarView {
-    private func setupNavigationImageScale(_ scale: CGFloat) {
-        navigationImageView.layer.transform = CATransform3DMakeScale(
-            scale, scale, scale
-        )
+//    private func setupNavigationImageScale(_ scale: CGFloat) {
+//        navigationImageView.layer.transform = CATransform3DMakeScale(
+//            scale, scale, scale
+//        )
+//    }
+//    
+//    private func setupLeftButtonImageScale(_ scale: CGFloat) {
+//        leftBarButton.imageView?.layer.transform = CATransform3DMakeScale(
+//            scale, scale, scale
+//        )
+//    }
+//    
+//    private func setupRightButtonImageScale(_ scale: CGFloat) {
+//        rightBarButton.imageView?.layer.transform = CATransform3DMakeScale(
+//            scale, scale, scale
+//        )
+//    }
+    
+//    private func setupButtonBackground(type: UIImage.TopBarIconType?) {
+//        if type == .arrowLeft || type == .xmark {
+//            button.backgroundColor = .gray900
+//        } else {
+//            button.backgroundColor = .clear
+//        }
+//    }
+}
+
+//extension BibbiNavigationBarView {
+//    @objc func didTapLeftButton(_ button: UIButton, event: UIButton.Event) {
+//        guard let _ = button.currentImage else { return }
+//        delegate?.navigationBarView?(button, didTapLeftBarButton: event)
+//    }
+//    
+//    @objc func didTapRightButton(_ button: UIButton, event: UIButton.Event) {
+//        guard let _ = button.currentImage else { return }
+//        delegate?.navigationBarView?(button, didTapRightBarButton: event)
+//    }
+//}
+
+//public final class NavigationBarButton: UIButton {
+//    let type: LeftBarButton
+//}
+public enum LeftBarItem: Equatable {
+    case xmark
+    case arrowLeft
+    case family
+    
+    var backgroundColor: UIColor {
+        switch self {
+        case .xmark, .arrowLeft: return .gray900
+        default: return .clear
+        }
     }
     
-    private func setupLeftButtonImageScale(_ scale: CGFloat) {
-        leftBarButton.imageView?.layer.transform = CATransform3DMakeScale(
-            scale, scale, scale
-        )
-    }
-    
-    private func setupRightButtonImageScale(_ scale: CGFloat) {
-        rightBarButton.imageView?.layer.transform = CATransform3DMakeScale(
-            scale, scale, scale
-        )
-    }
-    
-    private func setupButtonBackground(_ button: UIButton, type: UIImage.TopBarIconType?) {
-        if type == .arrowLeft || type == .xmark {
-            button.backgroundColor = .gray900
-        } else {
-            button.backgroundColor = .clear
+    var image: UIImage {
+        switch self {
+        case .arrowLeft: return DesignSystemAsset.arrowLeft.image
+        case .xmark: return DesignSystemAsset.xmark.image
+        case .family: return DesignSystemAsset.addPerson.image
         }
     }
 }
 
 extension BibbiNavigationBarView {
-    @objc func didTapLeftButton(_ button: UIButton, event: UIButton.Event) {
-        guard let _ = button.currentImage else { return }
-        delegate?.navigationBarView?(button, didTapLeftBarButton: event)
+    
+    
+    public enum CenterBarItem: Equatable {
+        case logo
+        case label(String?)
+        
+        var title: String? {
+            switch self {
+            case .label(let title): return title
+            default: return nil
+            }
+        }
+        
+        var logo: UIImage? {
+            switch self {
+            case .logo: return DesignSystemAsset.bibbiLogo.image
+            default: return nil
+            }
+        }
+    }
+
+    public enum RightBarItem {
+        case empty
+        case setting
+        case calendar
+        
+        var image: UIImage? {
+            switch self {
+            case .setting: return DesignSystemAsset.setting.image
+            case .calendar: return DesignSystemAsset.heartCalendar.image
+            default: return nil
+            }
+        }
     }
     
-    @objc func didTapRightButton(_ button: UIButton, event: UIButton.Event) {
-        guard let _ = button.currentImage else { return }
-        delegate?.navigationBarView?(button, didTapRightBarButton: event)
+    public func setNavigationView(leftItem: LeftBarItem, centerItem: CenterBarItem? = nil, rightItem: RightBarItem) {
+        leftBarButton.setImage(leftItem.image, for: .normal)
+        rightBarButton.setImage(rightItem.image, for: .normal)
+        leftBarButton.backgroundColor = leftItem.backgroundColor
+        
+        self.leftBarItem = leftItem
+        self.navigationImageView.image = centerItem?.logo
+        self.navigationTitleLabel.text = centerItem?.title
+    }
+    
+    public func setNavigationTitle(title: String) {
+        self.navigationTitleLabel.text = title
+    }
+}
+
+extension Reactive where Base: BibbiNavigationBarView {
+   public  var leftButtonTap: ControlEvent<LeftBarItem?> {
+        let source = base.leftBarButton.rx.tap
+            .withUnretained(base)
+            .map { $0.0.leftBarItem }
+            .throttle(RxConst.throttleInterval, scheduler: MainScheduler.instance)
+        
+        return ControlEvent(events: source)
+    }
+    
+    public var rightButtonTap: ControlEvent<Void> {
+        let source = base.rightBarButton.rx.tap
+            .throttle(RxConst.throttleInterval, scheduler: MainScheduler.instance)
+
+        return ControlEvent(events: source)
     }
 }

--- a/14th-team5-iOS/Core/Sources/Views/BibbiNavigationBarView/DelegateProxy/RxBibbiNavigationDelegateProxy.swift
+++ b/14th-team5-iOS/Core/Sources/Views/BibbiNavigationBarView/DelegateProxy/RxBibbiNavigationDelegateProxy.swift
@@ -9,42 +9,42 @@ import UIKit
 
 import RxSwift
 import RxCocoa
-
-@objc public protocol BibbiNavigationBarViewDelegate {
-    @objc optional func navigationBarView(_ button: UIButton, didTapRightBarButton event: UIControl.Event)
-    @objc optional func navigationBarView(_ button: UIButton, didTapLeftBarButton event: UIControl.Event)
-}
-
-final class RxBibbiNavigationBarViewDelegateProxy: DelegateProxy<BibbiNavigationBarView, BibbiNavigationBarViewDelegate>, DelegateProxyType, BibbiNavigationBarViewDelegate {
-    static func registerKnownImplementations() {
-        self.register {
-            RxBibbiNavigationBarViewDelegateProxy(parentObject: $0, delegateProxy: self)
-        }
-    }
-}
-
-extension BibbiNavigationBarView: HasDelegate {
-    public typealias Delegate = BibbiNavigationBarViewDelegate
-}
-
-extension Reactive where Base: BibbiNavigationBarView {
-    public var delegate: DelegateProxy<BibbiNavigationBarView, BibbiNavigationBarViewDelegate> {
-        return RxBibbiNavigationBarViewDelegateProxy.proxy(for: self.base)
-    }
-    
-    public var didTapLeftBarButton: ControlEvent<UIButton> {
-        let source = delegate.sentMessage(#selector(BibbiNavigationBarViewDelegate.navigationBarView(_:didTapLeftBarButton:)))
-            .debug("navigationBarView(_:didTapLeftBarButton:) 메서드 호출 성공")
-            .map { $0[0] as! UIButton }
-        
-        return ControlEvent(events: source)
-    }
-    
-    public var didTapRightBarButton: ControlEvent<UIButton> {
-        let source = delegate.sentMessage(#selector(BibbiNavigationBarViewDelegate.navigationBarView(_:didTapRightBarButton:)))
-            .debug("navigationBarView(_:didTapRightBarButton:) 메서드 호출 성공")
-            .map { $0[0] as! UIButton }
-        
-        return ControlEvent(events: source)
-    }
-}
+//
+//@objc public protocol BibbiNavigationBarViewDelegate {
+//    @objc optional func navigationBarView(_ button: UIButton, didTapRightBarButton event: UIControl.Event)
+//    @objc optional func navigationBarView(_ button: UIButton, didTapLeftBarButton event: UIControl.Event)
+//}
+//
+//final class RxBibbiNavigationBarViewDelegateProxy: DelegateProxy<BibbiNavigationBarView, BibbiNavigationBarViewDelegate>, DelegateProxyType, BibbiNavigationBarViewDelegate {
+//    static func registerKnownImplementations() {
+//        self.register {
+//            RxBibbiNavigationBarViewDelegateProxy(parentObject: $0, delegateProxy: self)
+//        }
+//    }
+//}
+//
+//extension BibbiNavigationBarView: HasDelegate {
+//    public typealias Delegate = BibbiNavigationBarViewDelegate
+//}
+//
+//extension Reactive where Base: BibbiNavigationBarView {
+//    public var delegate: DelegateProxy<BibbiNavigationBarView, BibbiNavigationBarViewDelegate> {
+//        return RxBibbiNavigationBarViewDelegateProxy.proxy(for: self.base)
+//    }
+//    
+//    public var didTapLeftBarButton: ControlEvent<UIButton> {
+//        let source = delegate.sentMessage(#selector(BibbiNavigationBarViewDelegate.navigationBarView(_:didTapLeftBarButton:)))
+//            .debug("navigationBarView(_:didTapLeftBarButton:) 메서드 호출 성공")
+//            .map { $0[0] as! UIButton }
+//        
+//        return ControlEvent(events: source)
+//    }
+//    
+//    public var didTapRightBarButton: ControlEvent<UIButton> {
+//        let source = delegate.sentMessage(#selector(BibbiNavigationBarViewDelegate.navigationBarView(_:didTapRightBarButton:)))
+//            .debug("navigationBarView(_:didTapRightBarButton:) 메서드 호출 성공")
+//            .map { $0[0] as! UIButton }
+//        
+//        return ControlEvent(events: source)
+//    }
+//}


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 삐삐네비게이션 어트리뷰터 수정
- 베이스뷰컨트롤러 수정
- left, right 버튼 이벤트 수정
- 모든 뷰컨트롤러 레이아웃 수정



## 변경 로직 ⚒️

- 네비게이션바를 baseviewcontroller에 추가하였기 때문에 앞으로 베이스뷰컨을 상속받는 경우 setupui, setupautolayout은 따로 설정해주지 않으셔도 됩니다.

- 대신 setupAttributes에서 navigationview.do { $0.setNavigationView() }를 호출하면서 left,center,right item을 한꺼번에 설정해주세요.

- left, center, right Item의 경우 enum으로 설정해두었기 때문에 새로운게 생기면 enum을 추가해서 사용해주세요.

- 또한 왼쪽 버튼(X 또는 <)일 경우 pop 되게 해두었기 때문에 따로 tap이벤트 걸지 않으셔도 됩니다. 나갈 때 액션이 필요한 경우에만 tap이벤트 설정해주세요.




