### PR TITLE
fix: 의도치 않은 프로필 터치 문제 수정, 중복 Push 이벤트 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -181,6 +181,14 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
             }
             .disposed(by: disposeBag)
         
+        reactor.pulse(\.$shouldPushProfileViewController)
+            .delay(.milliseconds(500), scheduler: Schedulers.main)
+            .compactMap { $0 }
+            .bind(with: self) { owner, id in
+                owner.pushProfileViewController(memberId: id)
+            }
+            .disposed(by: disposeBag)
+        
         reactor.state.compactMap { $0.visiblePostList }
             .map { $0 }
             .distinctUntilChanged()
@@ -226,9 +234,8 @@ public final class CalendarPostViewController: BaseViewController<CalendarPostVi
 //            .withUnretained(self)
 //            .subscribe { $0.0.navigationController?.popViewController(animated: true) }
 //            .disposed(by: disposeBag)
-//        
-        didTapProfileImageNotificationHandler()
-        didTapSelectableCameraButtonNotifcationHandler()
+//
+        didTapCameraButtonNotifcationHandler()
     }
     
     public override func setupUI() {
@@ -437,25 +444,12 @@ extension CalendarPostViewController {
 }
 
 extension CalendarPostViewController {
-    private func didTapSelectableCameraButtonNotifcationHandler() {
+    private func didTapCameraButtonNotifcationHandler() {
         NotificationCenter.default
             .rx.notification(.didTapSelectableCameraButton)
             .withUnretained(self)
             .bind { owner, _ in
                 owner.pushCameraViewController(cameraType: .realEmoji)
-            }.disposed(by: disposeBag)
-    }
-    
-    private func didTapProfileImageNotificationHandler() {
-        NotificationCenter.default
-            .rx.notification(.didTapProfilImage)
-            .withUnretained(self)
-            .bind { owner, notification in
-                guard let userInfo = notification.userInfo,
-                      let memberId = userInfo["memberId"] as? String else {
-                    return
-                }
-                owner.pushProfileViewController(memberId: memberId)
             }
             .disposed(by: disposeBag)
     }

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/CommentCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/CommentCellReactor.swift
@@ -18,7 +18,7 @@ final public class CommentCellReactor: Reactor {
     public enum Action { 
         case fetchUserName
         case fetchProfileImageUrlString
-        case didTapProfileImageView
+        case didTapProfileButton
     }
     
     // MARK: - Mutation
@@ -79,7 +79,7 @@ final public class CommentCellReactor: Reactor {
             let urlString = memberUseCase.executeProfileImageUrlString(memberId: initialState.memberId)
             return Observable<Mutation>.just(.injectProfileImageUrlString(urlString))
             
-        case .didTapProfileImageView:
+        case .didTapProfileButton:
             let memberId = initialState.memberId
             if memberUseCase.executeCheckIsValidMember(memberId: memberId) {
                 provider.postGlobalState.pushProfileViewController(memberId)

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
@@ -41,7 +41,8 @@ final public class PostCommentViewReactor: Reactor {
         case becomeFirstResponseder
         case clearCommentTextField
         case enableCommentTextField(Bool)
-        case setProfileViewController(String)
+        
+        case dismiss
     }
     
     // MARK: - State
@@ -60,7 +61,7 @@ final public class PostCommentViewReactor: Reactor {
         @Pulse var shouldPresentEmptyCommentView: Bool
         @Pulse var shouldPresentPaperAirplaneLottieView: Bool
         @Pulse var shouldGenerateErrorHapticNotification: Bool
-        @Pulse var shouldPushProfileViewController: String?
+        @Pulse var shouldDismiss: Bool
         @Pulse var becomeFirstResponder: Bool
         var enableCommentTextField: Bool
         var tableViewBottomOffset: CGFloat
@@ -97,7 +98,7 @@ final public class PostCommentViewReactor: Reactor {
             shouldPresentEmptyCommentView: false,
             shouldPresentPaperAirplaneLottieView: false,
             shouldGenerateErrorHapticNotification: false,
-            shouldPushProfileViewController: nil,
+            shouldDismiss: false,
             becomeFirstResponder: false,
             enableCommentTextField: false,
             tableViewBottomOffset: 0
@@ -128,8 +129,8 @@ final public class PostCommentViewReactor: Reactor {
         let postMutation = provider.postGlobalState.event
             .flatMap { event in
                 switch event {
-                case let .pushProfileViewController(memberId):
-                    return Observable<Mutation>.just(.setProfileViewController(memberId))
+                case let .pushProfileViewController(_):
+                    return Observable<Mutation>.just(.dismiss)
                 default:
                     return Observable<Mutation>.empty()
                 }
@@ -344,8 +345,8 @@ final public class PostCommentViewReactor: Reactor {
         case let .setTableViewOffset(height):
             newState.tableViewBottomOffset = height
             
-        case let .setProfileViewController(memberId):
-            newState.shouldPushProfileViewController = memberId
+        case .dismiss:
+            newState.shouldDismiss = true
         }
         
         return newState

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/View/Cell/CommentCell.swift
@@ -19,6 +19,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     private let containerView: UIView = UIView()
     private let firstNameLabel: UILabel = BibbiLabel(.head2Bold, alignment: .center, textColor: .bibbiWhite)
     private let profileImageView: UIImageView = UIImageView()
+    private let profileButton: UIButton = UIButton()
     
     private let userNameStack: UIStackView = UIStackView()
     private let userNameLabel: BibbiLabel = BibbiLabel(.body2Bold, textColor: .gray100)
@@ -40,6 +41,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     
     // MARK: - Helerps
     public override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        disposeBag = DisposeBag()
+        
         userNameLabel.text = String.none
         createdAtLabel.text = String.none
         profileImageView.image = nil
@@ -59,9 +64,9 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
         
-        containerView.rx.tap
+        profileButton.rx.tap
             .throttle(RxConst.throttleInterval, scheduler: Schedulers.main)
-            .map { Reactor.Action.didTapProfileImageView }
+            .map { Reactor.Action.didTapProfileButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
@@ -99,7 +104,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     public override func setupUI() {
         super.setupUI()
         
-        containerView.addSubviews(firstNameLabel, profileImageView)
+        containerView.addSubviews(firstNameLabel, profileImageView, profileButton)
         contentView.addSubviews(containerView, userNameStack, commentLabel)
         userNameStack.addArrangedSubviews(userNameLabel, createdAtLabel)
     }
@@ -111,6 +116,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             $0.size.equalTo(44)
             $0.top.equalTo(contentView.snp.top).offset(8)
             $0.leading.equalTo(contentView.snp.leading).offset(20)
+        }
+        
+        profileButton.snp.makeConstraints {
+            $0.edges.equalToSuperview()
         }
         
         firstNameLabel.snp.makeConstraints {
@@ -139,6 +148,11 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         
         contentView.do {
             $0.backgroundColor = UIColor.bibbiBlack
+        }
+        
+        profileButton.do {
+            $0.setTitle(.none, for: .normal)
+            $0.backgroundColor = UIColor.clear
         }
         
         containerView.do {

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/ViewController/PostCommentViewController.swift
@@ -190,12 +190,10 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
             .bind(to: bibbiLottieView.rx.isHidden)
             .disposed(by: disposeBag)
         
-        reactor.pulse(\.$shouldPushProfileViewController)
-            .compactMap { $0 }
-            .bind(with: self, onNext: { owner, memberId in
-                owner.dismiss(animated: true) {
-                    owner.postDidTapProfileImageNotification(memberId: memberId)
-                }
+        reactor.pulse(\.$shouldDismiss)
+            .filter { $0 }
+            .bind(with: self, onNext: { owner, _ in
+                owner.dismiss(animated: true)
             })
             .disposed(by: disposeBag)
         
@@ -350,16 +348,6 @@ final public class PostCommentViewController: BaseViewController<PostCommentView
         fetchFailureView.do {
             $0.isHidden = true
         }
-    }
-}
-
-extension PostCommentViewController {
-    private func postDidTapProfileImageNotification(memberId: String) {
-        NotificationCenter.default.post(
-            name: .didTapProfilImage,
-            object: nil,
-            userInfo: ["memberId": memberId]
-        )
     }
 }
 

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostDetailViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/PostDetailViewReactor.swift
@@ -24,7 +24,6 @@ final class PostDetailViewReactor: Reactor {
     
     enum Mutation {
         case injectDisplayContent([DisplayEditItemModel])
-        case setProfileViewController(String)
     }
     
     struct State {
@@ -53,7 +52,7 @@ extension PostDetailViewReactor {
         case .didTapProfileImageView:
             let memberId = initialState.post.author?.memberId ?? .none
             if memberUseCase.executeCheckIsValidMember(memberId: memberId) {
-                return Observable<Mutation>.just(.setProfileViewController(memberId))
+                provider.postGlobalState.pushProfileViewController(memberId)
             }
             return Observable<Mutation>.empty()
             
@@ -73,8 +72,6 @@ extension PostDetailViewReactor {
         switch mutation {
         case let .injectDisplayContent(section):
             newState.fetchedDisplayContent = [.displayKeyword(section)]
-        case let .setProfileViewController(memberId):
-            newState.shouldPushProfileViewController = memberId
         }
         return newState
     }

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
@@ -77,6 +77,13 @@ final class PostViewController: BaseViewController<PostReactor> {
             .bind(onNext: { $0.0.navigationController?.popViewController(animated: true) })
             .disposed(by: disposeBag)
         
+        reactor.pulse(\.$shouldPushProfileViewController)
+            .compactMap { $0 }
+            .bind(with: self) { owner, id in
+                owner.pushProfileViewController(memberId: id)
+            }
+            .disposed(by: disposeBag)
+        
         collectionView.rx.willBeginDragging
             .observe(on: MainScheduler.instance)
             .bind(onNext: { [weak self] _ in
@@ -98,8 +105,6 @@ final class PostViewController: BaseViewController<PostReactor> {
             .map { Reactor.Action.setPost($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        didTapProfileImageNotificationHandler()
     }
     
     override func setupUI() {
@@ -226,22 +231,6 @@ extension PostViewController {
                     return cell
                 }
             })
-    }
-}
-
-extension PostViewController {
-    private func didTapProfileImageNotificationHandler() {
-        NotificationCenter.default
-            .rx.notification(.didTapProfilImage)
-            .withUnretained(self)
-            .bind { owner, notification in
-                guard let userInfo = notification.userInfo,
-                      let memberId = userInfo["memberId"] as? String else {
-                    return
-                }
-                owner.pushProfileViewController(memberId: memberId)
-            }
-            .disposed(by: disposeBag)
     }
 }
 

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostDetailCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Views/PostDetailCollectionViewCell.swift
@@ -199,7 +199,7 @@ extension PostDetailCollectionViewCell {
         reactor.pulse(\.$shouldPushProfileViewController)
             .compactMap { $0 }
             .bind(with: self) { owner, memberId in
-                owner.postDidTapProfileImageNotification(memberId: memberId)
+                
             }
             .disposed(by: disposeBag)
     }
@@ -226,14 +226,6 @@ extension PostDetailCollectionViewCell {
         if let name = post.author?.name {
             userNameLabel.text = name
         }
-    }
-    
-    private func postDidTapProfileImageNotification(memberId: String) {
-        NotificationCenter.default.post(
-            name: .didTapProfilImage,
-            object: nil,
-            userInfo: ["memberId": memberId]
-        )
     }
 }
 

--- a/14th-team5-iOS/Core/Sources/Extensions/Notification+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Notification+Ext.swift
@@ -22,5 +22,4 @@ extension Notification.Name {
     public static let didTapCreatFamilyGroupButton = Notification.Name("didTapCreatFamilyGroupButton")
     public static let didTapBibbiToastTranstionButton = Notification.Name("didTapTranstionButton")
     public static let didTapUpdateButton = Notification.Name("didTapUpdateButton")
-    public static let didTapProfilImage = Notification.Name("didTapProfileImage")
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 댓글 목록 화면에서 프로필 이미지가 의도치 않은 클릭이 일어날 수 있는 문제 수정
- 댓글 목록 화면에서 프로필 이미지를 클릭하면 프로필 화면 이동 이벤트가 중복으로 일어나는 문제 수정

close #442 