### PR TITLE
feat: 재촉하기 네트워크 통신 로직 구현

### DIFF
--- a/14th-team5-iOS/App/Project.swift
+++ b/14th-team5-iOS/App/Project.swift
@@ -19,7 +19,7 @@ private let targets: [Target] = [
                 "CFBundleDisplayName": .string("Bibbi"),
                 "CFBundleVersion": .string("1"),
                 "CFBuildVersion": .string("0"),
-                "CFBundleShortVersionString": .string("1.1.8"),
+                "CFBundleShortVersionString": .string("1.2"),
                 "UILaunchStoryboardName": .string("LaunchScreen.storyboard"),
                 "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),
                 "UIUserInterfaceStyle": .string("Light"),

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/DataMapping/PickMemberListResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/DataMapping/PickMemberListResponseDTO.swift
@@ -1,0 +1,55 @@
+//
+//  PickMemberListResponse.swift
+//  Data
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation
+
+import Domain
+
+public struct PickMemberListResponseDTO: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case results
+    }
+    public var results: [PickMemberDTO]
+}
+
+extension PickMemberListResponseDTO {
+    public struct PickMemberDTO: Decodable {
+        enum CodingKeys: String, CodingKey {
+            case memberId
+            case name
+            case imageUrl
+            case familyId
+            case familyJoinAt
+            case dayOfBirth
+        }
+        public var memberId: String
+        public var name: String
+        public var imageUrl: String
+        public var familyId: String
+        public var familyJoinAt: String
+        public var dayOfBirth: String
+    }
+}
+
+extension PickMemberListResponseDTO {
+    func toDomain() -> PickMemberListResponse {
+        return .init(results: results.map { $0.toDomain() })
+    }
+}
+
+extension PickMemberListResponseDTO.PickMemberDTO {
+    func toDomain() -> PickMember {
+        return .init(
+            memberId: memberId,
+            name: name,
+            imageUrl: imageUrl,
+            familyId: familyId,
+            familyJoinedAt: familyJoinAt.toDate(with: .dashYyyyMMdd),
+            dayOfBirth: dayOfBirth.toDate(with: .dashYyyyMMdd)
+        )
+    }
+}

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/DataMapping/PickResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/DataMapping/PickResponseDTO.swift
@@ -1,0 +1,23 @@
+//
+//  PickResponseDTO.swift
+//  Data
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation
+
+import Domain
+
+public struct PickResponseDTO: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case success
+    }
+    public var success: Bool
+}
+
+extension PickResponseDTO {
+    func toDomain() -> PickResponse {
+        return .init(success: success)
+    }
+}

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIWorker.swift
@@ -1,0 +1,8 @@
+//
+//  PickAPIWorker.swift
+//  Data
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIWorker.swift
@@ -5,4 +5,118 @@
 //  Created by 김건우 on 4/15/24.
 //
 
+import Core
+import Domain
 import Foundation
