### PR TITLE
feat: CalendarAPI 추가 및 Deprecated 처리

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/DataSource/MonthlyCalendarSectionModel.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/DataSource/MonthlyCalendarSectionModel.swift
@@ -5,12 +5,10 @@
 //  Created by 김건우 on 12/22/23.
 //
 
+import Domain
 import Foundation
 
-import Domain
 import RxDataSources
-
-typealias CalendarTestData = SectionOfMonthlyCalendar.TestData
 
 public struct SectionOfMonthlyCalendar {
     public var items: [Item]
@@ -22,105 +20,5 @@ extension SectionOfMonthlyCalendar: SectionModelType {
     public init(original: SectionOfMonthlyCalendar, items: [Item]) {
         self = original
         self.items = items
-    }
-}
-
-extension SectionOfMonthlyCalendar {
-    enum TestData {
-        static let calendar = Calendar.current
-        static let components1: DateComponents = DateComponents(year: 2023, month: 12, day: 1)
-        static let components2: DateComponents = DateComponents(year: 2023, month: 12, day: 3)
-        static let components3: DateComponents = DateComponents(year: 2023, month: 12, day: 5)
-        
-        static let components4: DateComponents = DateComponents(year: 2024, month: 1, day: 7)
-        static let components5: DateComponents = DateComponents(year: 2024, month: 1, day: 9)
-        static let components6: DateComponents = DateComponents(year: 2024, month: 1, day: 11)
-        
-        static let date1: Date = calendar.date(from: components1)!
-        static let date2: Date = calendar.date(from: components2)!
-        static let date3: Date = calendar.date(from: components3)!
-        
-        static let date4: Date = calendar.date(from: components4)!
-        static let date5: Date = calendar.date(from: components5)!
-        static let date6: Date = calendar.date(from: components6)!
-        
-        static let months: [Date] = [
-            "2023-12".toDate(with: "yyyy-MM"), "2024-01".toDate(with: "yyyy-MM")
-        ]
-        static let dates: [[Date]] = [
-            [date1, date2, date3],
-            [date4, date5, date6]
-        ]
-        static let representativePostIds: [[String]] = [
-            ["1", "2", "3"],
-            ["4", "5", "6"],
-        ]
-        static let representativeThumbnailUrls: [[String]] = [
-            [
-                "https://cdn.pixabay.com/photo/2023/11/20/13/48/butterfly-8401173_1280.jpg",
-                "https://cdn.pixabay.com/photo/2023/11/10/02/30/woman-8378634_1280.jpg",
-                "https://cdn.pixabay.com/photo/2023/11/26/08/27/leaves-8413064_1280.jpg"
-            ],
-            [
-                "https://cdn.pixabay.com/photo/2023/11/20/13/48/butterfly-8401173_1280.jpg",
-                "https://cdn.pixabay.com/photo/2023/11/10/02/30/woman-8378634_1280.jpg",
-                "https://cdn.pixabay.com/photo/2023/11/26/08/27/leaves-8413064_1280.jpg"
-            ],
-        ]
-        static let allFamilyMemebersUploadeds: [[Bool]] = [
-            [false, true, false],
-            [true, false, true]
-        ]
-        
-        static let dayInfo202312: [CalendarResponse] = (0...2).map {
-            return CalendarResponse(
-                date: dates[0][$0],
-                representativePostId: representativePostIds[0][$0],
-                representativeThumbnailUrl: representativeThumbnailUrls[0][$0],
-                allFamilyMemebersUploaded: allFamilyMemebersUploadeds[0][$0]
-            )
-        }
-        
-        static let dayInfo202401: [CalendarResponse] = (0...2).map {
-            return CalendarResponse(
-                date: dates[1][$0],
-                representativePostId: representativePostIds[1][$0],
-                representativeThumbnailUrl: representativeThumbnailUrls[1][$0],
-                allFamilyMemebersUploaded: allFamilyMemebersUploadeds[1][$0]
-            )
-        }
-    }
-    
-    static func generateTestData() -> ArrayResponseCalendarResponse {
-        var arrayCalendarResponse: ArrayResponseCalendarResponse = .init(results: [])
-        
-        (0...1).forEach { outerIdx in
-            (0...2).forEach { innerIdx in
-                let dayResponse = CalendarResponse(
-                    date: CalendarTestData.dates[outerIdx][innerIdx],
-                    representativePostId: CalendarTestData.representativePostIds[outerIdx][innerIdx],
-                    representativeThumbnailUrl: CalendarTestData.representativeThumbnailUrls[outerIdx][innerIdx],
-                    allFamilyMemebersUploaded: CalendarTestData.allFamilyMemebersUploadeds[outerIdx][innerIdx]
-                )
-                arrayCalendarResponse.results.append(dayResponse)
-            }
-        }
-        
-        return arrayCalendarResponse
-    }
-    
-    static func generateTestData(_ yearMonth: String) -> ArrayResponseCalendarResponse {
-        
-        var arrayCalendarResponse: ArrayResponseCalendarResponse = .init(results: [])
-        switch yearMonth {
-        case "2023-12":
-            arrayCalendarResponse.results.append(contentsOf: TestData.dayInfo202312)
-        case "2024-01":
-            fallthrough
-        default:
-            arrayCalendarResponse.results.append(contentsOf: TestData.dayInfo202401)
-        }
-        
-        return arrayCalendarResponse
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/ImageCalendarCellDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Dependency/ImageCalendarCellDIContainer.swift
@@ -15,7 +15,7 @@ final public class ImageCalendarCellDIContainer {
     // MARK: - Properties
     public let type: ImageCalendarCellReactor.CalendarType
     public let isSelected: Bool
-    public let dayResponse: CalendarResponse
+    public let dayResponse: CalendarEntity
     
     private var globalState: GlobalStateProviderProtocol {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
@@ -28,7 +28,7 @@ final public class ImageCalendarCellDIContainer {
     public init(
         _ type: ImageCalendarCellReactor.CalendarType,
         isSelected: Bool = false,
-        dayResponse: CalendarResponse
+        dayResponse: CalendarEntity
     ) {
         self.type = type
         self.isSelected = isSelected

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPageViewCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPageViewCellReactor.swift
@@ -25,9 +25,9 @@ public final class CalendarPageCellReactor: Reactor {
     
     // MARK: - Mutation
     public enum Mutation {
-        case injectCalendarBanner(BannerResponse)
-        case injectStatisticsSummary(FamilyMonthlyStatisticsResponse)
-        case injectCalendarResponse(ArrayResponseCalendarResponse)
+        case injectCalendarBanner(BannerEntity)
+        case injectStatisticsSummary(FamilyMonthlyStatisticsEntity)
+        case injectCalendarResponse(ArrayResponseCalendarEntity)
     }
     
     // MARK: - State
@@ -35,7 +35,7 @@ public final class CalendarPageCellReactor: Reactor {
         var yearMonthDate: Date
         var displayCalendarBanner: BannerViewModel.State?
         var displayMemoryCount: Int
-        var displayCalendarResponse: ArrayResponseCalendarResponse?
+        var displayCalendarResponse: ArrayResponseCalendarEntity?
     }
     
     // MARK: - Properties

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/CalendarPostViewReactor.swift
@@ -29,7 +29,7 @@ public final class CalendarPostViewReactor: Reactor {
     // MARK: - Mutation
     public enum Mutation {
         case setAllUploadedToastMessageView(Bool)
-        case injectCalendarResponse(String, ArrayResponseCalendarResponse)
+        case injectCalendarResponse(String, ArrayResponseCalendarEntity)
         case injectPostResponse([PostListData])
         case injectBlurImageIndex(Int)
         case injectVisiblePost(PostListData)
@@ -48,7 +48,7 @@ public final class CalendarPostViewReactor: Reactor {
         var blurImageUrlString: String?
         var visiblePost: PostListData?
         @Pulse var displayPostResponse: [PostListSectionModel]
-        @Pulse var displayCalendarResponse: [String: [CalendarResponse]]
+        @Pulse var displayCalendarResponse: [String: [CalendarEntity]]
         @Pulse var shouldPresentAllUploadedToastMessageView: Bool
         @Pulse var shouldGenerateSelectionHaptic: Bool
         @Pulse var shouldPushProfileViewController: String?

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/ImageCalendarCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/Reactor/ImageCalendarCellReactor.swift
@@ -49,7 +49,7 @@ final public class ImageCalendarCellReactor: Reactor {
     init(
         _ type: CalendarType,
         isSelected: Bool,
-        dayResponse: CalendarResponse,
+        dayResponse: CalendarEntity,
         calendarUseCase: CalendarUseCaseProtocol,
         provider: GlobalStateProviderProtocol
     ) {

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/View/Cell/CalendarPageCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/View/Cell/CalendarPageCell.swift
@@ -238,7 +238,7 @@ extension CalendarPageCell: FSCalendarDataSource {
             
             // 해당 일자에 데이터가 존재하지 않는다면
             guard let dayResponse = reactor?.currentState.displayCalendarResponse?.results.filter({ $0.date == date }).first else {
-                let emptyResponse = CalendarResponse(
+                let emptyResponse = CalendarEntity(
                     date: date,
                     representativePostId: .none,
                     representativeThumbnailUrl: .none,

--- a/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Calendar/ViewController/CalendarPostViewController.swift
@@ -486,7 +486,7 @@ extension CalendarPostViewController: FSCalendarDataSource {
         guard let currentState = reactor?.currentState,
               let dayResponse = currentState.displayCalendarResponse[yyyyMM]?.filter({ $0.date.isEqual(with: date) }).first
         else {
-            let emptyResponse = CalendarResponse(
+            let emptyResponse = CalendarEntity(
                 date: date,
                 representativePostId: .none,
                 representativeThumbnailUrl: .none,

--- a/14th-team5-iOS/Data/Sources/API/APIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/API/APIWorker.swift
@@ -85,6 +85,15 @@ public final class BibbiRequestInterceptor: RequestInterceptor, BibbiRouterInter
 // MARK: API Worker
 public class APIWorker: NSObject, BibbiRouterInterface {
     
+    // MARK: - Headers
+    var _headers: Observable<[APIHeader]?> {
+        return App.Repository.token.accessToken
+            .map {
+                guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
+                return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
+            }
+    }
+    
     private func appendCommonHeaders(to headers: [APIHeader]?) -> [APIHeader] {
         var result: [APIHeader] = BibbiAPI.Header.baseHeaders
         guard let headers = headers else { return result }

--- a/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Account/AccountAPI/AccountAPIWorker.swift
@@ -26,15 +26,6 @@ extension AccountAPIs {
             super.init()
             self.id = "AccountAPIWorker"
         }
-        
-        // MARK: Values
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/Account/MeAPI/MeAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Account/MeAPI/MeAPIWorker.swift
@@ -26,15 +26,6 @@ extension MeAPIs {
             super.init()
             self.id = "MeAPIWorker"
         }
-        
-        // MARK: Values
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/CalendarAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/CalendarAPIWorker.swift
@@ -22,21 +22,14 @@ extension CalendarAPIs {
             super.init()
             self.id = "CalendarAPIWorker"
         }
-        
-        // MARK: - Headers
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
-                }
-        }
     }
 }
 
 // MARK: - Extensions
 extension CalendarAPIWorker {
-    private func fetchCalendarResponse(spec: APISpec, headers: [APIHeader]?) -> Single<ArrayResponseCalendarResponse?> {
+    
+    @available(*, deprecated)
+    private func fetchCalendarResponse(spec: APISpec, headers: [APIHeader]?) -> Single<ArrayResponseCalendarEntity?> {
         return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)
             .do {
@@ -50,8 +43,9 @@ extension CalendarAPIWorker {
             .asSingle()
     }
     
-    public func fetchCalendarResponse(yearMonth: String) -> Single<ArrayResponseCalendarResponse?> {
-        let spec = CalendarAPIs.fetchCalendarResponse(yearMonth).spec
+    @available(*, deprecated)
+    public func fetchCalendarResponse(yearMonth: String) -> Single<ArrayResponseCalendarEntity?> {
+        let spec = CalendarAPIs.calendarResponse(yearMonth).spec
         
         return Observable<Void>.just(())
             .withLatestFrom(self._headers)
@@ -61,7 +55,7 @@ extension CalendarAPIWorker {
             .asSingle()
     }
     
-    private func fetchStatisticsSummary(spec: APISpec, headers: [APIHeader]?) -> Single<FamilyMonthlyStatisticsResponse?> {
+    private func fetchStatisticsSummary(spec: APISpec, headers: [APIHeader]?) -> Single<FamilyMonthlyStatisticsEntity?> {
         return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)
             .do {
@@ -75,8 +69,60 @@ extension CalendarAPIWorker {
             .asSingle()
     }
     
-    public func fetchStatisticsSummary(yearMonth: String) -> Single<FamilyMonthlyStatisticsResponse?> {
-        let spec = CalendarAPIs.fetchStatisticsSummary(yearMonth).spec
+    public func fetchMonthlyCalendar(yearMonth: String) -> Single<ArrayResponseMonthlyCalendarEntity?> {
+        let spec = CalendarAPIs.monthlyCalendar(yearMonth).spec
+        
+        return Observable<Void>.just(())
+            .withLatestFrom(self._headers)
+            .observe(on: Self.queue)
+            .withUnretained(self)
+            .flatMap { $0.0.fetchMonthlyCalendar(spec: spec, headers: $0.1) }
+            .asSingle()
+    }
+    
+    
+    private func fetchMonthlyCalendar(spec: APISpec, headers: [APIHeader]?) -> Single<ArrayResponseMonthlyCalendarEntity?> {
+        return request(spec: spec, headers: headers)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("MonthlyCalendar Fetch Result: \(str)")
+                }
+            }
+            .map(ArrayResponseMonthlyCalendarResponseDTO.self)
+            .catchAndReturn(nil)
+            .map { $0?.toDomain() }
+            .asSingle()
+    }
+    
+    public func fetchDailyCalendar(yearMonth: String) -> Single<ArrayResponseDailyCalendarEntity?> {
+        let spec = CalendarAPIs.monthlyCalendar(yearMonth).spec
+        
+        return Observable<Void>.just(())
+            .withLatestFrom(self._headers)
+            .observe(on: Self.queue)
+            .withUnretained(self)
+            .flatMap { $0.0.fetchDailyCalendar(spec: spec, headers: $0.1) }
+            .asSingle()
+    }
+    
+    
+    private func fetchDailyCalendar(spec: APISpec, headers: [APIHeader]?) -> Single<ArrayResponseDailyCalendarEntity?> {
+        return request(spec: spec, headers: headers)
+            .subscribe(on: Self.queue)
+            .do {
+                if let str = String(data: $0.1, encoding: .utf8) {
+                    debugPrint("DailyCalendar Fetch Result: \(str)")
+                }
+            }
+            .map(ArrayResponseDailyCalendarResponseDTO.self)
+            .catchAndReturn(nil)
+            .map { $0?.toDomain() }
+            .asSingle()
+    }
+    
+    public func fetchStatisticsSummary(yearMonth: String) -> Single<FamilyMonthlyStatisticsEntity?> {
+        let spec = CalendarAPIs.statisticsSummary(yearMonth).spec
         
         return Observable<Void>.just(())
             .withLatestFrom(self._headers)
@@ -86,7 +132,7 @@ extension CalendarAPIWorker {
             .asSingle()
     }
     
-    private func fetchCalendarBanner(spec: APISpec, headers: [APIHeader]?) -> Single<BannerResponse?> {
+    private func fetchCalendarBanner(spec: APISpec, headers: [APIHeader]?) -> Single<BannerEntity?> {
         return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)
             .do {
@@ -100,8 +146,8 @@ extension CalendarAPIWorker {
             .asSingle()
     }
     
-    public func fetchCalendarBanner(yearMonth: String) -> Single<BannerResponse?> {
-        let spec = CalendarAPIs.fetchCalendarBenner(yearMonth).spec
+    public func fetchCalendarBanner(yearMonth: String) -> Single<BannerEntity?> {
+        let spec = CalendarAPIs.calendarBenner(yearMonth).spec
         
         return Observable<Void>.just(())
             .withLatestFrom(self._headers)

--- a/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/CalendarAPIs.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/CalendarAPIs.swift
@@ -10,17 +10,26 @@ import Foundation
 import Domain
 
 enum CalendarAPIs: API {
-    case fetchCalendarResponse(String)
-    case fetchStatisticsSummary(String)
-    case fetchCalendarBenner(String)
+    @available(*, deprecated)
+    case calendarResponse(String)
+    
+    case monthlyCalendar(String)
+    case dailyCalendar(String)
+    case statisticsSummary(String)
+    case calendarBenner(String)
     
     var spec: APISpec {
         switch self {
-        case let .fetchCalendarResponse(yearMonth):
+        case let .calendarResponse(yearMonth):
             return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/calendar?type=MONTHLY&yearMonth=\(yearMonth)")
-        case let .fetchStatisticsSummary(yearMonth):
+            
+        case let .monthlyCalendar(yearMonth):
+            return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/calendar/monthly?yearMonth=\(yearMonth)")
+        case let .dailyCalendar(yearMonth):
+            return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/calendar/daily?yearMonthDay=\(yearMonth)")
+        case let .statisticsSummary(yearMonth):
             return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/calendar/summary?yearMonth=\(yearMonth)")
-        case let .fetchCalendarBenner(yearMonth):
+        case let .calendarBenner(yearMonth):
             return APISpec(method: .get, url: "\(BibbiAPI.hostApi)/calendar/banner?yearMonth=\(yearMonth)")
         }
     }

--- a/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/ArrayResponseDailyCalendarResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/ArrayResponseDailyCalendarResponseDTO.swift
@@ -1,0 +1,73 @@
+//
+//  ArrayResponseDailyCalendarResponseDTO.swift
+//  Data
+//
+//  Created by 김건우 on 5/3/24.
+//
+
+import Domain
+import Foundation
+
+struct ArrayResponseDailyCalendarResponseDTO: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case results
+    }
+    var results: [DailyCalendarResponseDTO]
+}
+
+extension ArrayResponseDailyCalendarResponseDTO {
+    struct DailyCalendarResponseDTO: Decodable {
+        enum CodingKeys: String, CodingKey {
+            case date
+            case type
+            case postId
+            case postImageUrl = "postImgUrl"
+            case postContent
+            case missionContent
+            case authorId
+            case commentCount
+            case emojiCount
+            case allFamilyMembersUploaded
+            case createdAt
+        }
+        var date: String
+        var type: String
+        var postId: String
+        var postImageUrl: String
+        var postContent: String
+        var missionContent: String
+        var authorId: String
+        var commentCount: Int
+        var emojiCount: Int
+        var allFamilyMembersUploaded: Bool
+        var createdAt: String
+    }
+}
+
+extension ArrayResponseDailyCalendarResponseDTO {
+    func toDomain() -> ArrayResponseDailyCalendarEntity {
+        return ArrayResponseDailyCalendarEntity(
+            results: results.map { $0.toDomain() }
+        )
+    }
+}
+
+extension ArrayResponseDailyCalendarResponseDTO.DailyCalendarResponseDTO {
+    func toDomain() -> DailyCalendarEntity {
+        return DailyCalendarEntity(
+            date: date.toDate(with: .dashYyyyMMdd),
+            type: .init(rawValue: type) ?? .survival,
+            postId: postId,
+            postImageUrl: postImageUrl,
+            postContent: postContent,
+            missionContent: missionContent,
+            authorId: authorId,
+            commentCount: commentCount,
+            emojiCount: emojiCount,
+            allFamilyMembersUploaded: allFamilyMembersUploaded,
+            createdAt: createdAt.iso8601ToDate()
+        )
+    }
+}
+
+

--- a/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/ArrayResponseMonthlyCalendarResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/ArrayResponseMonthlyCalendarResponseDTO.swift
@@ -1,23 +1,22 @@
 //
-//  ArrayResponseCalendarResponse+Mapping.swift
+//  ArrayResponseMonthlyCalendarResponse.swift
 //  Data
 //
-//  Created by 김건우 on 12/21/23.
+//  Created by 김건우 on 5/3/24.
 //
 
 import Domain
 import Foundation
 
-@available(*, deprecated)
-public struct ArrayResponseCalendarResponseDTO: Decodable {
+public struct ArrayResponseMonthlyCalendarResponseDTO: Decodable {
     private enum CodingKeys: String, CodingKey {
         case results
     }
-    var results: [CalendarResponseDTO]
+    var results: [MonthlyCalendarResponseDTO]
 }
 
-extension ArrayResponseCalendarResponseDTO {
-    public struct CalendarResponseDTO: Decodable {
+extension ArrayResponseMonthlyCalendarResponseDTO {
+    public struct MonthlyCalendarResponseDTO: Decodable {
         private enum CodingKeys: String, CodingKey {
             case date
             case representativePostId
@@ -31,18 +30,18 @@ extension ArrayResponseCalendarResponseDTO {
     }
 }
 
-extension ArrayResponseCalendarResponseDTO {
-    func toDomain() -> ArrayResponseCalendarEntity {
-        return ArrayResponseCalendarEntity(
+extension ArrayResponseMonthlyCalendarResponseDTO {
+    func toDomain() -> ArrayResponseMonthlyCalendarEntity {
+        return ArrayResponseMonthlyCalendarEntity(
             results: results.map { $0.toDomain() }
         )
     }
 }
 
-extension ArrayResponseCalendarResponseDTO.CalendarResponseDTO {
-    func toDomain() -> CalendarEntity {
-        return CalendarEntity(
-            date: date.toDate(),
+extension ArrayResponseMonthlyCalendarResponseDTO.MonthlyCalendarResponseDTO {
+    func toDomain() -> MonthlyCalendarEntity {
+        return MonthlyCalendarEntity(
+            date: date.toDate(with: .dashYyyyMMdd),
             representativePostId: representativePostId,
             representativeThumbnailUrl: representativeThumbnailUrl,
             allFamilyMemebersUploaded: allFamilyMembersUploaded

--- a/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/BannerResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/BannerResponseDTO.swift
@@ -71,7 +71,7 @@ extension BannerResponseDTO {
 }
 
 extension BannerResponseDTO {
-    func toDomain() -> BannerResponse {
+    func toDomain() -> BannerEntity {
         return .init(
             familyTopPercentage: familyTopPercentage,
             allFamilyMembersUploadedDays: allFamilyMembersUploadedDays,

--- a/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/FamilyMonthlyStatisticsResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/CalendarAPI/DataMapping/FamilyMonthlyStatisticsResponseDTO.swift
@@ -18,7 +18,7 @@ public struct FamilyMonthlyStatisticsResponseDTO: Decodable {
 }
 
 extension FamilyMonthlyStatisticsResponseDTO {
-    func toDomain() -> FamilyMonthlyStatisticsResponse {
+    func toDomain() -> FamilyMonthlyStatisticsEntity {
         return .init(totalImageCnt: self.totalImageCnt)
     }
 }

--- a/14th-team5-iOS/Data/Sources/Calendar/Repository/CalendarRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Calendar/Repository/CalendarRepository.swift
@@ -23,18 +23,32 @@ public final class CalendarRepository: CalendarRepositoryProtocol {
 
 // MARK: - Extensions
 extension CalendarRepository {
-    public func fetchCalendarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarResponse?> {
+    
+    @available(*, deprecated)
+    public func fetchCalendarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarEntity?> {
         return calendarApiWorker.fetchCalendarResponse(yearMonth: yearMonth)
             .asObservable()
     }
     
-    public func fetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsResponse?> {
+    
+    public func fetchMonthyCalendarResponse(yearMonth: String) -> Observable<ArrayResponseMonthlyCalendarEntity?> {
+        return calendarApiWorker.fetchMonthlyCalendar(yearMonth: yearMonth)
+            .asObservable()
+    }
+    
+    public func fetchDailyCalendarResponse(yearMonth: String) -> Observable<ArrayResponseDailyCalendarEntity?> {
+        return calendarApiWorker.fetchDailyCalendar(yearMonth: yearMonth)
+            .asObservable()
+    }
+    
+    public func fetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsEntity?> {
         return calendarApiWorker.fetchStatisticsSummary(yearMonth: yearMonth)
             .asObservable()
     }
     
-    public func fetchCalendarBanner(yearMonth: String) -> Observable<BannerResponse?> {
+    public func fetchCalendarBanner(yearMonth: String) -> Observable<BannerEntity?> {
         return calendarApiWorker.fetchCalendarBanner(yearMonth: yearMonth)
             .asObservable()
     }
+    
 }

--- a/14th-team5-iOS/Data/Sources/Emoji/EmojiAPI/EmojiAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Emoji/EmojiAPI/EmojiAPIWorker.swift
@@ -23,14 +23,6 @@ extension EmojiAPIs {
             super.init()
             self.id = "EmojiAPIWorker"
         }
-        
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/Family/FamilyAPI/FamilyAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Family/FamilyAPI/FamilyAPIWorker.swift
@@ -23,14 +23,6 @@ extension FamilyAPIs {
             super.init()
             self.id = "FamilyAPIWorker"
         }
-        
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/Mission/MissionAPI/MissionAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Mission/MissionAPI/MissionAPIWorker.swift
@@ -23,14 +23,6 @@ extension MissionAPIs {
             super.init()
             self.id = "MissionAPIWorker"
         }
-        
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Pick/PickAPI/PickAPIWorker.swift
@@ -22,19 +22,6 @@ extension PickAPIs {
             super.init()
             self.id = "PickAPIWorker"
         }
-        
-        // MARK: - Headers
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, 
-                          let accessToken = token.accessToken,
-                          !accessToken.isEmpty else {
-                        return []
-                    }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/Post/PostList/PostListAPI/PostListAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Post/PostList/PostListAPI/PostListAPIWorker.swift
@@ -24,14 +24,6 @@ extension PostListAPIs {
             super.init()
             self.id = "PostListAPIWorker"
         }
-        
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/PostComment/PostCommentAPI/PostCommentAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/PostComment/PostCommentAPI/PostCommentAPIWorker.swift
@@ -22,15 +22,6 @@ extension PostCommentAPIs {
             super.init()
             self.id = "PostCommentAPIWorker"
         }
-        
-        // MARK: - Headers
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/RealEmoji/RealEmojiAPI/RealEmojiAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/RealEmoji/RealEmojiAPI/RealEmojiAPIWorker.swift
@@ -24,14 +24,6 @@ extension RealEmojiAPIS {
             super.init()
             self.id = "RealEmojiAPIWorker"
         }
-        
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken), BibbiAPI.Header.acceptJson]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Data/Sources/View/Main/Worker/MainAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/View/Main/Worker/MainAPIWorker.swift
@@ -23,15 +23,6 @@ extension MainAPIs {
             super.init()
             self.id = "MainAPIWorker"
         }
-        
-        // MARK: - Headers
-        private var _headers: Observable<[APIHeader]?> {
-            return App.Repository.token.accessToken
-                .map {
-                    guard let token = $0, let accessToken = token.accessToken, !accessToken.isEmpty else { return [] }
-                    return [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)]
-                }
-        }
     }
 }
 

--- a/14th-team5-iOS/Domain/Sources/Calendar/Entities/ArrayResponseCalendarEntity.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Entities/ArrayResponseCalendarEntity.swift
@@ -1,21 +1,22 @@
 //
-//  ArrayResponseCalendarResponse.swift
+//  dddd.swift
 //  Domain
 //
-//  Created by 김건우 on 12/21/23.
+//  Created by 김건우 on 5/3/24.
 //
 
 import Foundation
 
-public struct ArrayResponseCalendarResponse {
-    public var results: [CalendarResponse]
+@available(*, deprecated)
+public struct ArrayResponseCalendarEntity {
+    public var results: [CalendarEntity]
     
-    public init(results: [CalendarResponse]) {
+    public init(results: [CalendarEntity]) {
         self.results = results
     }
 }
 
-public struct CalendarResponse {
+public struct CalendarEntity {
     public var date: Date
     public var representativePostId: String
     public var representativeThumbnailUrl: String
@@ -33,3 +34,4 @@ public struct CalendarResponse {
         self.allFamilyMemebersUploaded = allFamilyMemebersUploaded
     }
 }
+

--- a/14th-team5-iOS/Domain/Sources/Calendar/Entities/ArrayResponseDailyCalendarEntity.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Entities/ArrayResponseDailyCalendarEntity.swift
@@ -1,0 +1,57 @@
+//
+//  ArrayResponseDailyCalendarEntity.swift
+//  Domain
+//
+//  Created by 김건우 on 5/3/24.
+//
+
+import Foundation
+
+public struct ArrayResponseDailyCalendarEntity {
+    public var results: [DailyCalendarEntity]
+    
+    public init(results: [DailyCalendarEntity]) {
+        self.results = results
+    }
+}
+
+public struct DailyCalendarEntity {
+    public var date: Date
+    public var type: PostType
+    public var postId: String
+    public var postImageUrl: String
+    public var postContent: String
+    public var missionContent: String
+    public var authorId: String
+    public var commentCount: Int
+    public var emojiCount: Int
+    public var allFamilyMembersUploaded: Bool
+    public var createdAt: Date
+    
+    public init(
+        date: Date,
+        type: PostType,
+        postId: String,
+        postImageUrl: String,
+        postContent: String,
+        missionContent: String,
+        authorId: String,
+        commentCount: Int,
+        emojiCount: Int,
+        allFamilyMembersUploaded: Bool,
+        createdAt: Date
+    ) {
+        self.date = date
+        self.type = type
+        self.postId = postId
+        self.postImageUrl = postImageUrl
+        self.postContent = postContent
+        self.missionContent = missionContent
+        self.authorId = authorId
+        self.commentCount = commentCount
+        self.emojiCount = emojiCount
+        self.allFamilyMembersUploaded = allFamilyMembersUploaded
+        self.createdAt = createdAt
+    }
+}
+

--- a/14th-team5-iOS/Domain/Sources/Calendar/Entities/ArrayResponseMonthlyCalendarEntity.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Entities/ArrayResponseMonthlyCalendarEntity.swift
@@ -1,0 +1,36 @@
+//
+//  ArrayResponseCalendarResponse.swift
+//  Domain
+//
+//  Created by 김건우 on 12/21/23.
+//
+
+import Foundation
+
+public struct ArrayResponseMonthlyCalendarEntity {
+    public var results: [MonthlyCalendarEntity]
+    
+    public init(results: [MonthlyCalendarEntity]) {
+        self.results = results
+    }
+}
+
+public struct MonthlyCalendarEntity {
+    public var date: Date
+    public var representativePostId: String
+    public var representativeThumbnailUrl: String
+    public var allFamilyMemebersUploaded: Bool
+    
+    public init(
+        date: Date,
+        representativePostId: String,
+        representativeThumbnailUrl: String,
+        allFamilyMemebersUploaded: Bool
+    ) {
+        self.date = date
+        self.representativePostId = representativePostId
+        self.representativeThumbnailUrl = representativeThumbnailUrl
+        self.allFamilyMemebersUploaded = allFamilyMemebersUploaded
+    }
+    
+}

--- a/14th-team5-iOS/Domain/Sources/Calendar/Entities/BannerEntity.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Entities/BannerEntity.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public struct BannerResponse {
+public struct BannerEntity {
     public var familyTopPercentage: Int
     public var allFammilyMembersUploadedDays: Int
     public var familyLevel: Int

--- a/14th-team5-iOS/Domain/Sources/Calendar/Entities/FamilyMonthlyStatisticsEntity.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Entities/FamilyMonthlyStatisticsEntity.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct FamilyMonthlyStatisticsResponse {
+public struct FamilyMonthlyStatisticsEntity {
     public var totalImageCnt: Int
     
     public init(totalImageCnt: Int) {

--- a/14th-team5-iOS/Domain/Sources/Calendar/Interfaces/Repositories/CalendarRepository.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/Interfaces/Repositories/CalendarRepository.swift
@@ -12,7 +12,10 @@ import RxSwift
 public protocol CalendarRepositoryProtocol {
     var disposeBag: DisposeBag { get }
     
-    func fetchCalendarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarResponse?>
-    func fetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsResponse?>
-    func fetchCalendarBanner(yearMonth: String) -> Observable<BannerResponse?>
+    func fetchCalendarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarEntity?>
+    
+    func fetchMonthyCalendarResponse(yearMonth: String) -> Observable<ArrayResponseMonthlyCalendarEntity?>
+    func fetchDailyCalendarResponse(yearMonth: String) -> Observable<ArrayResponseDailyCalendarEntity?>
+    func fetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsEntity?>
+    func fetchCalendarBanner(yearMonth: String) -> Observable<BannerEntity?>
 }

--- a/14th-team5-iOS/Domain/Sources/Calendar/UseCases/CalendarUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Calendar/UseCases/CalendarUseCase.swift
@@ -10,9 +10,9 @@ import Foundation
 import RxSwift
 
 public protocol CalendarUseCaseProtocol {
-    func executeFetchCalednarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarResponse?>
-    func executeFetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsResponse?>
-    func executeFetchCalendarBenner(yearMonth: String) -> Observable<BannerResponse?>
+    func executeFetchCalednarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarEntity?>
+    func executeFetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsEntity?>
+    func executeFetchCalendarBenner(yearMonth: String) -> Observable<BannerEntity?>
 }
 
 public final class CalendarUseCase: CalendarUseCaseProtocol {
@@ -22,15 +22,15 @@ public final class CalendarUseCase: CalendarUseCaseProtocol {
         self.calendarRepository = calendarRepository
     }
 
-    public func executeFetchCalednarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarResponse?> {
+    public func executeFetchCalednarResponse(yearMonth: String) -> Observable<ArrayResponseCalendarEntity?> {
         return calendarRepository.fetchCalendarResponse(yearMonth: yearMonth)
     }
     
-    public func executeFetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsResponse?> {
+    public func executeFetchStatisticsSummary(yearMonth: String) -> Observable<FamilyMonthlyStatisticsEntity?> {
         return calendarRepository.fetchStatisticsSummary(yearMonth: yearMonth)
     }
     
-    public func executeFetchCalendarBenner(yearMonth: String) -> Observable<BannerResponse?> {
+    public func executeFetchCalendarBenner(yearMonth: String) -> Observable<BannerEntity?> {
         return calendarRepository.fetchCalendarBanner(yearMonth: yearMonth)
     }
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- APIWorker의 `_header` 프로퍼티를 상위 클래스로 이동
- `Monthly` 및 `Daily` CalendarAPI 추가 및 Deprecated 처리
(API 추가만 하고, 실제 적용은 X)

## 테스트 케이스 ✅

- [ ] Calendar 통신이 제대로 되는지

close #494 

