### PR TITLE
fix: base_ref release, develop 조건절 수정

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
       - fix/*
   pull_request:
     branches:
-      - releases/**
+      - release/**
       - develop
   
 jobs:  
@@ -61,7 +61,7 @@ jobs:
         run: tuist generate
 
       - name: fastlane upload_stg_testflight
-        if: ${{ github.base_ref == 'release' }}
+        if: github.event.pull_request.base.ref == 'release'
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
@@ -83,7 +83,7 @@ jobs:
 
 
       - name: fastlane upload_prd_testflight
-        if: ${{ github.base_ref == 'develop' }}
+        if: github.event.pull_request.base.ref == 'develop'
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -61,7 +61,7 @@ jobs:
         run: tuist generate
 
       - name: fastlane upload_stg_testflight
-        if: github.ref == 'refs/heads/releases/**'
+        if: ${{ github.base_ref == 'release' }}
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
@@ -83,7 +83,7 @@ jobs:
 
 
       - name: fastlane upload_prd_testflight
-        if: github.ref == 'refs/heads/develop'
+        if: ${{ github.base_ref == 'develop' }}
         env:
           APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
           APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}


### PR DESCRIPTION
## 작업 내용 🧑‍💻
- CI 기존 `ref.head` 가 아닌 `base_ref`를 통해 event tracking
- release 브런치 오타 수정


## 체크 리스트 📝

- [ ] base_ref를 사용해서 release Branch로 Merge 할 경우 `STG` develop 브런치로 Merge 할 경우 `PRD`로 배포하도록 수정
