### PR TITLE
fix: 댓글 화면에서 알 수 없는 사용자 프로필로 이동하는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
@@ -82,8 +82,8 @@ final public class CommentCellReactor: Reactor {
                 navigator.dismiss { [weak self] in
                     self?.navigator.toProfile(memberId: memberId)
                 }
-//                provider.postGlobalState.pushProfileViewController(memberId)
             }
+            
             return Observable<Mutation>.empty()
         }
     }

--- a/14th-team5-iOS/App/Sources/Presentation/Comment/ViewController/CommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Comment/ViewController/CommentViewController.swift
@@ -52,7 +52,6 @@ final public class CommentViewController: ReactorViewController<CommentViewReact
     
     private func bindInput(reactor: CommentViewReactor) { 
         Observable<Void>.just(())
-            .delay(RxInterval._900milliseconds, scheduler: RxScheduler.main)
             .map { Reactor.Action.fetchComment }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/Data/Sources/APIs/My/Repository/MyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/My/Repository/MyRepository.swift
@@ -11,8 +11,11 @@ import Foundation
 public final class MyRepository: MyRepositoryProtocol {
     
     // MARK: - Properties
+    
     private let appUserDefaults: AppUserDefaultsType = AppUserDefaults()
-    // private let familyUserDefaults = FamilyUserDefaults()
+    private let myUserDefaults: MyUserDefaultsType = MyUserDefaults()
+    private let familyUserDefaults: FamilyInfoUserDefaultsType = FamilyInfoUserDefaults()
+    
     
     // MARK: - Intializer
     
@@ -22,26 +25,20 @@ public final class MyRepository: MyRepositoryProtocol {
 
 extension MyRepository {
     
-    
     public func fetchMyMemberId() -> String? {
-        // TODO: - 리팩토링된 FamilyUserDefaults로 바꾸기
-        FamilyUserDefaults.returnMyMemberId()
+        return myUserDefaults.loadMemberId()
     }
     
     public func fetchMyUserName() -> String? {
-        // TODO: - 리팩토링된 FamilyUserDefaults로 바꾸기
-        let myMemberId = FamilyUserDefaults.returnMyMemberId()
-        return FamilyUserDefaults.load(memberId: myMemberId)?.name
+        return myUserDefaults.loadUserName()
     }
     
     public func fetchUserName(memberId: String) -> String? {
-        // TODO: - 리팩토링된 FamilyUserDefaults로 바꾸기
-        FamilyUserDefaults.load(memberId: memberId)?.name
+        return familyUserDefaults.loadFamilyMember(memberId)?.name
     }
     
     public func fetchProfileImageUrl(memberId: String) -> String? {
-        // TODO: - 리팩토링된 FamilyUserDefaults로 바꾸기
-        FamilyUserDefaults.load(memberId: memberId)?.profileImageURL
+        return familyUserDefaults.loadFamilyMember(memberId)?.profileImageURL
     }
     
     public func fetchIsFirstOnboarding() -> Bool {

--- a/14th-team5-iOS/Domain/Sources/UseCases/My/CheckIsVaildMemberUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/My/CheckIsVaildMemberUseCase.swift
@@ -23,7 +23,7 @@ public class CheckIsVaildMemberUseCase: CheckIsVaildMemberUseCaseProtocol {
     
     // MARK: - Execute
     public func execute(memberId: String) -> Bool {
-        myRepository.fetchUserName(memberId: memberId) != ""
+        return myRepository.fetchUserName(memberId: memberId) != nil
     }
     
 }


### PR DESCRIPTION
## 작업 내용 🧑‍💻

- 0.9초 후 댓글 목록을 불러오는 코드 삭제
- 댓글 화면에서 알 수 없는 사용자 프로필로 이동하는 문제 수정

<br>

- MyRepository에서 구 FamilyUserDefaults 코드 삭제, 새로운 코드로 대체

## 테스트 케이스 ✅

- [x] 댓글 목록 불러오기 로직 테스트
- [x] 댓글 화면 → 프로필 화면 이동 로직 테스트


close #617 
