### PR TITLE
fix: 로그인 시 FamilyId 조회 못하는 이슈 수정해요

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/DIContainer/NavigatorDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Application/DIContainer/NavigatorDIContainer.swift
@@ -31,6 +31,12 @@ final class NavigatorDIContainer: BaseContainer {
             )
         }
         
+        container.register(type: HomeNavigatorProtocol.self) { _ in
+            HomeNavigator(
+                navigationController: makeUINavigationController()
+            )
+        }
+        
         container.register(type: MainNavigatorProtocol.self) { _ in
                 MainNavigator(navigationController: makeUINavigationController())
         }

--- a/14th-team5-iOS/App/Sources/Application/DIContainer/RealEmojiDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Application/DIContainer/RealEmojiDIContainer.swift
@@ -25,6 +25,10 @@ final class RealEmojiDIContainer: BaseContainer {
     private func makeFetchRealEmojiListUseCase() -> FetchRealEmojiListUseCaseProtocol {
         return FetchRealEmojiListUseCase(realEmojiRepository: repository)
     }
+    
+    private func makeFetchMyRealEmojiUseCase() -> FetchMyRealEmojiUseCaseProtocol {
+        return FetchMyRealEmojiUseCase(realEmojiRepository: repository)
+    }
 }
 
 extension RealEmojiDIContainer {
@@ -39,6 +43,10 @@ extension RealEmojiDIContainer {
         
         container.register(type: FetchRealEmojiListUseCaseProtocol.self) { _ in
             self.makeFetchRealEmojiListUseCase()
+        }
+        
+        container.register(type: FetchMyRealEmojiUseCaseProtocol.self) { _ in
+            self.makeFetchMyRealEmojiUseCase()
         }
     }
 }