+
+import RxSwift
+
+typealias PickAPIWorker = PickAPIs.Worker
+extension PickAPIs {
+    public final class Worker: APIWorker {
+        static let queue = {
+            ConcurrentDispatchQueueScheduler(queue: DispatchQueue(label: "PickAPIQueue", qos: .utility))
+        }()
+        
+        override public init() {
+            super.init()
+            self.id = "PickAPIWorker"
+        }
+        
+        // MARK: - Headers
+        private var _headers: Observable<[APIHeader]?> {
+            return App.Repository.token.accessToken
+                .map {
+                    guard let token = $0, 
+                          let accessToken = token.accessToken,
+                          !accessToken.isEmpty else {
+                        return []
+                    }
+                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
+                }
+        }
+    }
+}
+
+extension PickAPIWorker {
+    
+    private func pickMember(spec: APISpec, headers: [APIHeader]?) -> Single<PickResponse?> {
+        return request(spec: spec, headers: headers)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("PickMember Result: \(str)")
+                }
+            }
+            .map(PickResponseDTO.self)
+            .catchAndReturn(nil)
+            .map { $0?.toDomain() }
+            .asSingle()
+    }
+    
+    public func pickMember(memberId: String) -> Single<PickResponse?> {
+        let spec = PickAPIs.pick(memberId).spec
+        
+        return Observable<Void>.just(())
+            .withLatestFrom(self._headers)
+            .observe(on: Self.queue)
+            .withUnretained(self)
+            .flatMap { $0.0.pickMember(spec: spec, headers: $0.1) }
+            .asSingle()
+    }
+    
+    
+    private func fetchWhoDidIPickMember(spec: APISpec, headers: [APIHeader]?) -> Single<PickMemberListResponse?> {
+        return request(spec: spec, headers: headers)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("Who Did I Pick: \(str)")
+                }
+            }
+            .map(PickMemberListResponseDTO.self)
+            .catchAndReturn(nil)
+            .map { $0?.toDomain() }
+            .asSingle()
+    }
+    
+    public func fetchWhoDidIPickMember(memberId: String) -> Single<PickMemberListResponse?> {
+        let spec = PickAPIs.whoDidIPick(memberId).spec
+        
+        return Observable<Void>.just(())
+            .withLatestFrom(self._headers)
+            .observe(on: Self.queue)
+            .withUnretained(self)
+            .flatMap { $0.0.fetchWhoDidIPickMember(spec: spec, headers: $0.1) }
+            .asSingle()
+    }
+    
+    private func fetchWhoPickedMeMember(spec: APISpec, headers: [APIHeader]?) -> Single<PickMemberListResponse?> {
+        return request(spec: spec, headers: headers)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("Who Picked Me: \(str)")
+                }
+            }
+            .map(PickMemberListResponseDTO.self)
+            .catchAndReturn(nil)
+            .map { $0?.toDomain() }
+            .asSingle()
+    }
+    
+    public func fetchWhoPickedMeMember(memberId: String) -> Single<PickMemberListResponse?> {
+        let spec = PickAPIs.whoPickedMe(memberId).spec
+        
+        return Observable<Void>.just(())
+            .withLatestFrom(self._headers)
+            .observe(on: Self.queue)
+            .withUnretained(self)
+            .flatMap { $0.0.fetchWhoPickedMeMember(spec: spec, headers: $0.1) }
+            .asSingle()
+    }
+    
+    
+    
+    
+}

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIs.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIs.swift
@@ -1,0 +1,8 @@
+//
+//  PickAPIs.swift
+//  Data
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIs.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIs.swift
@@ -6,3 +6,20 @@
 //
 
 import Foundation
+
+enum PickAPIs: API {
+    case pick(String)
+    case whoDidIPick(String)
+    case whoPickedMe(String)
+    
+    var spec: APISpec {
+        switch self {
+        case let .pick(memberId):
+            return APISpec(method: .post, url: "\(BibbiAPI.hostApi)/members/\(memberId)/pick")
+        case let .whoDidIPick(memberId):
+            return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/members/\(memberId)/picked")
+        case let .whoPickedMe(memberId):
+            return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/members/\(memberId)/pick")
+        }
+    }
+}

--- a/14th-team5-iOS/Data/Sources/Pick/Repository/PickRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/Repository/PickRepository.swift
@@ -1,0 +1,37 @@
+//
+//  PickRepository.swift
+//  Data
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Core
+import Domain
+import Foundation
+
+import RxSwift
+
+public final class PickRepository: PickRepositoryProtocol {
+    public let disposeBag: DisposeBag = DisposeBag()
+    
+    private let pickApiWorker: PickAPIWorker = PickAPIWorker()
+    
+    public init() { }
+}
+
+extension PickRepository {
+    public func pickMember(memberId: String) -> Observable<PickResponse?> {
+        return pickApiWorker.pickMember(memberId: memberId)
+            .asObservable()
+    }
+    
+    public func whoDidIPickMember(memberId: String) -> Observable<PickMemberListResponse?> {
+        return pickApiWorker.fetchWhoDidIPickMember(memberId: memberId)
+            .asObservable()
+    }
+    
+    public func whoPickedMeMember(memberId: String) -> Observable<PickMemberListResponse?> {
+        return pickApiWorker.fetchWhoPickedMeMember(memberId: memberId)
+            .asObservable()
+    }
+}

