### PR TITLE
fix: 프로필 미션 피드 불러오기 기능 수정 및 기타 이슈 반영

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
@@ -126,7 +126,7 @@ public final class CameraViewReactor: Reactor {
         case .didTapToggleButton:
             return Observable.just(.setPosition(!self.currentState.isSwitchPosition))
         case .didTapFlashButton:
-            return Observable.just(.setFlashMode(self.currentState.isFlashMode))
+            return Observable.just(.setFlashMode(!self.currentState.isFlashMode))
         case let .didTapZoomButton(scale):
             if self.currentState.zoomScale == 2.0 {
                 return .just(.setZoomScale(self.currentState.zoomScale - scale))

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileFeedViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/ProfileFeedViewController.swift
@@ -67,6 +67,11 @@ final class ProfileFeedViewController: BaseViewController<ProfileFeedViewReactor
     
     override func bind(reactor: ProfileFeedViewReactor) {
         
+        Observable.just(())
+            .map { Reactor.Action.reloadFeedItems }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         
         profileFeedCollectionView.rx
             .setDelegate(self)

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileFeedViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileFeedViewReactor.swift
@@ -18,7 +18,7 @@ final class ProfileFeedViewReactor: Reactor {
     @Injected private var feedUseCase: FetchMembersPostListUseCaseProtocol
     @Injected private var provider: ServiceProviderProtocol
     enum Action {
-        case reloadFeedItems(String)
+        case reloadFeedItems
         case fetchMoreFeedItems
         case didTapProfileFeedItem(IndexPath, [PostEntity])
     }
@@ -58,28 +58,12 @@ final class ProfileFeedViewReactor: Reactor {
         )
     }
     
-    
-    func transform(action: Observable<Action>) -> Observable<Action> {
-        let fetchMemberIdMutation = provider.profileGlobalState.event
-            .flatMap { event -> Observable<Action> in
-                switch event {
-                case let .fetchMemberId(memberId):
-                    return .just(.reloadFeedItems(memberId))
-                default:
-                    return .empty()
-                }
-            }
-        
-        return .merge(fetchMemberIdMutation, action)
-    }
-    
     func mutate(action: Action) -> Observable<Mutation> {
         
         var query: PostListQuery = PostListQuery(page: currentState.feedPage, size: 10, date: "", memberId: currentState.memberId, type: currentState.type, sort: .desc)
         
         switch action {
-        case let .reloadFeedItems(memberId):
-            query.memberId = memberId
+        case .reloadFeedItems:
             return feedUseCase.execute(query: query)
                 .asObservable()
                 .flatMap { entity -> Observable<ProfileFeedViewReactor.Mutation> in

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -19,6 +19,7 @@ public final class ProfileViewReactor: Reactor {
     @Injected private var createProfilePresignedUseCase: CreateCameraUseCaseProtocol
     @Injected private var uploadProfileImageUseCase: FetchCameraUploadImageUseCaseProtocol
     @Injected private var updateProfileUseCase: UpdateMembersProfileUseCaseProtocol
+    @Injected private var deleteProfileImageUseCase: DeleteMembersProfileUseCaseProtocol
     
     
     
@@ -176,19 +177,16 @@ public final class ProfileViewReactor: Reactor {
                             }
                     }
             )
-            
         case .didTapInitProfile:
-            return fetchMembersProfileUseCase.execute(memberId: memberId)
+            return deleteProfileImageUseCase.execute(memberId: memberId)
                 .asObservable()
-                .flatMap { entity -> Observable<ProfileViewReactor.Mutation> in
+                .flatMap { entity -> Observable<Mutation> in
                     return .concat(
                         .just(.setLoading(false)),
                         .just(.setProfileMemberItems(entity)),
                         .just(.setLoading(true))
                     )
-                    
                 }
-            
         case let .didTapSegementControl(feedType):
             provider.profilePageGlobalState.didTapSegmentedPageType(type: feedType)
             return .just(.setProfileFeedType(feedType))

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/Reactor/ProfileViewReactor.swift
@@ -86,7 +86,6 @@ public final class ProfileViewReactor: Reactor {
         //TODO: Keychain, UserDefaults 추가
         switch action {
         case .viewDidLoad:
-            provider.profileGlobalState.fetchMemberdId(memberId: currentState.memberId)
             return fetchMembersProfileUseCase.execute(memberId: currentState.memberId)
                 .asObservable()
                 .flatMap { entity -> Observable<ProfileViewReactor.Mutation> in

--- a/14th-team5-iOS/Core/Sources/Base/BaseTableView.swift
+++ b/14th-team5-iOS/Core/Sources/Base/BaseTableView.swift
@@ -16,7 +16,6 @@ open class BaseTableView<R>: UITableView, ReactorKit.View where R: Reactor {
     
     // MARK: - Properties
     
-    private var initialReactor: Reactor?
     
     public var disposeBag: RxSwift.DisposeBag = DisposeBag()
     
@@ -24,7 +23,7 @@ open class BaseTableView<R>: UITableView, ReactorKit.View where R: Reactor {
     
     public convenience init(reactor: Reactor? = nil) {
         self.init(frame: .zero, style: .plain)
-        self.initialReactor = reactor
+        self.reactor = reactor
     }
     
     public override init(frame: CGRect, style: UITableView.Style) {
@@ -32,7 +31,6 @@ open class BaseTableView<R>: UITableView, ReactorKit.View where R: Reactor {
         setupUI()
         setupAutoLayout()
         setupAttributes()
-        setupReactor()
     }
     
     public required init?(coder: NSCoder) {
@@ -52,8 +50,4 @@ open class BaseTableView<R>: UITableView, ReactorKit.View where R: Reactor {
     
     // 뷰의 속성 설정을 위한 메서드
     open func setupAttributes() { }
-    
-    open func setupReactor() {
-        self.reactor = initialReactor
-    }
 }

--- a/14th-team5-iOS/Core/Sources/Base/BaseViewController.swift
+++ b/14th-team5-iOS/Core/Sources/Base/BaseViewController.swift
@@ -16,7 +16,6 @@ open class BaseViewController<R>: UIViewController, ReactorKit.View where R: Rea
     public typealias Reactor = R
     
     // MARK: - Properties
-    private var initialReactor: Reactor?
     public var disposeBag: RxSwift.DisposeBag = DisposeBag()
     public let navigationBarView: BibbiNavigationBarView = BibbiNavigationBarView()
     
@@ -27,7 +26,7 @@ open class BaseViewController<R>: UIViewController, ReactorKit.View where R: Rea
     
     public convenience init(reactor: Reactor? = nil) {
         self.init()
-        self.initialReactor = reactor
+        self.reactor = reactor
     }
     
     required public init?(coder: NSCoder) {
@@ -40,7 +39,6 @@ open class BaseViewController<R>: UIViewController, ReactorKit.View where R: Rea
         setupUI()
         setupAutoLayout()
         setupAttributes()
-        setupReactor()
     }
     
     // MARK: - Helpers
@@ -60,12 +58,6 @@ open class BaseViewController<R>: UIViewController, ReactorKit.View where R: Rea
                 }
             })
             .disposed(by: disposeBag)
-    }
-    
-    open func setupReactor() {
-        if let reactor = initialReactor {
-            self.reactor = reactor
-        }
     }
     
     /// 서브 뷰 추가를 위한 메서드

--- a/14th-team5-iOS/Core/Sources/Base/ReactorViewController.swift
+++ b/14th-team5-iOS/Core/Sources/Base/ReactorViewController.swift
@@ -19,8 +19,6 @@ open class ReactorViewController<R>: UIViewController, ReactorKit.View where R: 
     
     // MARK: - Properties
 
-    private var initialReactor: Reactor?
-
     public var disposeBag: RxSwift.DisposeBag = DisposeBag()
     
     // MARK: - Intializer
@@ -31,7 +29,7 @@ open class ReactorViewController<R>: UIViewController, ReactorKit.View where R: 
     
     public convenience init(reactor: Reactor? = nil) {
         self.init()
-        self.initialReactor = reactor
+        self.reactor = reactor
     }
     
     required public init?(coder: NSCoder) {
@@ -45,7 +43,6 @@ open class ReactorViewController<R>: UIViewController, ReactorKit.View where R: 
         setupUI()
         setupAutoLayout()
         setupAttributes()
-        setupReactor()
     }
     
     // MARK: - Helpers
@@ -60,7 +57,4 @@ open class ReactorViewController<R>: UIViewController, ReactorKit.View where R: 
         view.backgroundColor = .bibbiBlack
     }
     
-    open func setupReactor() {
-        self.reactor = initialReactor
-    }
 }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ProfileGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ProfileGlobalState.swift
@@ -11,7 +11,6 @@ import RxSwift
 
 public enum ProfileEvent {
     case refreshFamilyMembers
-    case fetchMemberId(String)
 }
 
 public protocol ProfileGlobalStateType {
@@ -19,8 +18,6 @@ public protocol ProfileGlobalStateType {
     
     @discardableResult
     func refreshFamilyMembers() -> Observable<Void>
-    @discardableResult
-    func fetchMemberdId(memberId: String) -> Observable<String>
 }
 
 final public class ProfileGlobalState: BaseService, ProfileGlobalStateType {
@@ -29,11 +26,6 @@ final public class ProfileGlobalState: BaseService, ProfileGlobalStateType {
     public func refreshFamilyMembers() -> Observable<Void> {
         event.onNext(.refreshFamilyMembers)
         return Observable<Void>.just(())
-    }
-    
-    public func fetchMemberdId(memberId: String) -> Observable<String> {
-        event.onNext(.fetchMemberId(memberId))
-        return Observable<String>.just(memberId)
     }
 }
 


### PR DESCRIPTION
## 🔵PR을 올리기 전 아래 사항을 확인해주세요.
- 구현한 로직과 기능이 올바르게 작동되는지 충분히 테스트해주세요.
- 코드의 성능이나 메모리 효율성이 적절하게 고려되었는지, 불필요한 코드가 없는지 검토해주세요.
- 이번 PR에서 구현된 주요 기능이나 해결된 문제에 대해 자세히 서술해주세요.
(위 내용은 지워주세요)



## 😽개요

* 프로필 화면 `프로필 이미지 초기화` 반영(수정)
* `BaseViewController` `reactor` 초기화 시점 변경
* 카메라 화면 플래시 버튼 기능 수정

## 🛠️작업 내용

### BaseViewController `reactor`초기화 시점 변경
- `BaseViewController`에서 reactor 초기화 시점을 `init`으로 변경했습니다. `ProfileFeedViewController` 같은 경우 `ProfileViewReactor`에 있는 `memberId`를 주입받아서 Action으로 처리하고 있기 때문에 초기화 시점이 중요합니다. 때문에 `setupAttributes` 보다 늦게 주입을 하게 된다면 `memberId`가 nil 값으로 반영이 되기 때문에 `ProfileFeedViewController`에서 미션 피드 API를 호출하지 못하기 때문에 변경하였습니다.

```swift
    public convenience init(reactor: Reactor? = nil) {
        self.init()
        self.reactor = reactor
    }
```



## 🟡 BsaeViewController init 시점 논의

* BaseViewController `init` 시점을 논의해서 변경
* `ProfileFeedViewController`를 globalState를 사용해서 `meberId`를 조회하는 방법도 있습니다. 다만 `FeedType`에 따라서 memberId를 지속적으로 조회해야 하기 때문에 다른 방안을 고민해 봐야 할 것 같습니다.


## ✅테스트 케이스
* 프로필 미션 피드, 서바이벌 피드를 조회하는지 확인해요
* 카메라에서 플래시 기능이 잘 동작하는지 확인해요
* 프로필 초기화 버튼 클릭 시 프로필 이미지 삭제 API 호출하는지 확인해요


