### PR TITLE
feat: BBAlertService구현, Pick 로직이 제대로 이뤄지지 못하는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/Cell/MainFamilyCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/Cell/MainFamilyCellReactor.swift
@@ -117,9 +117,9 @@ final class MainFamilyCellReactor: Reactor {
             let memberName = initialState.profileData.name
 
             return provider.bbAlertService.show(
-                image: DesignSystemAsset.missionKeyGraphic.image,
-                title: "미션 열쇠 획득!",
-                subtitle: "열쇠를 획득해 잠금이 해제되었어요.\n미션 사진을 찍을 수 있어요!",
+                image: DesignSystemAsset.exhaustedBibbiGraphic.image,
+                title: "생존 확인하기",
+                subtitle: "\(memberName)님의 생존 여부를 물어볼까요?\n지금 알림이 전송됩니다.",
                 actions: actions
             )
             .withUnretained(self)
@@ -129,7 +129,7 @@ final class MainFamilyCellReactor: Reactor {
                     return $0.0.pickMemberUseCase.execute(memberId: memberId)
                         .flatMap {
                             guard
-                                let entity = $0, !entity.success
+                                let entity = $0, entity.success
                             else { return Observable<Mutation>.empty() }
                             
                             return Observable<Mutation>.just(.setHiddenPickButton(true))

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/Cell/MainFamilyCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/Cell/MainFamilyCellReactor.swift
@@ -5,9 +5,10 @@
 //  Created by 마경미 on 21.04.24.
 //
 
-import Foundation
 
 import Core
+import Foundation
+import DesignSystem
 import Domain
 
 import ReactorKit
@@ -18,18 +19,47 @@ enum RankBadge: Int {
     case three = 3
 }
 
+
+// MARK: - BBAlertActionType
+
+enum PickAlertAction: BBAlertActionType {
+    case pick
+    case cancel
+    
+    var title: String? {
+        switch self {
+        case .pick: return "지금 하기"
+        case .cancel: return "다음에 하기"
+        }
+    }
+    
+    var style: BBAlertActionStyle {
+        switch self {
+        case .pick: return .default
+        case .cancel: return .cancel
+        }
+    }
+}
+
+
+
+
+// MARK: - Reactor
+
 final class MainFamilyCellReactor: Reactor {
     
     // MARK: - Action
     enum Action {
         case fetchData
-        case pickButtonTapped
+        
+        case didTapPickButton
     }
     
     // MARK: - Mutation
     enum Mutation {
         case setData
-        case setPickButtonAppearent(Bool)
+        
+        case setHiddenPickButton(Bool)
     }
     
     // MARK: - State
@@ -38,12 +68,17 @@ final class MainFamilyCellReactor: Reactor {
         var profile: (imageUrl: String?, name: String) = (nil, .none)
         var rank: Int? = nil
         var isShowBirthdayBadge: Bool = false
-        var isShowPickButton: Bool = false
+        
+        var hiddenPickButton: Bool = false
     }
     
     // MARK: - Properties
+    
     let initialState: State
-    let provider: ServiceProviderProtocol
+        
+    @Injected var pickMemberUseCase: PickMemberUseCaseProtocol
+    
+    @Injected var provider: ServiceProviderProtocol
     
     // MARK: - Intializer
     init(_ profileData: FamilyMemberProfileEntity, service provider: ServiceProviderProtocol) {
@@ -60,7 +95,7 @@ final class MainFamilyCellReactor: Reactor {
                     guard id == self.currentState.profileData.memberId else {
                         return Observable<Mutation>.empty()
                     }
-                    return Observable<Mutation>.just(.setPickButtonAppearent(show))
+                    return Observable<Mutation>.just(.setHiddenPickButton(show))
                 
                 default:
                     return Observable<Mutation>.empty()
@@ -76,12 +111,34 @@ final class MainFamilyCellReactor: Reactor {
         case .fetchData:
             return Observable.just(.setData)
             
-        case .pickButtonTapped:
-            provider.mainService.pickButtonTapped(
-                name: currentState.profileData.name,
-                memberId: currentState.profileData.memberId
+        case .didTapPickButton:
+            let actions: [PickAlertAction] = [.pick, .cancel]
+            let memberId = initialState.profileData.memberId
+            let memberName = initialState.profileData.name
+
+            return provider.bbAlertService.show(
+                image: DesignSystemAsset.missionKeyGraphic.image,
+                title: "미션 열쇠 획득!",
+                subtitle: "열쇠를 획득해 잠금이 해제되었어요.\n미션 사진을 찍을 수 있어요!",
+                actions: actions
             )
-            return Observable<Mutation>.empty()
+            .withUnretained(self)
+            .flatMap {
+                switch $0.1 {
+                case .pick:
+                    return $0.0.pickMemberUseCase.execute(memberId: memberId)
+                        .flatMap {
+                            guard
+                                let entity = $0, !entity.success
+                            else { return Observable<Mutation>.empty() }
+                            
+                            return Observable<Mutation>.just(.setHiddenPickButton(true))
+                        }
+                    
+                default:
+                    return Observable<Mutation>.empty()
+                }
+            }
         }
     }
     
@@ -94,10 +151,10 @@ final class MainFamilyCellReactor: Reactor {
             newState.profile = (currentState.profileData.profileImageURL, currentState.profileData.name)
             newState.rank = currentState.profileData.postRank
             newState.isShowBirthdayBadge = currentState.profileData.isShowBirthdayMark
-            newState.isShowPickButton = currentState.profileData.isShowPickIcon
+            newState.hiddenPickButton = !currentState.profileData.isShowPickIcon
             
-        case let .setPickButtonAppearent(show):
-            newState.isShowPickButton = show
+        case let .setHiddenPickButton(hidden):
+            newState.hiddenPickButton = hidden
         }
         
         return newState

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/MainViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/MainViewReactor.swift
@@ -281,7 +281,7 @@ extension MainViewReactor {
         case .updateMainNight(let data):
             newState.familyname = data.familyName
             newState.familySection = FamilySection.Model(model: 0, items: data.mainFamilyProfileDatas.map {
-                .main(MainFamilyCellReactor($0, service: provider))
+                .main(MainFamilyCellReactor($0,  service: provider))
             }).items
             newState.contributor = data.familyRankData
         case .setCamerEnabled:

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/MainViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/MainViewController.swift
@@ -148,7 +148,7 @@ extension MainViewController {
         Observable.merge(
             contributorView.nextButtonTapEvent.map { Reactor.Action.openNextViewController(.contributorNextButtonTap)},
             cameraButton.camerTapEvent.map { Reactor.Action.openNextViewController(.cameraButtonTap )},
-//            navigationBar.rx.didTapRightBarButton.map { _ in Reactor.Action.openNextViewController(.navigationRightButtonTap)},
+            navigationBar.rx.didTapRightBarButton.map { _ in Reactor.Action.openNextViewController(.navigationRightButtonTap)},
             navigationBar.rx.didTapLeftBarButton.map { _ in Reactor.Action.openNextViewController(.navigationLeftButtonTap)}
         )
         .observe(on: MainScheduler.instance)

--- a/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/MainViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/ViewControllers/MainViewController.swift
@@ -148,7 +148,7 @@ extension MainViewController {
         Observable.merge(
             contributorView.nextButtonTapEvent.map { Reactor.Action.openNextViewController(.contributorNextButtonTap)},
             cameraButton.camerTapEvent.map { Reactor.Action.openNextViewController(.cameraButtonTap )},
-            navigationBar.rx.didTapRightBarButton.map { _ in Reactor.Action.openNextViewController(.navigationRightButtonTap)},
+//            navigationBar.rx.didTapRightBarButton.map { _ in Reactor.Action.openNextViewController(.navigationRightButtonTap)},
             navigationBar.rx.didTapLeftBarButton.map { _ in Reactor.Action.openNextViewController(.navigationLeftButtonTap)}
         )
         .observe(on: MainScheduler.instance)

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Views/MainFamilyCollectionViewCell.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Views/MainFamilyCollectionViewCell.swift
@@ -123,8 +123,8 @@ extension MainFamilyCollectionViewCell {
             .disposed(by: disposeBag)
         
         pickButton.rx.tap
-            .throttle(RxConst.milliseconds300Interval, scheduler: RxSchedulers.main)
-            .map { Reactor.Action.pickButtonTapped }
+            .throttle(RxInterval._300milliseconds, scheduler: RxScheduler.main)
+            .map { Reactor.Action.didTapPickButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
@@ -150,9 +150,8 @@ extension MainFamilyCollectionViewCell {
             .bind(to: birthdayBadge.rx.isHidden)
             .disposed(by: disposeBag)
         
-        reactor.state.map { $0.isShowPickButton }
+        reactor.state.map { $0.hiddenPickButton }
             .distinctUntilChanged()
-            .map { !$0 }
             .bind(to: pickButton.rx.isHidden)
             .disposed(by: disposeBag)
     }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/BBAlertService.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/BBAlertService.swift
@@ -1,0 +1,220 @@
+//
+//  BBAlertService.swift
+//  Core
+//
+//  Created by 김건우 on 9/20/24.
+//
+
+import UIKit
+
+import RxSwift
+
+
+// MARK: - BBAlertActionType
+
+public protocol BBAlertActionType {
+    var title: String? { get }
+    var style: BBAlertActionStyle { get }
+}
+
+public extension BBAlertActionType {
+    var style: BBAlertActionStyle {
+        return .default
+    }
+}
+
+
+
+// MARK: - BBAlertServiceType
+
+public protocol BBAlertServiceType {
+    @discardableResult
+    func show<Action>(
+        title: String,
+        titleFontStyle: BBFontStyle?,
+        subtitle: String?,
+        subtitleFontStyle: BBFontStyle?,
+        actions: [Action],
+        viewConfig: BBAlertViewConfiguration,
+        config: BBAlertConfiguration
+    ) -> Observable<Action> where Action: BBAlertActionType
+    
+    @discardableResult
+    func show<Action>(
+        image: UIImage?,
+        imageTint: UIColor?,
+        title: String,
+        titleFontStyle: BBFontStyle?,
+        subtitle: String?,
+        subtitleFontStyle: BBFontStyle? ,
+        actions: [Action],
+        viewConfig: BBAlertViewConfiguration,
+        config: BBAlertConfiguration
+    ) -> Observable<Action> where Action: BBAlertActionType
+    
+    @discardableResult
+    func show<Action>(
+        child: any BBAlertStackView,
+        actions: [Action],
+        viewConfig: BBAlertViewConfiguration,
+        config: BBAlertConfiguration
+    ) -> Observable<Action> where Action: BBAlertActionType
+    
+    @discardableResult
+    func show<Action>(
+        _ style: BBAlertStyle,
+        primaryAction: Action,
+        config: BBAlertConfiguration
+    ) -> Observable<Action> where Action: BBAlertActionType
+}
+
+public extension BBAlertServiceType {
+    
+    @discardableResult
+    func show<Action>(
+        title: String,
+        titleFontStyle: BBFontStyle? = nil,
+        subtitle: String? = nil,
+        subtitleFontStyle: BBFontStyle? = nil,
+        actions: [Action],
+        viewConfig: BBAlertViewConfiguration = BBAlertViewConfiguration(),
+        config: BBAlertConfiguration = BBAlertConfiguration()
+    ) -> Observable<Action> where Action: BBAlertActionType {
+        
+        return Observable<Action>.create { observer in
+            let alert = BBAlert.text(
+                title: title,
+                titleFontStyle: titleFontStyle,
+                subtitle: subtitle,
+                subtitleFontStyle: subtitleFontStyle,
+                viewConfig: viewConfig,
+                config: config
+            )
+            
+            for action in actions {
+                let action = BBAlertAction(title: action.title, style: action.style) { alert in
+                    observer.onNext(action)
+                    alert?.close()
+                }
+                alert.addAction(action)
+            }
+            
+            alert.show()
+            
+            return Disposables.create {
+                alert.close()
+            }
+        }
+        
+    }
+    
+    @discardableResult
+    func show<Action>(
+        image: UIImage? = nil,
+        imageTint: UIColor? = nil,
+        title: String,
+        titleFontStyle: BBFontStyle? = nil,
+        subtitle: String? = nil,
+        subtitleFontStyle: BBFontStyle? = nil,
+        actions: [Action],
+        viewConfig: BBAlertViewConfiguration = BBAlertViewConfiguration(),
+        config: BBAlertConfiguration = BBAlertConfiguration()
+    ) -> Observable<Action> where Action: BBAlertActionType {
+        
+        return Observable<Action>.create { observer in
+            let alert = BBAlert.image(
+                image: image,
+                imageTint: imageTint,
+                title: title,
+                titleFontStyle: titleFontStyle,
+                subtitle: subtitle,
+                subtitleFontStyle: subtitleFontStyle,
+                viewConfig: viewConfig,
+                config: config
+            )
+            
+            for action in actions {
+                let action = BBAlertAction(title: action.title, style: action.style) { alert in
+                    observer.onNext(action)
+                    alert?.close()
+                }
+                alert.addAction(action)
+            }
+            
+            alert.show()
+            
+            return Disposables.create {
+                alert.close()
+            }
+        }
+        
+    }
+    
+    @discardableResult
+    func show<Action>(
+        child: any BBAlertStackView,
+        actions: [Action],
+        viewConfig: BBAlertViewConfiguration = BBAlertViewConfiguration(),
+        config: BBAlertConfiguration = BBAlertConfiguration()
+    ) -> Observable<Action> where Action: BBAlertActionType {
+        
+        return Observable<Action>.create { observer in
+            let alert = BBAlert.custom(
+                child,
+                viewConfig: viewConfig,
+                config: config
+            )
+            
+            for action in actions {
+                let action = BBAlertAction(title: action.title, style: action.style) { alert in
+                    observer.onNext(action)
+                    alert?.close()
+                }
+                alert.addAction(action)
+            }
+            
+            alert.show()
+            
+            return Disposables.create {
+                alert.close()
+            }
+        }
+        
+    }
+    
+    @discardableResult
+    func show<Action>(
+        _ style: BBAlertStyle,
+        primaryAction action: Action,
+        config: BBAlertConfiguration = BBAlertConfiguration()
+    ) -> Observable<Action> {
+        
+        return Observable<Action>.create { observer in
+            let action: BBAlertActionHandler = { alert in
+                observer.onNext(action)
+                alert?.close()
+            }
+            
+            let alert = BBAlert.style(
+                style,
+                primaryAction: action,
+                config: config
+            )
+            
+            alert.show()
+            
+            return Disposables.create {
+                alert.close()
+            }
+        }
+        
+    }
+    
+    
+}
+
+
+
+// MARK: - BBAlertService
+
+public final class BBAlertService: BaseService, BBAlertServiceType { }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/BBAlertService.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/BBAlertService.swift
@@ -12,8 +12,17 @@ import RxSwift
 
 // MARK: - BBAlertActionType
 
+/// BBAlertActionType은 BBAlert의 버튼 스타일과 액션을 정의하도록 도와주는 프로토콜입니다.
+///
+/// 우리가 Reactor의 Action 열거형에 액션 케이스를 정의하듯이,  마찬가지로 BBAlertActionType 프로토콜의 준수하는 열거형의 케이스가 버튼 액션의 결과가 됩니다.
+///
+/// - Authors: 김소월
 public protocol BBAlertActionType {
+    
+    /// title 프로퍼티는 필수 구현이며, 버튼의 타이틀을 의미합니다.
     var title: String? { get }
+    
+    /// style 프로퍼티는 버튼의 스타일을 의미합니다. 선택 구현이며, 기본값은 default입니다.
     var style: BBAlertActionStyle { get }
 }
 
@@ -70,6 +79,16 @@ public protocol BBAlertServiceType {
 
 public extension BBAlertServiceType {
     
+    /// 텍스트와 서브 텍스트가 포함된 Alert를 생성합니다.
+    /// - Parameters:
+    ///   - title: 타이틀 텍스트
+    ///   - titleFontStyle: 타이틀의 폰트 스타일
+    ///   - subtitle: 서브 타이틀 텍스트
+    ///   - subtitleFontStyle: 서브 타이틀의 폰트 스타일
+    ///   - actions: BBAlertActionType을 준수하는 열거형 케이스 배열
+    ///   - viewConfig: AlertView 설정값
+    ///   - config: Alert 설정값
+    /// - Returns: Observable
     @discardableResult
     func show<Action>(
         title: String,
@@ -108,6 +127,18 @@ public extension BBAlertServiceType {
         
     }
     
+    /// 텍스트, 서브 텍스트와 이미지가 포함된 Alert를 생성합니다.
+    /// - Parameters:
+    ///   - image: 이미지
+    ///   - imageTint: 이미지 강조 색상
+    ///   - title: 타이틀 텍스트
+    ///   - titleFontStyle: 타이틀의 폰트 스타일
+    ///   - subtitle: 서브 타이틀 텍스트
+    ///   - subtitleFontStyle: 서브 타이틀의 폰트 스타일
+    ///   - actions: BBAlertActionType을 준수하는 열거형 케이스 배열
+    ///   - viewConfig: AlertView 설정값
+    ///   - config: Alert 설정값
+    /// - Returns: Observable
     @discardableResult
     func show<Action>(
         image: UIImage? = nil,
@@ -150,6 +181,13 @@ public extension BBAlertServiceType {
         
     }
     
+    /// 직접 커스텀한 뷰로 BBAlert을 생성합니다.
+    /// - Parameters:
+    ///   - child: BBAlertStackView 프로토콜을 준수하는 UIView
+    ///   - actions: BBAlertActionType을 준수하는 열거형 케이스 배열
+    ///   - viewConfig: AlertView 설정값
+    ///   - config: Alert 설정값
+    /// - Returns: Observable
     @discardableResult
     func show<Action>(
         child: any BBAlertStackView,
@@ -182,6 +220,12 @@ public extension BBAlertServiceType {
         
     }
     
+    /// 정해진 Style의 Alert를 생성합니다.
+    /// - Parameters:
+    ///   - style: 스타일
+    ///   - primaryAction: BBAlertActionType을 준수하는 열거형 케이스
+    ///   - config: Alert 설정값
+    /// - Returns: Observable
     @discardableResult
     func show<Action>(
         _ style: BBAlertStyle,
@@ -217,4 +261,55 @@ public extension BBAlertServiceType {
 
 // MARK: - BBAlertService
 
+/// BBAlert를 조금 더 Rx스럽게 사용하도록 도와주는 서비스입니다.
+///
+/// 서비스의 **show(_:)** 메서드를 호출하기 전 버튼의 스타일과 액션이 정의된 **BBAlertActionType** 프로토콜을 준수하는 열거형을 선언해야 합니다.
+///
+/// ```swift
+///
+/// enum PickAlertAction: BBAlertActionType {
+///    case pick
+///    case cancel
+///
+///    var title: String? {
+///    switch self {
+///        case .pick: return "지금 하기"
+///        case .cancel: return "다음에 하기"
+///        }
+///    }
+///
+///    var style: BBAlertActionStyle {
+///        switch self {
+///        case .pick: return .default
+///        case .cancel: return .cancel
+///        }
+///    }
+///}
+/// ```
+///
+/// 이렇게 정의한 PickAlertAction 열거형의 케이스는 버튼 액션의 결과가 됩니다. 예를 들어, 지금 하기 버튼을 클릭하면 pick 케이스 항목이 방출되며, 방출된 아이템에 따라 flatMap 연산자에서 액션 분기 처리를 해줄 수 있습니다. 아래 코드는 버튼 액션을 받아 처리하는 방법을 보여줍니다.
+///
+/// ```swift
+/// let actions: [PickAlertAction] = [.pick, .cancel]
+///
+///return provider.bbAlertService.show(
+///        image: DesignSystemAsset.missionKeyGraphic.image,
+///        title: "미션 열쇠 획득!",
+///        subtitle: "열쇠를 획득해 잠금이 해제되었어요.",
+///        actions: actions
+///    )
+///    .withUnretained(self)
+///    .flatMap { // 버튼을 클릭하면 곧바로 해당하는 액션 항목이 방출됨
+///    switch $0.1 {
+///    case .pick:
+///        return Observable<Mutation>.just(.setHiddenPickButton(true))
+///
+///    default:
+///        return Observable<Mutation>.empty()
+///    }
+///}
+/// ```
+///
+/// - Authors: 김소월
+///
 public final class BBAlertService: BaseService, BBAlertServiceType { }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ServiceProvider.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ServiceProvider.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 public protocol ServiceProviderProtocol: AnyObject {
+    
+    var bbAlertService: BBAlertServiceType { get }
+    
     var mainService: MainServiceType { get }
     var managementService: ManagementServiceType { get }
     
@@ -21,6 +24,8 @@ public protocol ServiceProviderProtocol: AnyObject {
 }
 
 final public class ServiceProvider: ServiceProviderProtocol {
+    
+    public lazy var bbAlertService: any BBAlertServiceType = BBAlertService(provider: self)
     
     public lazy var mainService: MainServiceType = MainService(provider: self)
     public lazy var managementService: any ManagementServiceType = ManagementService(provider: self)


### PR DESCRIPTION
## 😽개요

* 가족멤버 셀에서 Pick을 하더라도 제대로 Pick 버튼이 사라지지 않는 문제 수정
* BBAlert 액션 흐름을 Rx스럽게 바꿔주는 **BBAlertActionType** 및 **BBAlertService** 정의

## 🛠️작업 내용

### BBAlertService 구현 및 사용법

* **BBAlertActionType**은  BBAlert의 버튼 스타일과 액션을 정의하도록 도와주는 프로토콜입니다. 우리가 **Action** 열거형에 액션 케이스를 정의하듯이, 아래 코드도 마찬가지로 **PickAlertAction** 열거형의 케이스가 버튼 액션의 결과가 됩니다. 아래 코드는 해당 프로토콜을 채택해 구현하는 방법을 보여줍니다.

```swift
enum PickAlertAction: BBAlertActionType {
    case pick
    case cancel
    
    var title: String? {
        switch self {
        case .pick: return "지금 하기"
        case .cancel: return "다음에 하기"
        }
    }
    
    var style: BBAlertActionStyle {
        switch self {
        case .pick: return .default
        case .cancel: return .cancel
        }
    }
}
```

* **title** 계산 프로퍼티는 필수 구현이며, 버튼의 타이틀을 의미합니다. **style** 계산 프로퍼티는 버튼의 스타일을 의미합니다. 선택 구현이며, 기본값은 `default`입니다.

* 이렇게 정의한 **PickAlertAction** 열거형의 케이스는 버튼 액션의 결과가 됩니다. 예를 들어, `지금 하기` 버튼을 클릭하면 `pick` 케이스 항목이 방출되며, 방출된 아이템에 따라 `flatMap` 연산자에서 액션 분기 처리를 해줄 수 있습니다. 아래 코드는 버튼 액션을 받아 처리하는 방법을 보여줍니다.

```swift
func mutate(action: Action) -> Observable<Mutation> {
        switch action {
        case .didTapPickButton:
            let actions: [PickAlertAction] = [.pick, .cancel]
            let memberId = initialState.profileData.memberId
            let memberName = initialState.profileData.name

            return provider.bbAlertService.show(
                image: DesignSystemAsset.missionKeyGraphic.image,
                title: "미션 열쇠 획득!",
                subtitle: "열쇠를 획득해 잠금이 해제되었어요.\n미션 사진을 찍을 수 있어요!",
                actions: actions
            )
            .withUnretained(self)
            .flatMap { // 버튼을 클릭하면 곧바로 액션 항목이 방출됨
                switch $0.1 {
                case .pick:
                    return $0.0.pickMemberUseCase.execute(memberId: memberId)
                        .flatMap {
                            guard
                                let entity = $0, !entity.success
                            else { return Observable<Mutation>.empty() }
                            
                            return Observable<Mutation>.just(.setHiddenPickButton(true))
                        }
                    
                default:
                    return Observable<Mutation>.empty()
                }
            }
        }
    }
```

| 이미지① |
| :----: |
| ![Simulator Screen Recording - iPhone 15 Pro - 2024-09-20 at 23 06 16](https://github.com/user-attachments/assets/00098f57-d189-49c3-a982-0d73960d7439) |

* **BBAlertService**를 활용하면 더 이상 버튼의 액션을 처리하기 위해 `BBAlertDelegate`를 구현할 필요가 없어집니다. 그리고 **Navigator**에 `showToast(_:)`와 같은 메서드를 구현할 필요도 없습니다. 그저 **bbAlertService**를 호출하세요.


## 🟡차후 계획

* **BBToast** 모듈에도 비슷하게 BBToastService에서 Toast를 불러오도록 구현할 예정입니다.


## ✅테스트 케이스

- [x] 픽 버튼 클릭 후 버튼이 제대로 사라지는지 확인


---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.



close #636 