### PR TITLE
fix: MainViewController segmentControl UserInteractionEnabled 처리 로직 제거

### DIFF
--- a/14th-team5-iOS/App/Resources/PrivacyInfo.xcprivacy
+++ b/14th-team5-iOS/App/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false />
+    <key>NSPrivacyTrackingDomains</key>
+    <array />
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+        </array>
+      </dict>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypeOtherUserContactInfo</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+        </array>
+      </dict>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypeProductInteraction</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+        </array>
+      </dict>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypeUserID</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <true />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+        </array>
+      </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>1C8F.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/MainViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/MainViewController.swift
@@ -151,12 +151,6 @@ extension MainViewController {
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
         
-        pageViewController.segmentEnabled
-            .distinctUntilChanged()
-            .observe(on: MainScheduler.instance)
-            .bind(to: segmentControl.rx.isUserInteractionEnabled)
-            .disposed(by: disposeBag)
-        
         alertConfirmRelay.map { Reactor.Action.pickConfirmButtonTapped($0.0, $0.1) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/SegmentPageViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/SegmentPageViewController.swift
@@ -30,7 +30,6 @@ final class SegmentPageViewController: UIPageViewController {
     private lazy var pages: [UIViewController] = [survivalViewController, missionViewController]
     
     let indexRelay: BehaviorRelay<PageRelay> = BehaviorRelay(value: .init(way: .segmentTap, index: 0))
-    let segmentEnabled: BehaviorRelay<Bool> = BehaviorRelay(value: true)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -48,7 +47,6 @@ final class SegmentPageViewController: UIPageViewController {
             .withUnretained(self)
             .observe(on: MainScheduler.instance)
             .bind(onNext: {
-                $0.0.isPagingEnabled = false
                 switch $0.1 {
                 case 0: $0.0.setViewControllers([$0.0.survivalViewController], direction: .reverse, animated: true) { [weak self] _ in
                     self?.isPagingEnabled = true
@@ -66,10 +64,6 @@ final class SegmentPageViewController: UIPageViewController {
 }
 
 extension SegmentPageViewController: UIPageViewControllerDelegate, UIPageViewControllerDataSource {
-    func pageViewController(_ pageViewController: UIPageViewController, willTransitionTo pendingViewControllers: [UIViewController]) {
-        segmentEnabled.accept(false)
-    }
-    
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let index = pages.firstIndex(of: viewController),
               index - 1 >= 0 else { return nil }
@@ -88,10 +82,6 @@ extension SegmentPageViewController: UIPageViewControllerDelegate, UIPageViewCon
         if let currentViewController = pageViewController.viewControllers?.first,
            let currentIndex = pages.firstIndex(of: currentViewController) {
             indexRelay.accept(.init(way: .scroll, index: currentIndex))
-        }
-        
-        if completed && finished {
-            segmentEnabled.accept(true)
         }
     }
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻
- SegmentPageViewController isPagingEnabled Property 코드 or Delegate Method 제거

## 변경 로직 ⚒️
- SegmentPageViewController `segmentEnabled` Event를 false로 전달을 해서  MainViewController에서 `segmentControl .rx. isUserInteractionEnabled` 에 `Tap` 이벤트를 받지 못하다 보니 `Observable.zip` 으로 작성하신 이벤트가 방출 되지 못하였습니다 그래서`isUserInteractionEnabled`,  `segmentEnabled ` 코드를 제거했습니다.


## 테스트 케이스 ✅

- [x]  PageViewController 스크롤이 잘 동작하는지 확인
- [x]  PageViewController Scroll 할 경우 Segmented Control 탭이 변경 되는지 확인


