### PR TITLE
fix: 로그인 시 메인화면 진입 못하는 이슈 수정해요

### DIFF
--- a/14th-team5-iOS/App/Sources/Application/Navigator/AccountSignInNavigator.swift
+++ b/14th-team5-iOS/App/Sources/Application/Navigator/AccountSignInNavigator.swift
@@ -13,6 +13,7 @@ protocol AccountSignInNavigatorProtocol: BaseNavigator {
     func toMain()
     func toSignUp()
     func toJoinFamily()
+    func toOnboarding()
 }
 
 final class AccountSignInNavigator: AccountSignInNavigatorProtocol {
@@ -35,6 +36,11 @@ final class AccountSignInNavigator: AccountSignInNavigatorProtocol {
     
     func toJoinFamily() {
         let vc = JoinFamilyViewControllerWrapper().viewController
+        navigationController.setViewControllers([vc], animated: false)
+    }
+    
+    func toOnboarding() {
+        let vc = OnboardingViewControllerWrapper().viewController
         navigationController.setViewControllers([vc], animated: false)
     }
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInReactor.swift
@@ -17,7 +17,9 @@ public final class AccountSignInReactor: Reactor {
     public var initialState: State
     @Injected var fetchIsFirstOnboardingUseCase: any FetchIsFirstOnboardingUseCaseProtocol
     private var accountRepository: AccountImpl = AccountRepository()
+    private let meUseCase: MeUseCaseProtocol = MeUseCase(meRepository: MeAPIs.Worker())
     private let fcmUseCase: FCMUseCaseProtocol = FCMUseCase(FCMRepository: MeAPIs.Worker())
+    @Navigator var signInNavigator: AccountSignInNavigatorProtocol
     private let disposeBag = DisposeBag()
     
     public enum Action {
@@ -26,14 +28,10 @@ public final class AccountSignInReactor: Reactor {
     }
     
     public enum Mutation {
-        case kakaoLogin(Bool)
-        case appleLogin(Bool)
         case setIsFirstOnboarding(Bool)
-        
     }
     
     public struct State {
-        var pushAccountSingUpVC: Bool
         @Pulse var isFirstOnboarding: Bool
     }
     
@@ -41,7 +39,6 @@ public final class AccountSignInReactor: Reactor {
 //        self.accountRepository = accountRepository
 //        self.fcmUseCase = fcmUseCase
         self.initialState = State(
-            pushAccountSingUpVC: false,
             isFirstOnboarding: false
         )
     }
@@ -49,36 +46,31 @@ public final class AccountSignInReactor: Reactor {
 
 extension AccountSignInReactor {
     public func mutate(action: Action) -> Observable<Mutation> {
-        let isFirstOnboarding = self.fetchIsFirstOnboardingUseCase.execute() == nil ? false : true
         switch action {
         case .kakaoLoginTapped(let sns, let vc):
             return accountRepository.kakaoLogin(with: sns, vc: vc)
-                .flatMap { result -> Observable<Mutation> in
+                .withUnretained(self)
+                .flatMap { owner, result -> Observable<Mutation> in
                     switch result {
                     case .success:
-                        self.saveFCM()
-                        return .concat(
-                            .just(.kakaoLogin(true)),
-                            .just(.setIsFirstOnboarding(isFirstOnboarding))
-                        )
+                        owner.saveFCM()
+                        return owner.transitionViewController()
                     case .failed:
-                        return .just(.kakaoLogin(false))
+                        return .empty()
                     }
                 }
             
             
         case .appleLoginTapped(let sns, let vc):
             return accountRepository.appleLogin(with: sns, vc: vc)
-                .flatMap { result -> Observable<Mutation> in
+                .withUnretained(self)
+                .flatMap { owner, result -> Observable<Mutation> in
                     switch result {
                     case .success:
                         self.saveFCM()
-                        return .concat(
-                            .just(.appleLogin(true)),
-                            .just(.setIsFirstOnboarding(isFirstOnboarding))
-                        )
+                        return owner.transitionViewController()
                     case .failed:
-                        return .just(.appleLogin(false))
+                        return .empty()
                     }
                 }
         }
@@ -87,10 +79,6 @@ extension AccountSignInReactor {
     public func reduce(state: State, mutation: Mutation) -> State {
         var newState = state
         switch mutation {
-        case .kakaoLogin(let result):
-            newState.pushAccountSingUpVC = result
-        case .appleLogin(let result):
-            newState.pushAccountSingUpVC = result
         case let .setIsFirstOnboarding(isFirstOnboarding):
             newState.isFirstOnboarding = isFirstOnboarding
         }
@@ -111,4 +99,53 @@ extension AccountSignInReactor {
           }
         }
     }
+}
+
+
+extension AccountSignInReactor {
+    private func transitionViewController() -> Observable<Mutation> {
+        let isFirstOnboarding = self.fetchIsFirstOnboardingUseCase.execute() == nil ? false : true
+        return App.Repository.token.accessToken
+            .skip(1)
+            .withUnretained(self)
+            .flatMapLatest { owner, token -> Observable<Mutation> in
+                print("token : \(token) or fisrtOnboarding: \(isFirstOnboarding)")
+                
+                guard let token,
+                      let isTemporaryToken = token.isTemporaryToken else {
+                    return .empty()
+                }
+                
+                if isTemporaryToken {
+                    owner.signInNavigator.toSignUp()
+                    return .empty()
+                }
+            
+                
+                return owner.meUseCase.getMemberInfo()
+                    .asObservable()
+                    .flatMap { memberInfo -> Observable<Mutation> in
+                        
+                        // 사용자가 AccessToken 값은
+                        // 기존 사용자가 회원 탈퇴를 하지 않은 상태에서 앱을 삭제 (App.Repostiroy x, isFirstOnboaring, false)
+                        // isTemporaryToken(true) 임시 계정
+                        
+                        if isTemporaryToken == false || isFirstOnboarding == false {
+                            print("go to Onboarding")
+                            owner.signInNavigator.toOnboarding()
+                            return .empty()
+                        }
+                        
+                        if memberInfo?.familyId == nil || isFirstOnboarding {
+                            print("go to JoinFamily ")
+                            owner.signInNavigator.toJoinFamily()
+                            return .empty()
+                        }
+                        
+                        owner.signInNavigator.toMain()
+                        return .empty()
+                    }
+            }
+    }
+    
 }

--- a/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Account/AccountSignIn/AccountSignInViewController.swift
@@ -119,39 +119,6 @@ public final class AccountSignInViewController: BaseViewController<AccountSignIn
             .map { Reactor.Action.appleLoginTapped(.apple, self) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
-        
-        
-        Observable
-            .combineLatest(
-                App.Repository.token.accessToken.distinctUntilChanged(),
-                reactor.pulse(\.$isFirstOnboarding).distinctUntilChanged()
-            )
-            .skip(1)
-            .observe(on: RxScheduler.main)
-            .bind(with: self) { owner, response in
-                let (token, isFirstOnboarding) = response
-                owner.showNextPage(token: token, isFirstOnboarding)
-            }
-            .disposed(by: disposeBag)
     }
 }
 
-extension AccountSignInViewController {
-    private func showNextPage(token: AccessToken?, _ isFirstOnboarding: Bool) {
-        @Navigator var signInNavigator: AccountSignInNavigatorProtocol
-        guard let token = token, let isTemporaryToken = token.isTemporaryToken else { return }
-        if isTemporaryToken {
-            signInNavigator.toSignUp()
-            return
-        }
-        
-        if isFirstOnboarding || isTemporaryToken == false {
-            if App.Repository.member.familyId.value == nil {
-                signInNavigator.toJoinFamily()
-                return
-            }
-            signInNavigator.toMain()
-            return
-        }
-    }
-}

--- a/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/MainViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Home/Reactor/MainViewReactor.swift
@@ -98,7 +98,6 @@ final class MainViewReactor: Reactor {
     @Injected var fetchMainUseCase: FetchMainUseCaseProtocol
     @Injected var fetchMainNightUseCase: FetchNightMainViewUseCaseProtocol
     @Injected var pickUseCase: PickUseCaseProtocol
-    @Injected var updateIsFirstOnboardingUseCase: any UpdateIsFirstOnboardingUseCaseProtocol
     @Injected var checkMissionAlertShowUseCase: CheckMissionAlertShowUseCaseProtocol
     @Injected var checkFamilyManagementUseCase: FetchIsFirstFamilyManagementUseCaseProtocol
     @Injected var saveFamilyManagementUseCase: UpdateFamilyManagementUseCaseProtocol
@@ -170,7 +169,6 @@ extension MainViewReactor {
             }
         case .calculateTime:
             let (isInTime, time) = self.calculateRemainingTime()
-            self.updateIsFirstOnboardingUseCase.execute(true)
             if isInTime {
                 return Observable.concat([
                     .just(.setInTime(true)),

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingReactor.swift
@@ -18,6 +18,7 @@ public final class OnBoardingReactor: Reactor {
     
     public var initialState: State = State()
     @Injected var familyUseCase: FamilyUseCaseProtocol
+    @Injected var updateIsFirstOnboardingUseCase: any UpdateIsFirstOnboardingUseCaseProtocol
     
     public enum Action {
         case permissionTapped
@@ -40,6 +41,7 @@ extension OnBoardingReactor {
     public func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .permissionTapped:
+            self.updateIsFirstOnboardingUseCase.execute(true)
             return Observable.zip(
                 Observable.create { observer in
                     MPEvent.Account.invitedGroupFinished.track(with: nil)

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
@@ -145,6 +145,7 @@ final public class OnBoardingViewController: BaseViewController<OnBoardingReacto
         @Navigator var onboardingNavigator: OnboardingNavigatorProtocol
         
         if App.Repository.member.familyId.value == nil {
+            print("Onboarding ViewController to Join Family")
             onboardingNavigator.toJoinFamily()
         } else {
             if let _ = UserDefaults.standard.inviteCode {

--- a/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/OnBoarding/OnBoardingViewController.swift
@@ -145,7 +145,6 @@ final public class OnBoardingViewController: BaseViewController<OnBoardingReacto
         @Navigator var onboardingNavigator: OnboardingNavigatorProtocol
         
         if App.Repository.member.familyId.value == nil {
-            print("Onboarding ViewController to Join Family")
             onboardingNavigator.toJoinFamily()
         } else {
             if let _ = UserDefaults.standard.inviteCode {

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/Reactor/AccountResignViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/Reactor/AccountResignViewReactor.swift
@@ -61,7 +61,7 @@ final class AccountResignViewReactor: Reactor {
                 .withUnretained(self)
                 .flatMap { owner, entity -> Observable<Mutation> in
                     if entity.isSuccess {
-                        owner.updateIsFirstOnboardingUseCase.execute(nil)
+                        owner.updateIsFirstOnboardingUseCase.execute(false)
                         return .concat(
                             .just(.setLoading(true)),
                             .just(.setResignEntity(entity.isSuccess)),

--- a/14th-team5-iOS/Data/Sources/APIs/My/Repository/MyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/My/Repository/MyRepository.swift
@@ -46,7 +46,7 @@ extension MyRepository {
     }
     
     public func updateIsFirstOnboarding(_ isFirstOnboarding: Bool?) {
-        appUserDefaults.saveIsFirstOnboarding(isFirstOnboarding)
+        return appUserDefaults.saveIsFirstOnboarding(isFirstOnboarding)
     }
     
 }

--- a/14th-team5-iOS/Data/Sources/Storages/UserDefaults/AppUserDefaults/AppUserDefaults.swift
+++ b/14th-team5-iOS/Data/Sources/Storages/UserDefaults/AppUserDefaults/AppUserDefaults.swift
@@ -98,10 +98,7 @@ final public class AppUserDefaults: AppUserDefaultsType {
     }
     
     public func loadIsFirstOnboarding() -> Bool? {
-        guard let isFirstOnboarding: Bool = userDefaults[.isFirstOnboarding] else {
-            return nil
-        }
-        return isFirstOnboarding
+        return userDefaults[.isFirstOnboarding]
     }
     
     // MARK: - FamilyManagement

--- a/14th-team5-iOS/Domain/Sources/UseCases/My/FetchIsFirstOnboardingUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/My/FetchIsFirstOnboardingUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 public protocol FetchIsFirstOnboardingUseCaseProtocol {
-    func execute() -> Bool?
+    func execute() -> Bool
 }
 
 
@@ -21,7 +21,10 @@ public final class FetchIsFirstOnboardingUseCase: FetchIsFirstOnboardingUseCaseP
         self.myRepository = myRepository
     }
     
-    public func execute() -> Bool? {
-        return myRepository.fetchIsFirstOnboarding()
+    public func execute() -> Bool {
+        guard let isFirstOnboarding = myRepository.fetchIsFirstOnboarding() else {
+            return false
+        }
+        return isFirstOnboarding
     }
 }

--- a/14th-team5-iOS/Domain/Sources/UseCases/My/UpdateIsFirstOnboardingUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/My/UpdateIsFirstOnboardingUseCase.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 public protocol UpdateIsFirstOnboardingUseCaseProtocol {
-    func execute(_ isFirstOnboarding: Bool?)
+    func execute(_ isFirstOnboarding: Bool)
 }
 
 public final class UpdateIsFirstOnboardingUseCase: UpdateIsFirstOnboardingUseCaseProtocol {
@@ -20,7 +20,7 @@ public final class UpdateIsFirstOnboardingUseCase: UpdateIsFirstOnboardingUseCas
         self.myRepository = myRepository
     }
     
-    public func execute(_ isFirstOnboarding: Bool?) {
+    public func execute(_ isFirstOnboarding: Bool) {
         myRepository.updateIsFirstOnboarding(isFirstOnboarding)
     }
 }


### PR DESCRIPTION
## 😽개요
* `AccountSignInViewReactor`에 회원 정보 API 호출 코드 및 화면 전환 로직을 수정해요

## 🛠️작업 내용
#### AccountSignInViewReactor에 `Member-info` API 호출하여 해당 계정에 FamilyId를 조회하여 화면 전환 로직을 수정했습니다.

### 화면 전환 로직

| AS-IS | TO-BE|
| :----: |:----: |
|<img src="https://github.com/user-attachments/assets/2e4e4e39-61ab-4fa2-be80-164d61366dda" width="700"/> |    <img src="https://github.com/user-attachments/assets/4757f2ac-e1c1-4b37-bf04-6376eec8f972" width="700"/>     |

### (소제목)

* `App.Repository.AccessToken`을 구독하여`Member-Info` API를 호출하도록 하였습니다.
* `App.Repository`를 구독한 이유는 초기 사용자 같은 경우 `AccessToken` 회원가입하지 않는 이상 `AccessToken` 값이 없기 때문에 구독 한 이후 Token 값을 여부를 판단하여 화면전환을 하기 위해서입니다.


## 🟡차후 계획 
* `App.Repository`같은 경우 `BehaviorRelay`로 정의되어 있기 때문에 해당 Repository에 accept가 될 경우 여러 번 이벤트가 방출됩니다. 예시) 회원 탈퇴 -> `App.Repository.token.accessToken.accept(nil)` -> 회원 가입 ->`App.Repository.token.accessToken.accept(token)` -> 총 2번 이벤트를 방출하게 됨
* 추후 회원가입 플로우를 `App.Repository.token.accessToken`에서 구독하는 것이 아닌 `UseCase`를 활용해서 리팩토링 해야 할 것 같습니다.

## ✅테스트 케이스

* 회원 탈퇴 시 온 보딩 화면을 보여주는 확인해요
* 초기 회원가입 시 온 보딩 화면을 보여주는지 확인해요
* 기존 사용자일 경우 홈 화면으로 넘어가는지 확인해요(Familyid 있을 경우)
* FamilyId가 없는 사용자인 경우 가족방 생성 화면으로 넘어가는지 확인해요

---

issue:  #662 