--- a/14th-team5-iOS/App/Sources/Application/Navigator/AccountSignInNavigator.swift
+++ b/14th-team5-iOS/App/Sources/Application/Navigator/AccountSignInNavigator.swift
@@ -12,6 +12,7 @@ import UIKit
 protocol AccountSignInNavigatorProtocol: BaseNavigator {
     func toMain()
     func toSignUp()
+    func toJoinFamily()
 }
 
 final class AccountSignInNavigator: AccountSignInNavigatorProtocol {
@@ -29,6 +30,11 @@ final class AccountSignInNavigator: AccountSignInNavigatorProtocol {
     
     func toSignUp() {
         let vc = AccountSignUpDIContainer().makeViewController()
+        navigationController.setViewControllers([vc], animated: false)
+    }
+    
+    func toJoinFamily() {
+        let vc = JoinFamilyViewControllerWrapper().viewController
         navigationController.setViewControllers([vc], animated: false)
     }
 }

--- a/14th-team5-iOS/App/Sources/Application/Navigator/SplashNavigator.swift
+++ b/14th-team5-iOS/App/Sources/Application/Navigator/SplashNavigator.swift
@@ -13,6 +13,7 @@ protocol SplashNavigatorProtocol: BaseNavigator {
     func toJoined()
     func toSignIn()
     func toOnboarding()
+    func toJoinFamily()
 }
 
 final class SplashNavigator: SplashNavigatorProtocol {
@@ -45,6 +46,11 @@ final class SplashNavigator: SplashNavigatorProtocol {
     
     func toOnboarding() {
         let vc = SplashViewControllerWrapper().viewController
+        navigationController.setViewControllers([vc], animated: false)
+    }
+    
+    func toJoinFamily() {
+        let vc = JoinFamilyViewControllerWrapper().viewController
         navigationController.setViewControllers([vc], animated: false)
     }
     

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
@@ -146,6 +146,10 @@ extension AccountSignInViewController {
         }
         
         if isFirstOnboarding || isTemporaryToken == false {
+            if App.Repository.member.familyId.value == nil {
+                signInNavigator.toJoinFamily()
+                return
+            }
             signInNavigator.toMain()
             return
         }

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
@@ -221,7 +221,7 @@ extension CameraViewReactor {
         case .realEmoji:
             
             return .concat(
-                fetchRealEmojiListUseCase.execute(memberId: memberId)
+                fetchRealEmojiListUseCase.execute()
                     .asObservable()
                     .withUnretained(self)
                     .flatMap { owner, entity -> Observable<CameraViewReactor.Mutation> in
@@ -373,7 +373,7 @@ extension CameraViewReactor {
                                             .flatMap { realEmojiEntity -> Observable<CameraViewReactor.Mutation> in
                                                 guard let createRealEmojiEntity = realEmojiEntity else { return .just(.setErrorAlert(true))}
                                                 owner.provider.realEmojiGlobalState.createRealEmojiImage(indexPath: owner.currentState.emojiType.rawValue - 1, image: createRealEmojiEntity.realEmojiImageURL, emojiType: createRealEmojiEntity.realEmojiType)
-                                                return owner.fetchRealEmojiListUseCase.execute(memberId: owner.memberId)
+                                                return owner.fetchRealEmojiListUseCase.execute()
                                                     .asObservable()
                                                     .flatMap { reloadEntity -> Observable<CameraViewReactor.Mutation> in
                                                         return .concat(

--- a/14th-team5-iOS/App/Sources/Presentation/FamilyEntrance/ViewController/JoinFamilyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/FamilyEntrance/ViewController/JoinFamilyViewController.swift
@@ -83,12 +83,6 @@ final class JoinFamilyViewController: BaseViewController<JoinFamilyReactor> {
             .bind(onNext: { $0.0.newGroupAlertController()})
             .disposed(by: disposeBag)
         
-        NotificationCenter.default
-            .rx.notification(.didTapCreatFamilyGroupButton)
-            .map { _ in Reactor.Action.makeFamily }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
         joinFamilyButton.rx.tap
             .map { Reactor.Action.joinFamily }
             .bind(to: reactor.action)
@@ -137,9 +131,10 @@ extension JoinFamilyViewController {
         )
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-        let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
+        let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
+            guard let self else { return }
             MPEvent.Account.creatGroupFinished.track(with: nil)
-            NotificationCenter.default.post(name: .didTapCreatFamilyGroupButton, object: nil, userInfo: nil)
+            self.reactor?.action.onNext(.makeFamily)
         }
         
         [cancelAction, confirmAction].forEach(resignAlertController.addAction(_:))

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/PrivacyViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/PrivacyViewController.swift
@@ -121,20 +121,7 @@ public final class PrivacyViewController: BaseViewController<PrivacyViewReactor>
                 @Navigator var privacyNavigator: PrivacyNavigatorProtocol
                 privacyNavigator.toSignIn()
             }.disposed(by: disposeBag)
-        
-        NotificationCenter.default
-            .rx.notification(.UserAccountLogout)
-            .map { _ in Reactor.Action.didTapLogoutButton }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        NotificationCenter.default
-            .rx.notification(.UserFamilyResign)
-            .map { _ in Reactor.Action.didTapFamilyUserResign }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        
+
         inquiryBannerView
             .rx.tap
             .throttle(.milliseconds(300), scheduler: MainScheduler.instance)
@@ -233,8 +220,9 @@ extension PrivacyViewController {
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         
-        let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
-            NotificationCenter.default.post(name: .UserAccountLogout, object: nil, userInfo: nil)
+        let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self]_ in
+            guard let self else { return }
+            self.reactor?.action.onNext(.didTapLogoutButton)
         }
         
         [cancelAction, confirmAction].forEach(logoutAlertController.addAction(_:))
@@ -251,8 +239,9 @@ extension PrivacyViewController {
         
         let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         
-        let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
-            NotificationCenter.default.post(name: .UserFamilyResign, object: nil, userInfo: nil)
+        let confirmAction = UIAlertAction(title: "확인", style: .default) { [weak self ]_ in
+            guard let self else { return }
+            self.reactor?.action.onNext(.didTapFamilyUserResign)
         }
         
         [cancelAction, confirmAction].forEach(resignAlertController.addAction(_:))

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileFeedViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileFeedViewController.swift
@@ -68,12 +68,6 @@ final class ProfileFeedViewController: BaseViewController<ProfileFeedViewReactor
     override func bind(reactor: ProfileFeedViewReactor) {
         
         
-        Observable.just(())
-            .map { Reactor.Action.reloadFeedItems }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-
-        
         profileFeedCollectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -86,6 +86,7 @@ public final class ProfileViewReactor: Reactor {
         //TODO: Keychain, UserDefaults 추가
         switch action {
         case .viewDidLoad:
+            provider.profileGlobalState.fetchMemberdId(memberId: currentState.memberId)
             return fetchMembersProfileUseCase.execute(memberId: currentState.memberId)
                 .asObservable()
                 .flatMap { entity -> Observable<ProfileViewReactor.Mutation> in

--- a/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Splash/SplashViewController.swift
@@ -93,31 +93,22 @@ public final class SplashViewController: BaseViewController<SplashReactor> {
     
     private func showNextPage(with member: MemberInfo?) {
         @Navigator var splashNavigator: SplashNavigatorProtocol
-        
+        print("memberId: \(member)")
         guard let member = member else {
             splashNavigator.toSignIn()
-//            container = UINavigationController(rootViewController: AccountSignInDIContainer().makeViewController())
-//            sceneDelegate.window?.rootViewController = container
-//            sceneDelegate.window?.makeKeyAndVisible()
             return
         }
-        
+        print("member FamilYId: \(member.familyId)")
         if let _ = member.familyId {
             if UserDefaults.standard.inviteCode != nil {
                 splashNavigator.toJoined()
-//                container = UINavigationController(rootViewController: JoinedFamilyDIContainer().makeViewController())
             } else {
                 splashNavigator.toHome()
-//                container = UINavigationController(rootViewController: MainViewControllerWrapper().makeViewController())
+                return
             }
-//            sceneDelegate.window?.rootViewController = container
-//            sceneDelegate.window?.makeKeyAndVisible()
             return
         } else {
-            splashNavigator.toOnboarding()
-//            container = UINavigationController(rootViewController: OnBoardingDIContainer().makeViewController())
-//            sceneDelegate.window?.rootViewController = container
-//            sceneDelegate.window?.makeKeyAndVisible()
+            splashNavigator.toJoinFamily()
             return
         }
     }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/API.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/API.swift
@@ -51,7 +51,7 @@ public enum BibbiAPI {
         public var value: String {
             switch self {
             case let .auth(token): return "Bearer \(token)"
-            case .xAppKey: return "7c5aaa36-570e-491f-b18a-26a1a0b72959" // TODO: - 번들에서 가져오기
+            case .xAppKey: return "7b159d28-b106-4b6d-a490-1fd654ce40c2" // TODO: - 번들에서 가져오기
             case let .xAuthToken(token): return "\(token)"
             case .contentForm: return "application/x-www-form-urlencoded"
             case .contentJson: return "application/json"

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ProfileGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ProfileGlobalState.swift
@@ -11,6 +11,7 @@ import RxSwift
 
 public enum ProfileEvent {
     case refreshFamilyMembers
+    case fetchMemberId(String)
 }
 
 public protocol ProfileGlobalStateType {
@@ -18,6 +19,8 @@ public protocol ProfileGlobalStateType {
     
     @discardableResult
     func refreshFamilyMembers() -> Observable<Void>
+    @discardableResult
+    func fetchMemberdId(memberId: String) -> Observable<String>
 }
 
 final public class ProfileGlobalState: BaseService, ProfileGlobalStateType {
@@ -26,6 +29,11 @@ final public class ProfileGlobalState: BaseService, ProfileGlobalStateType {
     public func refreshFamilyMembers() -> Observable<Void> {
         event.onNext(.refreshFamilyMembers)
         return Observable<Void>.just(())
+    }
+    
+    public func fetchMemberdId(memberId: String) -> Observable<String> {
+        event.onNext(.fetchMemberId(memberId))
+        return Observable<String>.just(memberId)
     }
 }
 

--- a/14th-team5-iOS/Core/Sources/Extensions/Notification+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Notification+Ext.swift
@@ -14,11 +14,8 @@ extension Notification.Name {
     public static let AccountViewPresignURLDismissNotification = Notification.Name("AccountViewPresignURLDismissNotification")
     public static let AppVersionsCheckWithRedirectStore = Notification.Name("AppVersionsCheckWithRedirectStore")
     public static let ProfileImageInitializationUpdate = Notification.Name("ProfileImageInitializationUpdate")
-    public static let UserAccountLogout = Notification.Name("UserAccountLogout")
-    public static let UserFamilyResign = Notification.Name("UserFamilyResign")
     public static let DidFinishProfileImageUpdate = Notification.Name("DidFinishProfileImageUpdate")
     public static let didTapSelectableCameraButton = Notification.Name("didTapSelectableCameraButton")
-    public static let didTapCreatFamilyGroupButton = Notification.Name("didTapCreatFamilyGroupButton")
     public static let didTapBibbiToastTranstionButton = Notification.Name("didTapTranstionButton")
     public static let didTapUpdateButton = Notification.Name("didTapUpdateButton")
 }

--- a/14th-team5-iOS/Data/Sources/APIs/App/Repository/AppRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/App/Repository/AppRepository.swift
@@ -33,7 +33,7 @@ extension AppRepository {
     
     public func fetchAppVersion() -> Observable<AppVersionEntity?> {
         // TODO: - xAppKey 불러오는 코드 다시 작성하기
-        let appKey = "7c5aaa36-570e-491f-b18a-26a1a0b72959"
+        let appKey = "7b159d28-b106-4b6d-a490-1fd654ce40c2"
         
         return appApiWorker.fetchAppVersion(appKey: appKey)
             .map { $0?.toDomain() }

--- a/14th-team5-iOS/Data/Sources/Trash/Camera/CameraAPI/CameraAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Trash/Camera/CameraAPI/CameraAPIWorker.swift
@@ -91,7 +91,9 @@ extension CameraAPIWorker {
         
     }
     
-    public func createRealEmojiPresignedURL(accessToken: String, memberId: String, parameters: Encodable) -> Single<CameraRealEmojiPreSignedResponseDTO?> {
+    public func createRealEmojiPresignedURL(accessToken: String, parameters: Encodable) -> Single<CameraRealEmojiPreSignedResponseDTO?> {
+        //TODO: Repository로 코드 원복
+        let memberId = App.Repository.member.memberID.value ?? ""
         let spec = CameraAPIs.uploadRealEmojiURL(memberId).spec
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
@@ -102,7 +104,9 @@ extension CameraAPIWorker {
         
     }
     
-    public func uploadRealEmojiImageToS3(accessToken: String, memberId: String, parameters: Encodable) -> Single<CameraCreateRealEmojiResponseDTO?> {
+    public func uploadRealEmojiImageToS3(accessToken: String, parameters: Encodable) -> Single<CameraCreateRealEmojiResponseDTO?> {
+        //TODO: Repository로 코드 원복
+        let memberId = App.Repository.member.memberID.value ?? ""
         let spec = CameraAPIs.updateRealEmojiImage(memberId).spec
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
@@ -112,7 +116,9 @@ extension CameraAPIWorker {
             .asSingle()
     }
     
-    public func loadRealEmojiImage(accessToken: String, memberId: String) -> Single<CameraRealEmojiImageItemResponseDTO?> {
+    public func loadRealEmojiImage(accessToken: String) -> Single<CameraRealEmojiImageItemResponseDTO?> {
+        //TODO: Repository로 코드 원복
+        let memberId = App.Repository.member.memberID.value ?? ""
         let spec = CameraAPIs.reloadRealEmoji(memberId).spec
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)])
@@ -122,7 +128,9 @@ extension CameraAPIWorker {
             .asSingle()
     }
     
-    public func updateRealEmojiImage(accessToken: String, memberId: String, realEmojiId: String, parameters: Encodable) -> Single<CameraUpdateRealEmojiResponseDTO?> {
+    public func updateRealEmojiImage(accessToken: String, realEmojiId: String, parameters: Encodable) -> Single<CameraUpdateRealEmojiResponseDTO?> {
+        //TODO: Repository로 코드 원복
+        let memberId = App.Repository.member.memberID.value ?? ""
         let spec = CameraAPIs.modifyRealEmojiImage(memberId, realEmojiId).spec
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
             .subscribe(on: Self.queue)

--- a/14th-team5-iOS/Data/Sources/Trash/Camera/Repository/CameraRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Trash/Camera/Repository/CameraRepository.swift
@@ -54,22 +54,22 @@ extension CameraRepository: CameraRepositoryProtocol {
     }
     
     public func fetchRealEmojiImageURL(memberId: String, parameters: CameraRealEmojiParameters) -> Single<CameraRealEmojiPreSignedEntity?> {
-        return cameraAPIWorker.createRealEmojiPresignedURL(accessToken: accessToken, memberId: memberId, parameters: parameters)
+        return cameraAPIWorker.createRealEmojiPresignedURL(accessToken: accessToken, parameters: parameters)
             .map { $0?.toDomain() }
     }
     
     public func uploadRealEmojiImageToS3(memberId: String, parameters: CameraCreateRealEmojiParameters) -> Single<CameraCreateRealEmojiEntity?> {
-        return cameraAPIWorker.uploadRealEmojiImageToS3(accessToken: accessToken, memberId: memberId, parameters: parameters)
+        return cameraAPIWorker.uploadRealEmojiImageToS3(accessToken: accessToken, parameters: parameters)
             .map { $0?.toDomain() }
     }
     
-    public func fetchRealEmojiItems(memberId: String) -> Single<[CameraRealEmojiImageItemEntity?]> {
-        return cameraAPIWorker.loadRealEmojiImage(accessToken: accessToken, memberId: memberId)
+    public func fetchRealEmojiItems() -> Single<[CameraRealEmojiImageItemEntity?]> {
+        return cameraAPIWorker.loadRealEmojiImage(accessToken: accessToken)
             .map { $0?.toDomain() ?? [] }
     }
     
     public func updateRealEmojiImage(memberId: String, realEmojiId: String, parameters: CameraUpdateRealEmojiParameters) -> Single<CameraUpdateRealEmojiEntity?> {
-        return cameraAPIWorker.updateRealEmojiImage(accessToken: accessToken, memberId: memberId, realEmojiId: realEmojiId, parameters: parameters)
+        return cameraAPIWorker.updateRealEmojiImage(accessToken: accessToken, realEmojiId: realEmojiId, parameters: parameters)
             .map { $0?.toDomain() }
     }
   

--- a/14th-team5-iOS/Domain/Sources/Entities/PostList/PostListQuery.swift
+++ b/14th-team5-iOS/Domain/Sources/Entities/PostList/PostListQuery.swift
@@ -41,7 +41,7 @@ public struct PostListQuery {
     public var page: Int
     public let size: Int
     public let date: String
-    public let memberId: String?
+    public var memberId: String?
     public let type: PostType
     public let sort: String
     

--- a/14th-team5-iOS/Domain/Sources/Trash/Camera/Interfaces/CameraRepositoryProtocol.swift
+++ b/14th-team5-iOS/Domain/Sources/Trash/Camera/Interfaces/CameraRepositoryProtocol.swift
@@ -68,13 +68,12 @@ public protocol CameraRepositoryProtocol {
     var disposeBag: DisposeBag { get }
     
     var accessToken: String { get }
-    
     func addPresignedeImageURL(parameters: CameraDisplayImageParameters) -> Single<CameraPreSignedEntity?>
     func uploadImageToS3(to url: String, from image: Data) -> Single<Bool>
     func editProfleImageToS3(memberId: String, parameter: ProfileImageEditParameter) -> Single<MembersProfileEntity?>
     func fetchRealEmojiImageURL(memberId: String, parameters: CameraRealEmojiParameters) -> Single<CameraRealEmojiPreSignedEntity?>
     func uploadRealEmojiImageToS3(memberId: String, parameters: CameraCreateRealEmojiParameters) -> Single<CameraCreateRealEmojiEntity?>
-    func fetchRealEmojiItems(memberId: String) -> Single<[CameraRealEmojiImageItemEntity?]>
+    func fetchRealEmojiItems() -> Single<[CameraRealEmojiImageItemEntity?]>
     func updateRealEmojiImage(memberId: String, realEmojiId: String, parameters: CameraUpdateRealEmojiParameters) -> Single<CameraUpdateRealEmojiEntity?>
     func fetchTodayMissionItem() -> Single<CameraTodayMssionEntity?>
     func combineWithTextImage(parameters: CameraDisplayPostParameters, query: CameraMissionFeedQuery) -> Single<CameraPostEntity?>

--- a/14th-team5-iOS/Domain/Sources/Trash/Camera/UseCases/RealEmoji/FetchCameraRealEmojiListUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/Trash/Camera/UseCases/RealEmoji/FetchCameraRealEmojiListUseCase.swift
@@ -12,7 +12,7 @@ import RxCocoa
 
 
 public protocol FetchCameraRealEmojiListUseCaseProtocol {
-    func execute(memberId: String) -> Single<[CameraRealEmojiImageItemEntity?]>
+    func execute() -> Single<[CameraRealEmojiImageItemEntity?]>
 }
 
 
@@ -24,8 +24,8 @@ public final class FetchCameraRealEmojiListUseCase: FetchCameraRealEmojiListUseC
         self.cameraRepository = cameraRepository
     }
     
-    public func execute(memberId: String) -> Single<[CameraRealEmojiImageItemEntity?]> {
-        return cameraRepository.fetchRealEmojiItems(memberId: memberId)
+    public func execute() -> Single<[CameraRealEmojiImageItemEntity?]> {
+        return cameraRepository.fetchRealEmojiItems()
     }
     
 }


### PR DESCRIPTION
## 😽개요
- `AccountSignInViewController`에서 회원 가입 이후 사용자가 가족방 생성하지 않은 상태에서 종료하게 되면 `Storage`에 FamilyId가 없지만 `toMain`으로 이동하고 있었습니다.
- 이러한 예외 처리가 `OnboardingViewController`에는 있었지만 저희가 기존 회원은 온 보딩 화면을 보지 않기 때문에 이슈가 발생하게 되었습니다.

## 🛠️작업 내용
- `AccountSignInViewController` 에서 FamilyId가 없을 경우 `JoinFamilyViewController`로 화면 전환 로직을 추가 했습니다.
- `CreateFamily`, `ResignFamily` 등 통신 로직이 다중으로 호출하는 경우가 있어서 NotificationCenter 에서 Reactor로 수정하였습니다. 

### AccountSignInViewController Code
```swift
if isFirstOnboarding || isTemporaryToken == false {
      if App.Repository.member.familyId.value == nil {
           signInNavigator.toJoinFamily()
         return
            }
          signInNavigator.toMain()
         return
    }

```

## ✅테스트 케이스

* 신규 회원일때 Onboarding 화면과, 가족방 생성 화면으로 이동하는지 
* 기존 회원일때 로그아웃 이후 바로 메인 화면으로 이동하는지
* 회원 탈퇴 이후 회원가입 화면으로 이동하는지
* 가족 탈퇴 이후 가족 방 생성후 메인화면 API 호출을 하는지

---