--- a/14th-team5-iOS/Domain/Sources/Pick/Entities/PickMemberListResponse.swift
+++ b/14th-team5-iOS/Domain/Sources/Pick/Entities/PickMemberListResponse.swift
@@ -1,0 +1,41 @@
+//
+//  PickMemberListResponseDTO.swift
+//  Domain
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation
+
+public struct PickMemberListResponse {
+    public var results: [PickMember]
+    
+    public init(results: [PickMember]) {
+        self.results = results
+    }
+}
+
+public struct PickMember {
+    public var memberId: String
+    public var name: String
+    public var imageUrl: String
+    public var familyId: String
+    public var familyJoinedAt: Date
+    public var dayOfBirth: Date
+    
+    public init(
+        memberId: String,
+        name: String,
+        imageUrl: String,
+        familyId: String,
+        familyJoinedAt: Date,
+        dayOfBirth: Date
+    ) {
+        self.memberId = memberId
+        self.name = name
+        self.imageUrl = imageUrl
+        self.familyId = familyId
+        self.familyJoinedAt = familyJoinedAt
+        self.dayOfBirth = dayOfBirth
+    }
+}

--- a/14th-team5-iOS/Domain/Sources/Pick/Entities/PickResponse.swift
+++ b/14th-team5-iOS/Domain/Sources/Pick/Entities/PickResponse.swift
@@ -1,0 +1,16 @@
+//
+//  PickResponse.swift
+//  Domain
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation
+
+public struct PickResponse {
+    public var success: Bool
+    
+    public init(success: Bool) {
+        self.success = success
+    }
+}

--- a/14th-team5-iOS/Domain/Sources/Pick/Interfaces/Repositories/PickRepositoryProtocol.swift
+++ b/14th-team5-iOS/Domain/Sources/Pick/Interfaces/Repositories/PickRepositoryProtocol.swift
@@ -1,0 +1,8 @@
+//
+//  PickRepositoryProtocol.swift
+//  Domain
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation

--- a/14th-team5-iOS/Domain/Sources/Pick/Interfaces/Repositories/PickRepositoryProtocol.swift
+++ b/14th-team5-iOS/Domain/Sources/Pick/Interfaces/Repositories/PickRepositoryProtocol.swift
@@ -6,3 +6,13 @@
 //
 
 import Foundation
+
+import RxSwift
+
+public protocol PickRepositoryProtocol {
+    var disposeBag: DisposeBag { get }
+    
+    func pickMember(memberId: String) -> Observable<PickResponse?>
+    func whoDidIPickMember(memberId: String) -> Observable<PickMemberListResponse?>
+    func whoPickedMeMember(memberId: String) -> Observable<PickMemberListResponse?>
+}

--- a/14th-team5-iOS/Domain/Sources/Pick/UseCases/PickUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Pick/UseCases/PickUseCase.swift
@@ -1,0 +1,8 @@
+//
+//  PickUseCase.swift
+//  Domain
+//
+//  Created by 김건우 on 4/15/24.
+//
+
+import Foundation

--- a/14th-team5-iOS/Domain/Sources/Pick/UseCases/PickUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Pick/UseCases/PickUseCase.swift
@@ -6,3 +6,31 @@
 //
 
 import Foundation
+
+import RxSwift
+
+public protocol PickUseCaseProtocol {
+    func executePickMember(memberId: String) -> Observable<PickResponse?>
+    func executeFetchWhoDidIPickMember(memberId: String) -> Observable<PickMemberListResponse?>
+    func executeFetchWhoPickedMeMember(memberId: String) -> Observable<PickMemberListResponse?>
+}
+
+public final class PickUseCase: PickUseCaseProtocol {
+    private let pickRepository: PickRepositoryProtocol
+    
+    public init(pickRepository: PickRepositoryProtocol) {
+        self.pickRepository = pickRepository
+    }
+    
+    public func executePickMember(memberId: String) -> Observable<PickResponse?> {
+        return pickRepository.pickMember(memberId: memberId)
+    }
+    
+    public func executeFetchWhoDidIPickMember(memberId: String) -> Observable<PickMemberListResponse?> {
+        return pickRepository.whoDidIPickMember(memberId: memberId)
+    }
+    
+    public func executeFetchWhoPickedMeMember(memberId: String) -> Observable<PickMemberListResponse?> {
+        return pickRepository.whoPickedMeMember(memberId: memberId)
+    }
+}


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 재촉하기 `DTO` 및 `Entity` 구현
- `PickAPIWorker` 및 `PickUseCase` 통신 로직 구현
- `CFShortVersionString`을 1.1.8 → 1.2로 변경

## 테스트 케이스 ✅

- [x] 재촉하기 네트워크 통신이 제대로 작동하는지

