### PR TITLE
fix: 피드의 댓글 개수가 제대로 갱신되지 않는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -22,19 +22,20 @@ public final class CalendarPostViewReactor: Reactor {
         case fetchPostList(Date)
         case fetchCalendarResponse(String)
         case setBlurImageIndex(Int)
-        case sendPostIdToReaction(Int)
+        case sendPostToReaction(Int)
         case popViewController
     }
     
     // MARK: - Mutation
     public enum Mutation {
-        case popViewController
         case setAllUploadedToastMessageView(Bool)
         case injectCalendarResponse(String, ArrayResponseCalendarResponse)
         case injectPostResponse([PostListData])
         case injectBlurImageIndex(Int)
         case injectVisiblePost(PostListData)
+        case renewPostCommentCount(Int)
         case pushProfileViewController(String)
+        case popViewController
         case generateSelectionHaptic
     }
     
@@ -42,7 +43,7 @@ public final class CalendarPostViewReactor: Reactor {
     public struct State {
         var selectedDate: Date
         var blurImageUrlString: String?
-        var visiblePostList: PostListData?
+        var visiblePost: PostListData?
         @Pulse var displayPostResponse: [PostListSectionModel]
         @Pulse var displayCalendarResponse: [String: [CalendarResponse]]
         @Pulse var shouldPresentAllUploadedToastMessageView: Bool
@@ -85,7 +86,7 @@ public final class CalendarPostViewReactor: Reactor {
         self.provider = provider
     }
     
-    // MARK: - Transform
+    // MARK: - Transfor
     public func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
         let toastMutation = provider.toastGlobalState.event
             .flatMap {
@@ -100,8 +101,8 @@ public final class CalendarPostViewReactor: Reactor {
                 switch event {
                 case let .pushProfileViewController(memberId):
                     return Observable<Mutation>.just(.pushProfileViewController(memberId))
-                default:
-                    return Observable<Mutation>.empty()
+                case let .renewalPostCommentCount(count):
+                    return Observable<Mutation>.just(.renewPostCommentCount(count))
                 }
             }
         
@@ -172,12 +173,12 @@ public final class CalendarPostViewReactor: Reactor {
         case let .setBlurImageIndex(index):
             return Observable<Mutation>.just(.injectBlurImageIndex(index))
             
-        case let .sendPostIdToReaction(index):
+        case let .sendPostToReaction(index):
             guard let dataSource = currentState.displayPostResponse.first else {
                 return Observable<Mutation>.empty()
             }
-            let postListData = dataSource.items[index]
-            return Observable<Mutation>.just(.injectVisiblePost(postListData))
+            let post = dataSource.items[index]
+            return Observable<Mutation>.just(.injectVisiblePost(post))
         }
     }
     
@@ -186,14 +187,26 @@ public final class CalendarPostViewReactor: Reactor {
         var newState = state
         
         switch mutation {
-        case .popViewController:
-            newState.shouldPopViewController = true
-            
         case let .injectBlurImageIndex(index):
             guard let items = newState.displayPostResponse.first?.items else {
                 return newState
             }
             newState.blurImageUrlString = items[index].imageURL
+            
+        case let .renewPostCommentCount(count):
+            guard var posts = currentState.displayPostResponse.first?.items,
+                  let index = posts.firstIndex(where: { post in
+                post.postId == currentState.visiblePost?.postId
+            }) else {
+                return newState
+            }
+            guard var renewedPost = currentState.visiblePost else { return newState }
+            renewedPost.commentCount = count
+
+            posts[index] = renewedPost
+            
+            newState.visiblePost = posts[index] // ReactionViewController 데이터 갱신하기
+            newState.displayPostResponse = [.init(model: .none, items: posts)] // PostColelctionView 데이터 갱신하기
             
         case let .setAllUploadedToastMessageView(uploaded):
             newState.shouldPresentAllUploadedToastMessageView = uploaded
@@ -204,11 +217,14 @@ public final class CalendarPostViewReactor: Reactor {
         case let .injectPostResponse(postResponse):
             newState.displayPostResponse = [PostListSectionModel(model: .none, items: postResponse)]
             
-        case let .injectVisiblePost(postListData):
-            newState.visiblePostList = postListData
+        case let .injectVisiblePost(post):
+            newState.visiblePost = post
             
         case let .pushProfileViewController(memberId):
             newState.shouldPushProfileViewController = memberId
+            
+        case .popViewController:
+            newState.shouldPopViewController = true
             
         case .generateSelectionHaptic:
             newState.shouldGenerateSelectionHaptic = true

--- a/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostComment/Reactor/PostCommentViewReactor.swift
@@ -205,7 +205,6 @@ final public class PostCommentViewReactor: Reactor {
             let body = CreatePostCommentRequest(content: safeComment)
             
             return Observable.concat(
-                // TODO: - Button Indicator UI 구현하기
                 Observable<Mutation>.just(.enableCommentTextField(false)),
                 
                 postCommentUseCase.executeCreatePostComment(postId: postId, body: body)

--- a/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/ReactionViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/PostDetail/Reactor/ReactionViewReactor.swift
@@ -64,20 +64,6 @@ final class ReactionViewReactor: Reactor {
 }
 
 extension ReactionViewReactor {
-    func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let postMutation = provider.postGlobalState.event
-            .flatMap { event in
-                switch event {
-                case let .renewalPostCommentCount(count):
-                    return Observable<Mutation>.just(.setPostCommentCount(count))
-                default:
-                    return Observable<Mutation>.empty()
-                }
-            }
-        
-        return Observable.merge(mutation, postMutation)
-    }
-    
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .fetchReactionList(let postId):

--- a/14th-team5-iOS/Domain/Sources/Post/Entities/PostListData.swift
+++ b/14th-team5-iOS/Domain/Sources/Post/Entities/PostListData.swift
@@ -10,7 +10,7 @@ import Foundation
 public struct PostListData: Equatable, Hashable {
     public let postId: String
     public let author: ProfileData?
-    public let commentCount: Int
+    public var commentCount: Int
     public let emojiCount: Int
     public let imageURL: String
     public let content: String?


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 주간 캘린더 화면에서 피드의 댓글 개수가 제대로 갱신되지 않는 문제 수정

close #448 

