### PR TITLE
fix: 가족방 설정 화면에서 사용자 프로필 못 가져오는 이슈 수정해요

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraViewReactor.swift
@@ -284,12 +284,11 @@ extension CameraViewReactor {
             
         case  .profile:
             //Profile 관련 이미지 업로드 Mutation
-            let profileImage = "\(imageData.hash).jpg"
+            let profileImage = "\(imageData.hashValue).jpg"
             let profileParameter = CameraDisplayImageParameters(imageName: profileImage)
             
             return .concat(
                 .just(.setLoading(false)),
-                
                 createProfileImageUseCase.execute(parameter: profileParameter)
                     .asObservable()
                     .withUnretained(self)

--- a/14th-team5-iOS/App/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
@@ -112,10 +112,6 @@ final class FamilyNameSettingViewController: BBNavigationViewController<FamilyNa
             $0.text = "홈 화면에 가족 이름이 추가돼요 "
         }
         
-        groupEditerView.do {
-            $0.isHidden = true
-        }
-        
         groupConfirmButton.do {
             $0.setTitle("저장", for: .normal)
             $0.setTitleFontStyle(.body1Bold)
@@ -146,14 +142,14 @@ final class FamilyNameSettingViewController: BBNavigationViewController<FamilyNa
         groupTextField.rx.text
             .orEmpty
             .skip(1)
-            .debounce(.milliseconds(300), scheduler: MainScheduler.instance)
+            .debounce(RxInterval._100milliseconds, scheduler: RxScheduler.main)
             .map { Reactor.Action.didChangeFamilyGroupNickname($0)}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
         groupConfirmButton.rx
             .tap
-            .throttle(.microseconds(300), scheduler: MainScheduler.instance)
+            .throttle(RxInterval._100milliseconds, scheduler: RxScheduler.main)
             .map { Reactor.Action.didTapUpdateFamilyGroupNickname(.update) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/Data/Sources/APIs/Members/MemberAPI/MembersAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/Members/MemberAPI/MembersAPIWorker.swift
@@ -17,7 +17,6 @@ typealias MembersAPIWorker = MembersAPIs.Worker
 
 extension MembersAPIs {
     final class Worker: APIWorker {
-        
         static let queue = {
             ConcurrentDispatchQueueScheduler(queue: DispatchQueue(label: "ProfileAPIQueue", qos: .utility))
         }()
@@ -33,10 +32,11 @@ extension MembersAPIs {
 
 extension MembersAPIWorker {
     
-    public func fetchProfileMember(accessToken: String, memberId: String) -> Single<MembersProfileResponseDTO?> {
+    public func fetchProfileMember(memberId: String) -> Single<MembersProfileResponseDTO?> {
         let spec = MembersAPIs.profileMember(memberId).spec
-
-        return request(spec: spec, headers: [BibbiAPI.Header.xAppVersion, BibbiAPI.Header.xUserPlatform, BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)])
+        let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
+        let headers = BibbiHeader.commonHeaders(accessToken: accessToken)
+        return request(spec: spec, headers: headers)
             .subscribe(on: Self.queue)
             .map(MembersProfileResponseDTO.self)
             .catchAndReturn(nil)
@@ -44,39 +44,41 @@ extension MembersAPIWorker {
         
     }
     
-    public func createProfileImagePresingedURL(accessToken: String, parameters: Encodable) -> Single<CameraDisplayImageResponseDTO?> {
+    public func createProfileImagePresingedURL(parameters: Encodable) -> Single<CameraDisplayImageResponseDTO?> {
         let spec = MembersAPIs.profileAlbumUploadImageURL.spec
-        
-        return request(spec: spec, headers: [BibbiAPI.Header.xAppVersion, BibbiAPI.Header.xUserPlatform, BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
+        let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
+        let headers = BibbiHeader.commonHeaders(accessToken: accessToken)
+        return request(spec: spec, headers: headers, jsonEncodable: parameters)
             .subscribe(on: Self.queue)
             .map(CameraDisplayImageResponseDTO.self)
             .catchAndReturn(nil)
             .asSingle()
     }
     
-    public func uploadToProfilePresingedURL(accessToken: String, toURL url: String, with imageData: Data) -> Single<Bool> {
+    public func uploadToProfilePresingedURL(toURL url: String, with imageData: Data) -> Single<Bool> {
         let spec = MembersAPIs.profileUploadToPreSignedURL(url).spec
-        
-        return upload(spec: spec, headers: [BibbiAPI.Header.xAppVersion, BibbiAPI.Header.xUserPlatform, BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)], image: imageData)
+        let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
+        let headers = BibbiHeader.commonHeaders(accessToken: accessToken)
+        return upload(spec: spec, headers: headers, image: imageData)
             .subscribe(on: Self.queue)
             .catchAndReturn(false)
             .map { _ in true }
     }
     
-    public func updateProfileAlbumImageToS3(accessToken: String, memberId: String, parameter: Encodable) -> Single<MembersProfileResponseDTO?> {
+    public func updateProfileAlbumImageToS3(memberId: String, parameter: Encodable) -> Single<MembersProfileResponseDTO?> {
         let spec = MembersAPIs.profileEditImage(memberId).spec
-        
-        return request(spec: spec, headers: [BibbiAPI.Header.xAppVersion, BibbiAPI.Header.xUserPlatform, BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameter)
+        let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
+        let headers = BibbiHeader.commonHeaders(accessToken: accessToken)
+        return request(spec: spec, headers: headers, jsonEncodable: parameter)
             .subscribe(on: Self.queue)
             .map(MembersProfileResponseDTO.self)
             .catchAndReturn(nil)
             .asSingle()
     }
     
-    public func deleteProfileImageToS3(accessToken: String, memberId: String) -> Single<MembersProfileResponseDTO?> {
+    public func deleteProfileImageToS3(memberId: String) -> Single<MembersProfileResponseDTO?> {
         let spec = MembersAPIs.profileDeleteImage(memberId).spec
-        
-        return request(spec: spec,headers: [BibbiAPI.Header.xAppVersion, BibbiAPI.Header.xUserPlatform, BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson])
+        return request(spec: spec)
             .subscribe(on: Self.queue)
             .map(MembersProfileResponseDTO.self)
             .catchAndReturn(nil)

--- a/14th-team5-iOS/Data/Sources/APIs/Members/Repositories/MembersRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/Members/Repositories/MembersRepository.swift
@@ -19,7 +19,6 @@ public final class MembersRepository {
     
     private let familyUserDefaults: FamilyInfoUserDefaults = FamilyInfoUserDefaults()
     private let membersAPIWorker: MembersAPIWorker = MembersAPIWorker()
-    private let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
     public init() { }
     
 }
@@ -28,13 +27,13 @@ public final class MembersRepository {
 extension MembersRepository: MembersRepositoryProtocol {
         
     public func fetchProfileMemberItems(memberId: String) -> Single<MembersProfileEntity?> {
-        return membersAPIWorker.fetchProfileMember(accessToken: accessToken, memberId: memberId)
+        return membersAPIWorker.fetchProfileMember(memberId: memberId)
             .map { $0?.toDomain() }
             .catchAndReturn(nil)
     }
     
     public func updataProfileImageToS3(memberId: String, parameter: ProfileImageEditParameter) -> Single<MembersProfileEntity?> {
-        return membersAPIWorker.updateProfileAlbumImageToS3(accessToken: accessToken, memberId: memberId, parameter: parameter)
+        return membersAPIWorker.updateProfileAlbumImageToS3(memberId: memberId, parameter: parameter)
             .do {
                 guard let userEntity = $0?.toProfileEntity() else { return }
                 self.familyUserDefaults.updateFamilyMember(userEntity)
@@ -44,7 +43,7 @@ extension MembersRepository: MembersRepositoryProtocol {
     }
     
     public func deleteProfileImageToS3(memberId: String) -> Single<MembersProfileEntity?> {
-        return membersAPIWorker.deleteProfileImageToS3(accessToken: accessToken, memberId: memberId)
+        return membersAPIWorker.deleteProfileImageToS3(memberId: memberId)
             .do {
                 guard let userEntity = $0?.toProfileEntity() else { return }
                 self.familyUserDefaults.updateFamilyMember(userEntity)

--- a/14th-team5-iOS/Data/Sources/Trash/Account/AccountRepository/AccountRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Trash/Account/AccountRepository/AccountRepository.swift
@@ -125,13 +125,13 @@ public final class AccountRepository: AccountImpl {
     }
     
     public func executePresignedImageURLCreate(parameter: CameraDisplayImageParameters) -> Observable<CameraPreSignedEntity?> {
-        return profileWorker.createProfileImagePresingedURL(accessToken: accessToken, parameters: parameter)
+        return profileWorker.createProfileImagePresingedURL(parameters: parameter)
             .compactMap { $0?.toDomain() }
             .asObservable()
     }
     
     public func executeProfileImageUpload(to url: String, data: Data) -> Observable<Bool> {
-        return profileWorker.uploadToProfilePresingedURL(accessToken: accessToken, toURL: url, with: data)
+        return profileWorker.uploadToProfilePresingedURL(toURL: url, with: data)
             .asObservable()
     }
     

--- a/14th-team5-iOS/Data/Sources/Trash/Camera/CameraAPI/CameraAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/Trash/Camera/CameraAPI/CameraAPIWorker.swift
@@ -32,9 +32,10 @@ extension CameraAPIs {
 
 
 extension CameraAPIWorker {
-    public func createProfilePresignedURL(accessToken: String, parameters: Encodable) -> Single<CameraDisplayImageResponseDTO?> {
+    public func createProfilePresignedURL(parameters: Encodable) -> Single<CameraDisplayImageResponseDTO?> {
         
         let spec = CameraAPIs.uploadProfileImageURL.spec
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
             .subscribe(on: Self.queue)
@@ -45,9 +46,9 @@ extension CameraAPIWorker {
     
     
     
-    public func createFeedPresignedURL(accessToken: String, parameters: Encodable) -> Single<CameraDisplayImageResponseDTO?> {
+    public func createFeedPresignedURL(parameters: Encodable) -> Single<CameraDisplayImageResponseDTO?> {
         let spec = CameraAPIs.uploadImageURL.spec
-        
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
             .subscribe(on: Self.queue)
@@ -56,8 +57,9 @@ extension CameraAPIWorker {
             .asSingle()
     }
     
-    public func editProfileImageToS3(accessToken: String, memberId: String, parameters: Encodable) -> Single<MembersProfileResponseDTO?>   {
+    public func editProfileImageToS3(memberId: String, parameters: Encodable) -> Single<MembersProfileResponseDTO?>   {
         let spec = CameraAPIs.editProfileImage(memberId).spec
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
             .subscribe(on: Self.queue)
             .map(MembersProfileResponseDTO.self)
@@ -65,7 +67,9 @@ extension CameraAPIWorker {
             .asSingle()
     }
     
-    public func uploadImageToPresignedURL(accessToken: String, toURL url: String, withImageData imageData: Data) -> Single<Bool> {
+    public func uploadImageToPresignedURL(toURL url: String, withImageData imageData: Data) -> Single<Bool> {
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
+        
         let spec = CameraAPIs.presignedURL(url).spec
         return upload(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.xAuthToken(accessToken)], image: imageData)
             .subscribe(on: Self.queue)
@@ -74,9 +78,9 @@ extension CameraAPIWorker {
             .map { $0 }
     }
     
-    public func combineWithTextImageUpload(accessToken: String, parameters: Encodable, query: CameraMissionFeedQuery)  -> Single<CameraDisplayPostResponseDTO?> {
+    public func combineWithTextImageUpload(parameters: Encodable, query: CameraMissionFeedQuery)  -> Single<CameraDisplayPostResponseDTO?> {
         let spec = CameraAPIs.updateImage(query).spec
-        
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
             .subscribe(on: Self.queue)
             .map(CameraDisplayPostResponseDTO.self)
@@ -91,9 +95,10 @@ extension CameraAPIWorker {
         
     }
     
-    public func createRealEmojiPresignedURL(accessToken: String, parameters: Encodable) -> Single<CameraRealEmojiPreSignedResponseDTO?> {
+    public func createRealEmojiPresignedURL(parameters: Encodable) -> Single<CameraRealEmojiPreSignedResponseDTO?> {
         //TODO: Repository로 코드 원복
         let memberId = App.Repository.member.memberID.value ?? ""
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         let spec = CameraAPIs.uploadRealEmojiURL(memberId).spec
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
@@ -104,9 +109,10 @@ extension CameraAPIWorker {
         
     }
     
-    public func uploadRealEmojiImageToS3(accessToken: String, parameters: Encodable) -> Single<CameraCreateRealEmojiResponseDTO?> {
+    public func uploadRealEmojiImageToS3(parameters: Encodable) -> Single<CameraCreateRealEmojiResponseDTO?> {
         //TODO: Repository로 코드 원복
         let memberId = App.Repository.member.memberID.value ?? ""
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         let spec = CameraAPIs.updateRealEmojiImage(memberId).spec
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
@@ -116,9 +122,10 @@ extension CameraAPIWorker {
             .asSingle()
     }
     
-    public func loadRealEmojiImage(accessToken: String) -> Single<CameraRealEmojiImageItemResponseDTO?> {
+    public func loadRealEmojiImage() -> Single<CameraRealEmojiImageItemResponseDTO?> {
         //TODO: Repository로 코드 원복
         let memberId = App.Repository.member.memberID.value ?? ""
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         let spec = CameraAPIs.reloadRealEmoji(memberId).spec
         
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)])
@@ -128,9 +135,10 @@ extension CameraAPIWorker {
             .asSingle()
     }
     
-    public func updateRealEmojiImage(accessToken: String, realEmojiId: String, parameters: Encodable) -> Single<CameraUpdateRealEmojiResponseDTO?> {
+    public func updateRealEmojiImage(realEmojiId: String, parameters: Encodable) -> Single<CameraUpdateRealEmojiResponseDTO?> {
         //TODO: Repository로 코드 원복
         let memberId = App.Repository.member.memberID.value ?? ""
+        let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
         let spec = CameraAPIs.modifyRealEmojiImage(memberId, realEmojiId).spec
         return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)], jsonEncodable: parameters)
             .subscribe(on: Self.queue)
@@ -139,8 +147,9 @@ extension CameraAPIWorker {
             .asSingle()
     }
   
-  public func fetchMissionItems(accessToken: String) -> Single<CameraTodayMissionResponseDTO?> {
+  public func fetchMissionItems() -> Single<CameraTodayMissionResponseDTO?> {
     let spec = CameraAPIs.fetchMissionToday.spec
+    let accessToken = App.Repository.token.accessToken.value?.accessToken ?? ""
     return request(spec: spec, headers: [BibbiAPI.Header.xAppKey, BibbiAPI.Header.acceptJson, BibbiAPI.Header.xAuthToken(accessToken)])
       .subscribe(on: Self.queue)
       .map(CameraTodayMissionResponseDTO.self)

--- a/14th-team5-iOS/Data/Sources/Trash/Camera/Repository/CameraRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Trash/Camera/Repository/CameraRepository.swift
@@ -20,7 +20,6 @@ public final class CameraRepository {
     
     public init() { }
     
-    public var accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
         
 }
 
@@ -28,24 +27,24 @@ extension CameraRepository: CameraRepositoryProtocol {
     
     
     public func combineWithTextImage(parameters: CameraDisplayPostParameters, query:CameraMissionFeedQuery) -> Single<CameraPostEntity?> {
-        return cameraAPIWorker.combineWithTextImageUpload(accessToken: accessToken, parameters: parameters, query: query)
+        return cameraAPIWorker.combineWithTextImageUpload(parameters: parameters, query: query)
             .map { $0?.toDomain() }
             .catchAndReturn(nil)
     }
     
     public func addPresignedeImageURL(parameters: CameraDisplayImageParameters) -> Single<CameraPreSignedEntity?> {
-        return cameraAPIWorker.createProfilePresignedURL(accessToken: accessToken, parameters: parameters)
+        return cameraAPIWorker.createProfilePresignedURL(parameters: parameters)
             .map { $0?.toDomain() }
     }
     
     
         
     public func uploadImageToS3(to url: String, from imageData: Data) -> Single<Bool> {
-        return cameraAPIWorker.uploadImageToPresignedURL(accessToken: accessToken, toURL: url, withImageData: imageData)
+        return cameraAPIWorker.uploadImageToPresignedURL(toURL: url, withImageData: imageData)
     }
     
     public func editProfleImageToS3(memberId: String, parameter: ProfileImageEditParameter) -> Single<MembersProfileEntity?> {
-        return cameraAPIWorker.editProfileImageToS3(accessToken: accessToken, memberId: memberId, parameters: parameter)
+        return cameraAPIWorker.editProfileImageToS3(memberId: memberId, parameters: parameter)
             .do {
                 guard let userEntity = $0?.toProfileEntity() else { return }
                 let familyUserDefaults = FamilyInfoUserDefaults()
@@ -55,27 +54,27 @@ extension CameraRepository: CameraRepositoryProtocol {
     }
     
     public func fetchRealEmojiImageURL(memberId: String, parameters: CameraRealEmojiParameters) -> Single<CameraRealEmojiPreSignedEntity?> {
-        return cameraAPIWorker.createRealEmojiPresignedURL(accessToken: accessToken, parameters: parameters)
+        return cameraAPIWorker.createRealEmojiPresignedURL(parameters: parameters)
             .map { $0?.toDomain() }
     }
     
     public func uploadRealEmojiImageToS3(memberId: String, parameters: CameraCreateRealEmojiParameters) -> Single<CameraCreateRealEmojiEntity?> {
-        return cameraAPIWorker.uploadRealEmojiImageToS3(accessToken: accessToken, parameters: parameters)
+        return cameraAPIWorker.uploadRealEmojiImageToS3(parameters: parameters)
             .map { $0?.toDomain() }
     }
     
     public func fetchRealEmojiItems() -> Single<[CameraRealEmojiImageItemEntity?]> {
-        return cameraAPIWorker.loadRealEmojiImage(accessToken: accessToken)
+        return cameraAPIWorker.loadRealEmojiImage()
             .map { $0?.toDomain() ?? [] }
     }
     
     public func updateRealEmojiImage(memberId: String, realEmojiId: String, parameters: CameraUpdateRealEmojiParameters) -> Single<CameraUpdateRealEmojiEntity?> {
-        return cameraAPIWorker.updateRealEmojiImage(accessToken: accessToken, realEmojiId: realEmojiId, parameters: parameters)
+        return cameraAPIWorker.updateRealEmojiImage(realEmojiId: realEmojiId, parameters: parameters)
             .map { $0?.toDomain() }
     }
   
   public func fetchTodayMissionItem() -> Single<CameraTodayMssionEntity?> {
-      return cameraAPIWorker.fetchMissionItems(accessToken: accessToken)
+      return cameraAPIWorker.fetchMissionItems()
           .map { $0?.toDomain() }
   }
     

--- a/14th-team5-iOS/Domain/Sources/Trash/Camera/Interfaces/CameraRepositoryProtocol.swift
+++ b/14th-team5-iOS/Domain/Sources/Trash/Camera/Interfaces/CameraRepositoryProtocol.swift
@@ -67,7 +67,6 @@ public enum UploadLocation {
 public protocol CameraRepositoryProtocol {
     var disposeBag: DisposeBag { get }
     
-    var accessToken: String { get }
     func addPresignedeImageURL(parameters: CameraDisplayImageParameters) -> Single<CameraPreSignedEntity?>
     func uploadImageToS3(to url: String, from image: Data) -> Single<Bool>
     func editProfleImageToS3(memberId: String, parameter: ProfileImageEditParameter) -> Single<MembersProfileEntity?>


### PR DESCRIPTION
## 😽개요
- 가족방 이름 설정 화면에서 설정한 사용자 프로필 못 가져오는 이슈 수정해요
- 초기 회원 가입 시 카메라 업로드 이슈 수정해요

## 🛠️ 작업 내용
- 가족방 이름 설정화면에서(설정 문구) 및 (사용자 프로필) 안 보이는 이슈를 수정하기 위해 `setupAttributes`에 isHidden 코드를 제거하였습니다.
- 초기 회원 가입 시 카메라 업로드 이슈 수정

### (소제목)

* 초기 회원가입시  카메라 업로드 API 호출 과정에서 Repository에 있는 `App.Repository.accessToken`이 빈값으로 호출되고 있었습니다.
<img width="756" alt="스크린샷 2024-09-30 오후 6 07 22" src="https://github.com/user-attachments/assets/d3287ea0-3abe-44ba-9a08-235a9e64f68a">
* `App.Repository.accessToken` 코드를 Repository 코드에서 주입하지 않고 `APIWorker`로 주입하도록 코드를 수정했습니다.

## ✅테스트 케이스

* 초기 회원가입 시 앨범, 카메라로 프로필 이미지 업로드가 정상적으로 호출되는지
* 가족방 이름 설정 시 초기(문구) 및 설정한 사용자 프로필을 잘 노출되는지
---

