### PR TITLE
fix: Pick 액션 후 Toast가 출력되지 않는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
@@ -47,7 +47,7 @@ final public class CommentViewReactor: Reactor {
     // MARK: - State
     
     public struct State {
-        @Pulse var commentDatasource: [CommentSectionModel] = [.init(model: "", items: [])]
+        @Pulse var commentDatasource: [CommentSectionModel] = []
     
         var hiddenTableProgressHud: Bool = false
         var hiddenFetchFailureView: Bool = true
@@ -233,7 +233,7 @@ final public class CommentViewReactor: Reactor {
         
         switch mutation {
         case let .setComments(comments):
-            let dataSource: CommentSectionModel = .init(model: "", items: comments)
+            let dataSource = CommentSectionModel(model: "", items: comments)
             newState.commentDatasource = [dataSource]
             
         case let .appendComment(comment):

--- a/14th-team5-iOS/App/Sources/Presentation/Comment/ViewController/CommentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Comment/ViewController/CommentViewController.swift
@@ -65,6 +65,7 @@ final public class CommentViewController: ReactorViewController<CommentViewReact
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
         
+        // TODO: - 코드 리팩토링하기
         commentTableView.rx.itemDeleted
             .withUnretained(self)
             .bind { $0.0.reactor?.action.onNext(.deleteComment($0.0.dataSource[$0.1].currentState.comment.commentId)) }
@@ -187,12 +188,6 @@ final public class CommentViewController: ReactorViewController<CommentViewReact
     
     public override func setupAttributes() {
         super.setupAttributes()
-        // TODO: - App.Repository 제거하기
-        dataSource.canEditRowAtIndexPath = {
-            let myMemberId = App.Repository.member.memberID.value
-            let commentMemberId = $0[$1].currentState.comment.memberId
-            return myMemberId == commentMemberId
-        }
     }
 }
 
@@ -214,13 +209,21 @@ extension CommentViewController {
     }
     
     private func prepareDatasource() -> RxDataSource {
-        return RxDataSource { dataSource, tableView, indexPath, reactor in
+        let dataSource = RxDataSource { dataSource, tableView, indexPath, reactor in
             let cell = tableView.dequeueReusableCell(
                 withIdentifier: CommentCell.id
             ) as! CommentCell
             cell.reactor = reactor
             return cell
         }
+        
+        dataSource.canEditRowAtIndexPath = {
+            let myMemberId = App.Repository.member.memberID.value
+            let commentMemberId = $0[$1].currentState.comment.memberId
+            return myMemberId == commentMemberId
+        }
+        
+        return  dataSource
     }
     
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/Cell/MainFamilyCellReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/Cell/MainFamilyCellReactor.swift
@@ -7,7 +7,7 @@
 
 
 import Core
-import Foundation
+import UIKit
 import DesignSystem
 import Domain
 
@@ -127,11 +127,20 @@ final class MainFamilyCellReactor: Reactor {
                 switch $0.1 {
                 case .pick:
                     return $0.0.pickMemberUseCase.execute(memberId: memberId)
+                        .withUnretained(self)
                         .flatMap {
                             guard
-                                let entity = $0, entity.success
-                            else { return Observable<Mutation>.empty() }
+                                let entity = $0.1, entity.success
+                            else {
+                                $0.0.provider.bbToastService.show(.error)
+                                return Observable<Mutation>.empty()
+                            }
                             
+                            $0.0.provider.bbToastService.show(
+                                image: DesignSystemAsset.yellowPaperPlane.image,
+                                imageTint: UIColor.mainYellow,
+                                title: "\(memberName)님에게 생존신고 알림을 보냈어요"
+                            )
                             return Observable<Mutation>.just(.setHiddenPickButton(true))
                         }
                     

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/BBToastConfiguration.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/BBToastConfiguration.swift
@@ -56,7 +56,7 @@ public struct BBToastConfiguration {
     public init(
         direction: BBToast.Direction = .bottom(yOffset: 0),
         dismissables: [BBToast.Dismissable] = [.time(time: 2.5), .swipe(direction: .natural)],
-        animationTime: TimeInterval = 0.6,
+        animationTime: TimeInterval = 0.8,
         enteringAnimation: BBToast.Animation = .default,
         exitingAnimation: BBToast.Animation = .default,
         attachTo view: UIView? = nil,
@@ -84,12 +84,12 @@ private extension BBToastConfiguration {
         switch direction {
         case let .top(yOffset):
             return .custom(
-                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -yOffset - 100)
+                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -yOffset - 300)
             )
             
         case let .bottom(yOffset):
             return .custom(
-                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: +yOffset + 100)
+                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -yOffset + 300)
             )
 
         case .center:

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/BBToastDirection.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/BBToastDirection.swift
@@ -11,15 +11,35 @@ extension BBToast {
     
     /// Toast가 나타나는 방향을 정의합니다.
     public enum Direction {
+        
+        /// Toast가 위에서 아래로 나타나게 합니다.
+        ///
+        /// yOffset 연관값은 Toast가 화면 상단으로부터 얼마나 멀리 떨어져 있는지 의미합니다. 예를 들어, 400값을 준다면 상단으로부터 400만큼 떨어져서 Toast가 내려옵니다.
+        ///
+        /// 애니메이션 속도가 너무 빠르다면 애니메이션 시간을 조정하세요.
         case top(yOffset: CGFloat = 0)
+        
+        /// Toast가 아래에서 위로 나타나게 합니다.
+        ///
+        /// yOffset 연관값은 Toast가 화면 하단으로부터 얼마나 멀리 떨어져 있는지 의미합니다. 예를 들어, -400값을 준다면 하단으로부터 -400만큼 떨어져서 Toast가 올라옵니다.
+        ///
+        /// 애니메이션 속도가 너무 빠르다면 애니메이션 시간을 조정하세요.
         case bottom(yOffset: CGFloat = 0)
+        
+        /// Toast가 중앙에 나타나게 합니다.
         case center(xOffset: CGFloat = 0, yOffset: CGFloat = 0)
     }
     
     /// Toast가 어느 방향으로 스와이프하면 사라지는지 정의합니다.
     public enum DismissSwipeDirection: Equatable {
+        
+        /// 위로 스와이프해야 Toast가 사라지게 합니다.
         case toTop
+        
+        /// 아래로 스와이프해야 Toast가 사라지게 합니다.
         case toBottom
+        
+        /// Toast가 나타나는 방향에 따라 스와이프 방향을 자동으로 설정하게 합니다.
         case natural
         
         func shouldApply(_ delta: CGFloat, direction: Direction) -> Bool {

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/ToastViews/DefaultToastView/ButtonToastView.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/ToastViews/DefaultToastView/ButtonToastView.swift
@@ -73,7 +73,7 @@ final public class ButtonToastView: UIStackView, BBToastStackView {
     
     private func commonInit() {
         axis = .horizontal
-        spacing = 0
+        spacing = 5
         alignment = .center
         distribution = .fillProportionally
     }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/ToastViews/DefaultToastView/DefaultToastView.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/ToastViews/DefaultToastView/DefaultToastView.swift
@@ -93,8 +93,8 @@ public class DefaultToastView: UIView, BBToastView {
         child.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            child.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15),
-            child.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -15),
+            child.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 20),
+            child.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
             child.topAnchor.constraint(equalTo: self.topAnchor, constant: 15),
             child.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -15)
         ])

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/ToastViews/DefaultToastView/IconToastView.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/ToastViews/DefaultToastView/IconToastView.swift
@@ -56,7 +56,7 @@ public class IconToastView: UIStackView, BBToastStackView {
     
     private func commonInit() {
         axis = .horizontal
-        spacing = 10
+        spacing = 5
         alignment = .center
         distribution = .fillProportionally
     }


### PR DESCRIPTION
## 😽개요

* BBToast 기본 설정값 변경
* BBToastDirection의 yOffset값이 제대로 적용되지 않는 문제 수정

* `Pick` 액션 후 BBToast가 출력되지 않는 문제 수정 (픽 성공, 픽 실패)
<br>

* 댓글 화면에서 RxDatasource 바인딩 에러가 일어나는 문제 수정

## 🛠️작업 내용

### BBToast 기본 설정값 변경

* BBToast의 기본 EdgeInset 값 수정 (leading 20, trailing 20으로)
* BBToastConfiguration에서 기본 애니메이션 시간을 0.8초로 수정

### BBToastDirection의 yOffset값이 제대로 적용되지 않는 문제 수정

* BBToastConfiguration에서 BBDirection에 따라 적용되는 Default Animation 값 수식 수정

### 픽 액션 후 BBToast 출력되지 않는 문제 수정

| 이미지① |
| :----: |
| ![Simulator Screen Recording - iPhone 16 Pro - 2024-09-26 at 17 56 12](https://github.com/user-attachments/assets/5ab52e7b-251f-425c-a914-6d35a9389c71) |

## ✅테스트 케이스

* 픽을 하면 픽 성공 토스트가 제대로 뜨는지
* 픽 실패하면 에러 토스트가 제대로 뜨는지

* 토스트가 아래에서 위로(bottom), 위에서 아래로(top) 제대로 뜨는지

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close #650 