### PR TITLE
feat: 카메라 화면 BBToast 기능 추가

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/DIContainer/NavigatorDIContainer.swift
+++ b/14th-team5-iOS/App/Sources/Application/DIContainer/NavigatorDIContainer.swift
@@ -77,6 +77,12 @@ final class NavigatorDIContainer: BaseContainer {
             )
         }
         
+        container.register(type: CameraDisplayNavigatorProtocol.self) { _ in
+            CameraDisplayNavigator(
+                navigationController: makeUINavigationController()
+            )
+        }
+        
         container.register(type: ManagementNavigatorProtocol.self) { _ in
             ManagementNavigator(
                 navigationController: makeUINavigationController()

--- a/14th-team5-iOS/App/Sources/Application/Navigator/CameraDisplayNavigator.swift
+++ b/14th-team5-iOS/App/Sources/Application/Navigator/CameraDisplayNavigator.swift
@@ -1,0 +1,69 @@
+//
+//  CameraDisplayNavigator.swift
+//  App
+//
+//  Created by Kim dohyun on 9/26/24.
+//
+
+import Core
+import DesignSystem
+import UIKit
+
+protocol CameraDisplayNavigatorProtocol: BaseNavigator {
+    func toHome()
+    func showToast()
+    func showArchiveToast()
+    func showWarningToast()
+}
+
+final class CameraDisplayNavigator: CameraDisplayNavigatorProtocol {
+    
+    //MARK: - Properties
+    var navigationController: UINavigationController
+    
+    
+    //MARK: - Intializer
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    //MARK: - Configure
+    func toHome() {
+        let vc = MainViewControllerWrapper().viewController
+        navigationController.setViewControllers([vc], animated: true)
+    }
+    
+    func showToast() {
+        let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
+        let viewConfig = BBToastViewConfiguration(minWidth: 207)
+        BBToast.default(
+            image: DesignSystemAsset.warning.image,
+            title: "8자까지 입력 가능해요",
+            viewConfig: viewConfig,
+            config: config
+        ).show()
+    }
+    
+    func showArchiveToast() {
+        let config = BBToastConfiguration(direction: .bottom(yOffset: 75))
+        let viewConfig = BBToastViewConfiguration(minWidth: 194)
+        BBToast.default(
+            image: DesignSystemAsset.camera.image.withTintColor(DesignSystemAsset.gray300.color),
+            title: "사진이 저장되었습니다.",
+            viewConfig: viewConfig,
+            config: config
+        ).show()
+    }
+    
+    func showWarningToast() {
+        let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
+        let viewConfig = BBToastViewConfiguration(minWidth: 207)
+        BBToast.default(
+            image: DesignSystemAsset.warning.image,
+            title: "띄어쓰기는 할 수 없어요",
+            viewConfig: viewConfig,
+            config: config
+        ).show()
+        
+    }
+}

--- a/14th-team5-iOS/App/Sources/Application/Navigator/CameraDisplayNavigator.swift
+++ b/14th-team5-iOS/App/Sources/Application/Navigator/CameraDisplayNavigator.swift
@@ -11,9 +11,6 @@ import UIKit
 
 protocol CameraDisplayNavigatorProtocol: BaseNavigator {
     func toHome()
-    func showToast()
-    func showArchiveToast()
-    func showWarningToast()
 }
 
 final class CameraDisplayNavigator: CameraDisplayNavigatorProtocol {
@@ -31,39 +28,5 @@ final class CameraDisplayNavigator: CameraDisplayNavigatorProtocol {
     func toHome() {
         let vc = MainViewControllerWrapper().viewController
         navigationController.setViewControllers([vc], animated: true)
-    }
-    
-    func showToast() {
-        let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
-        let viewConfig = BBToastViewConfiguration(minWidth: 207)
-        BBToast.default(
-            image: DesignSystemAsset.warning.image,
-            title: "8자까지 입력 가능해요",
-            viewConfig: viewConfig,
-            config: config
-        ).show()
-    }
-    
-    func showArchiveToast() {
-        let config = BBToastConfiguration(direction: .bottom(yOffset: 75))
-        let viewConfig = BBToastViewConfiguration(minWidth: 194)
-        BBToast.default(
-            image: DesignSystemAsset.camera.image.withTintColor(DesignSystemAsset.gray300.color),
-            title: "사진이 저장되었습니다.",
-            viewConfig: viewConfig,
-            config: config
-        ).show()
-    }
-    
-    func showWarningToast() {
-        let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
-        let viewConfig = BBToastViewConfiguration(minWidth: 207)
-        BBToast.default(
-            image: DesignSystemAsset.warning.image,
-            title: "띄어쓰기는 할 수 없어요",
-            viewConfig: viewConfig,
-            config: config
-        ).show()
-        
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraDisplayViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraDisplayViewReactor.swift
@@ -9,6 +9,7 @@ import Foundation
 
 import Data
 import Domain
+import DesignSystem
 import ReactorKit
 import Core
 
@@ -140,7 +141,14 @@ public final class CameraDisplayViewReactor: Reactor {
                     }
             )
         case .didTapArchiveButton:
-            cameraDisplayNavigator.showArchiveToast()
+            let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
+            let viewConfig = BBToastViewConfiguration(minWidth: 207)
+            provider.bbToastService.show(
+                image:DesignSystemAsset.camera.image.withTintColor(DesignSystemAsset.gray300.color),
+                title: "사진이 저장되었습니다.",
+                viewConfig: viewConfig,
+                config: config
+                )
             return .concat(
                 .just(.setLoading(false)),
                 .just(.saveDeviceimage(currentState.displayData)),
@@ -186,11 +194,25 @@ public final class CameraDisplayViewReactor: Reactor {
                 .just(.setDisplayEditSection([]))
             )
         case .showInputTextError:
-            cameraDisplayNavigator.showToast()
+            let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
+            let viewConfig = BBToastViewConfiguration(minWidth: 207)
+            provider.bbToastService.show(
+                image: DesignSystemAsset.warning.image,
+                title: "8자까지 입력 가능해요",
+                viewConfig: viewConfig,
+                config: config
+            )
             return .empty()
             
         case let .showInputBlankTextError(displayText):
-            cameraDisplayNavigator.showWarningToast()
+            let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
+            let viewConfig = BBToastViewConfiguration(minWidth: 207)
+            provider.bbToastService.show(
+                image: DesignSystemAsset.warning.image,
+                title: "띄어쓰기는 할 수 없어요",
+                viewConfig: viewConfig,
+                config: config
+            )
             let generateText = displayText.trimmingCharacters(in: .whitespaces)
             return .just(.setTrimedText(generateText))
         }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/BBToastConfiguration.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBToast/BBToastConfiguration.swift
@@ -84,12 +84,12 @@ private extension BBToastConfiguration {
         switch direction {
         case let .top(yOffset):
             return .custom(
-                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -yOffset - 100)
+                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -yOffset - 300)
             )
             
         case let .bottom(yOffset):
             return .custom(
-                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: +yOffset + 100)
+                transformation: CGAffineTransform(scaleX: 0.9, y: 0.9).translatedBy(x: 0, y: -yOffset + 300)
             )
 
         case .center:


### PR DESCRIPTION

## 😽개요

* `CameraDisplayViewController` 내부에 `BBToast` 띄우는 로직을 추가했습니다.

## 🛠️작업 내용
### `CameraDisplayNavigatorProtocol` 추가
- `CameraDisplayViewController`에  BBToast 띄우는 메서드 및 화면전환 메서드를 정의했습니다.

```swift
protocol CameraDisplayNavigatorProtocol: BaseNavigator {
    func toHome()
    func showToast()
    func showArchiveToast()
    func showWarningToast()
}
```
### CameraDisplayViewController 공백 팝업 안 띄워지는 이슈
- CameraDisplayViewController에서 공백 입력 시 팝업이 띄워져야 하는데 `trimmingCharacters`로 인해 공백을 제거하고 있어서 공백 팝업을 띄우지 못하는 이슈가 발생하였습니다.
- 위와 같은 이슈사항을 해결하기 위해 별도 Reactor를 통해 `Action`에서 입력받은 `Text`를 `trimmingCharacters` 를 통해 공백을 제거하고 `Textfield` 바인딩 하도록 하였고 해당 Action을 방출
```swift
        case let .showInputBlankTextError(displayText):
            cameraDisplayNavigator.showWarningToast()
            let generateText = displayText.trimmingCharacters(in: .whitespaces)
            return .just(.setTrimedText(generateText))
```





## ✅테스트 케이스

* 게시글 문구 입력 시 글자 수 제한 팝업 띄우는지 확인해요
* 게시글 문구 입력 시 공백 입력할 경우 팝업 띄우는지 확인해요
* 이미지 업로드 시 홈 화면으로 이동하는지 확인해요

---


