### PR TITLE
feat: 가족 정보를 유저디펄트에 저장해요

### DIFF
--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBButton/BBButton.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBButton/BBButton.swift
@@ -107,6 +107,7 @@ public class BBButton: UIButton {
         self.id = id
     }
     
+    /// 버튼의 이미지를 변경합니다.
     public func setImage(_ image: UIImage?) {
         mainImageView.image = image
     }

--- a/14th-team5-iOS/Data/Sources/APIs/Family/Repository/FamilyRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/Family/Repository/FamilyRepository.swift
@@ -129,20 +129,27 @@ extension FamilyRepository {
         return familyApiWorker.fetchPaginationFamilyMember(query: query)
             .map { $0?.toDomain() }
             .do(onSuccess: { [weak self] in
-                guard let self else { return }
-                
-                if let profiles = $0?.results {
-                    self.familyUserDefaults.saveFamilyMembers(profiles)
+                guard let self,
+                      let profiles = $0?.results else {
+                    return
                 }
+                
+                self.familyUserDefaults.saveFamilyMembers(profiles)
             })
             .asObservable()
     }
     
     public func fetchAllFamilyMembers() -> Observable<[FamilyMemberProfileEntity]?> {
         return familyApiWorker.fetchPaginationFamilyMember(query: .init())
-            .map { response in
-                return response?.results.map { $0.toDomain() }
-            }
+            .map { $0?.results.map{ $0.toDomain() }}
+            .do(onSuccess: { [weak self] in
+                guard let self,
+                      let profiles = $0 else {
+                    return
+                }
+                
+                self.familyUserDefaults.saveFamilyMembers(profiles)
+            })
             .asObservable()
     }
     

--- a/14th-team5-iOS/Data/Sources/APIs/MainView/MainViewAPI/MainViewAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/MainView/MainViewAPI/MainViewAPIWorker.swift
@@ -39,23 +39,21 @@ extension MainViewAPIs {
 }
 
 extension MainAPIWorker {
-    func fetchMain() -> Single<MainViewEntity?> {
+    func fetchMain() -> Single<MainResponseDTO?> {
         let spec = MainViewAPIs.fetchMain.spec
         return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)
             .map(MainResponseDTO.self)
             .catchAndReturn(nil)
-            .map { $0?.toDomain() }
             .asSingle()
     }
     
-    func fetchMainNight() -> Single<NightMainViewEntity?> {
+    func fetchMainNight() -> Single<MainNightResponseDTO?> {
         let spec = MainViewAPIs.fetchMainNight.spec
         return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)
             .map(MainNightResponseDTO.self)
             .catchAndReturn(nil)
-            .map { $0?.toDomain() }
             .asSingle()
     }
 }

--- a/14th-team5-iOS/Data/Sources/APIs/MainView/Repository/MainViewRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/MainView/Repository/MainViewRepository.swift
@@ -14,6 +14,7 @@ import RxSwift
 public final class MainViewRepository: MainViewRepositoryProtocol {
     public let disposeBag: DisposeBag = DisposeBag()
     
+    private let familyUserDefaults: FamilyInfoUserDefaults = FamilyInfoUserDefaults()
     private let mainApiWorker: MainAPIWorker = MainAPIWorker()
     
     public init() { }
@@ -22,12 +23,29 @@ public final class MainViewRepository: MainViewRepositoryProtocol {
 extension MainViewRepository {
     public func fetchMain() -> Observable<MainViewEntity?> {
         return mainApiWorker.fetchMain()
+            .map { $0?.toDomain() }
+            .do(onSuccess: { [weak self] in
+                guard 
+                    let self,
+                    let profiles = $0?.mainFamilyProfileDatas else {
+                    return
+                }
+                self.familyUserDefaults.saveFamilyMembers(profiles)
+            })
             .asObservable()
-
     }
     
     public func fetchMainNight() -> Observable<NightMainViewEntity?> {
         return mainApiWorker.fetchMainNight()
+            .map { $0?.toDomain() }
+            .do(onSuccess: { [weak self] in
+                guard
+                    let self,
+                    let profiles = $0?.mainFamilyProfileDatas else {
+                    return
+                }
+                self.familyUserDefaults.saveFamilyMembers(profiles)
+            })
             .asObservable()
     }
 }

--- a/14th-team5-iOS/Domain/Sources/UseCases/Post/FetchPostListUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/Post/FetchPostListUseCase.swift
@@ -25,6 +25,8 @@ public class FetchPostListUseCase: FetchPostListUseCaseProtocol {
         self.familyRepository = familyRepository
     }
 
+    /// postList를 불러옵니다. - 메인 화면에서 사용 중 입니다.
+    /// 만약, userdefaults에 저장된 가족 멤버가 없다면, fetchFamily를 한 번 실행하여 post 정보를 가져옵니다.
     public func execute(query: PostListQuery) -> Observable<[PostEntity]?> {
         return postListRepository.fetchTodayPostList(query: query)
             .flatMap { posts -> Single<[PostEntity]?> in
@@ -37,36 +39,7 @@ public class FetchPostListUseCase: FetchPostListUseCaseProtocol {
             .asObservable()
     }
 
-    private func loadFamilyMembersAndUpdatePosts(posts: [PostEntity]) -> Single<[PostEntity]?> {
-        let members = self.familyRepository.loadAllFamilyMembers()
-
-        if let members = members {
-            return self.updatePostsWithMembers(posts: posts, members: members)
-        } else {
-            return self.familyRepository.fetchAllFamilyMembers()
-                .flatMap { membersFromApi -> Single<[PostEntity]?> in
-                    return self.updatePostsWithMembers(posts: posts, members: membersFromApi)
-                }
-                .asSingle()
-        }
-    }
-
-    private func updatePostsWithMembers(posts: [PostEntity], members: [Profile]?) -> Single<[PostEntity]?> {
-        guard let members = members else {
-            return Single.just(nil)
-        }
-        
-        let updatedPosts = posts.map { post in
-            var updatedPost = post
-            if let member = members.first(where: { $0.memberId == updatedPost.author.memberId }) {
-                updatedPost.author = member
-            }
-            return updatedPost
-        }
-        
-        return Single.just(updatedPosts) // updatedPosts를 Single로 반환
-    }
-    
+    /// PostList를 페이지네이션 형태로 불러옵니다 - 프로필 조회에서 사용 중 입니다.
     public func execute(query: PostListQuery) -> Observable<PostListPageEntity?> {
         return postListRepository.fetchTodayPostList(query: query)
             .flatMap { posts -> Single<PostListPageEntity?> in
@@ -89,5 +62,37 @@ public class FetchPostListUseCase: FetchPostListUseCaseProtocol {
                 return Single.just(updatedPosts)
             }
             .asObservable()
+    }
+}
+
+extension FetchPostListUseCase {
+    private func loadFamilyMembersAndUpdatePosts(posts: [PostEntity]) -> Single<[PostEntity]?> {
+        let members = self.familyRepository.loadAllFamilyMembers()
+
+        if let members = members {
+            return self.updatePostsWithMembers(posts: posts, members: members)
+        } else {
+            return self.familyRepository.fetchAllFamilyMembers()
+                .flatMap { membersFromApi -> Single<[PostEntity]?> in
+                    return self.updatePostsWithMembers(posts: posts, members: membersFromApi)
+                }
+                .asSingle()
+        }
+    }
+    
+    private func updatePostsWithMembers(posts: [PostEntity], members: [Profile]?) -> Single<[PostEntity]?> {
+        guard let members = members else {
+            return Single.just(nil)
+        }
+        
+        let updatedPosts = posts.map { post in
+            var updatedPost = post
+            if let member = members.first(where: { $0.memberId == updatedPost.author.memberId }) {
+                updatedPost.author = member
+            }
+            return updatedPost
+        }
+        
+        return Single.just(updatedPosts)
     }
 }


### PR DESCRIPTION
## 😽개요

* main, mainnight, fetchfamily하는 경우에 패밀리 정보를 유저디펄트에 저장해요.
* 항상 최신 유저 정보를 지녀야한다 생각해요. 예를 들면, 홈에서는 프로필 사진이 변경 되었는데, 유저디펄트에는 옛날 사진을 지니고 있을 수도 있으니까 family를 땡겨오는 모든 곳에서 유저디펄트를 업데이트 시키는게 맞다 생각했습니다!
* 또한, 메인 화면을 지나는 모든 화면에 "알 수 없음" 오류가 해결 됩니다!



## ✅테스트 케이스
- 앱 삭제 후 캘린더, 프로필 조회 잘 되는지 확인
