### PR TITLE
fix: 가족방 이름 설정화면 레이아웃 및 카메라 텍스트 정렬 이슈 수정해요

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/CameraDisplayViewController.swift
@@ -256,9 +256,9 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
         displayEditTextField.rx
             .text.changed
             .compactMap { $0 }
-            .filter { $0.contains(" ") }
-            .debug("카메라 상세 공백 체크")
+            .filter { $0.contains(" ") || $0.count > 8 }
             .distinctUntilChanged()
+            .debounce(RxInterval._600milliseconds, scheduler: RxScheduler.main)
             .map { _ in Reactor.Action.showInputTextError }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
@@ -271,16 +271,7 @@ public final class CameraDisplayViewController: BaseViewController<CameraDisplay
         
         displayEditTextField.rx
             .text.orEmpty
-            .filter{ $0.count > 8 }
-            .debounce(RxInterval._600milliseconds, scheduler: RxScheduler.main)
-            .map { _ in Reactor.Action.showInputTextError }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        displayEditTextField.rx
-            .text.orEmpty
             .filter { !$0.contains(" ")}
-            .debounce(RxInterval._600milliseconds, scheduler: RxScheduler.main)
             .scan("") { previous, new -> String in
                 if new.count > 8 {
                   return previous

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraDisplayViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/Reactor/CameraDisplayViewReactor.swift
@@ -141,7 +141,7 @@ public final class CameraDisplayViewReactor: Reactor {
                     }
             )
         case .didTapArchiveButton:
-            let config = BBToastConfiguration(direction: .bottom(yOffset: -360), animationTime: 1.0)
+            let config = BBToastConfiguration(direction: .bottom(yOffset: -20), animationTime: 1.0)
             let viewConfig = BBToastViewConfiguration(minWidth: 207)
             provider.bbToastService.show(
                 image:DesignSystemAsset.camera.image.withTintColor(DesignSystemAsset.gray300.color),

--- a/14th-team5-iOS/App/Sources/Presentation/Camera/View/BibbiMissionView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Camera/View/BibbiMissionView.swift
@@ -1,17 +1,18 @@
 //
 //  BibbiMissionView.swift
-//  Core
+//  App
 //
-//  Created by Kim dohyun on 5/1/24.
+//  Created by Kim dohyun on 10/9/24.
 //
 
 import UIKit
 
+import Core
 import DesignSystem
 import SnapKit
 
 
-public final class BibbiMissionView: UIView {
+final class BibbiMissionView: UIView {
     
     public let missionBadgeView: UIImageView = UIImageView()
     public let missionTitleView: BBLabel = BBLabel(.body2Bold, textAlignment: .center, textColor: .mainYellow)

--- a/14th-team5-iOS/App/Sources/Presentation/Content/WebContentViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Content/WebContentViewController.swift
@@ -72,13 +72,6 @@ public class WebContentViewController: BaseViewController<WebContentReactor> {
             .disposed(by: disposeBag)
         
         reactor.state
-            .compactMap { $0.url?.lastPathComponent == "privacy" ? "개인정보처리방침" : "이용 약관" }
-            .distinctUntilChanged()
-            .withUnretained(self)
-            .bind(onNext: { $0.0.navigationBarView.setNavigationTitle(title: $0.1) })
-            .disposed(by: disposeBag)
-        
-        reactor.state
             .map { $0.isLoading }
             .distinctUntilChanged()
             .asDriver(onErrorJustReturn: false)

--- a/14th-team5-iOS/App/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
@@ -61,7 +61,6 @@ final class FamilyNameSettingViewController: BBNavigationViewController<FamilyNa
         }
         
         groupEditerView.snp.makeConstraints {
-            $0.width.equalTo(171)
             $0.height.equalTo(24)
             $0.bottom.equalTo(groupConfirmButton.snp.top).offset(-14)
             $0.centerX.equalToSuperview()
@@ -142,7 +141,6 @@ final class FamilyNameSettingViewController: BBNavigationViewController<FamilyNa
         groupTextField.rx.text
             .orEmpty
             .skip(1)
-            .debounce(RxInterval._100milliseconds, scheduler: RxScheduler.main)
             .map { Reactor.Action.didChangeFamilyGroupNickname($0)}
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/14th-team5-iOS/App/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
@@ -36,12 +36,12 @@ final class FamilyNameSettingViewController: BBNavigationViewController<FamilyNa
         groupNameLabel.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide).offset(130)
             $0.height.equalTo(25)
-            $0.centerX.equalToSuperview().inset(20)
+            $0.centerX.equalToSuperview()
         }
         
         groupTextField.snp.makeConstraints {
             $0.top.equalTo(groupNameLabel.snp.bottom).offset(8)
-            $0.centerX.equalToSuperview().inset(20)
+            $0.centerX.equalToSuperview()
         }
         
         groupErrorStackView.snp.makeConstraints {

--- a/14th-team5-iOS/App/Sources/Presentation/Privacy/View/BibbiInquireBannerView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Privacy/View/BibbiInquireBannerView.swift
@@ -1,17 +1,18 @@
 //
 //  BibbiInquireBannerView.swift
-//  Core
+//  App
 //
-//  Created by Kim dohyun on 3/20/24.
+//  Created by Kim dohyun on 10/9/24.
 //
 
 import UIKit
 
+import Core
 import DesignSystem
 import SnapKit
 import Then
 
-public final class BibbiInquireBannerView: UIView {
+final class BibbiInquireBannerView: UIView {
     
     
     private let mainLogoView: UIImageView = UIImageView()
@@ -113,5 +114,7 @@ public final class BibbiInquireBannerView: UIView {
     
     
 }
+
+
 
 

--- a/14th-team5-iOS/App/Sources/Presentation/Profile/View/BibbiProfileView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Profile/View/BibbiProfileView.swift
@@ -1,38 +1,36 @@
 //
 //  BibbiProfileView.swift
-//  Core
+//  App
 //
-//  Created by Kim dohyun on 12/17/23.
+//  Created by Kim dohyun on 10/9/24.
 //
 
 import UIKit
 
+import Core
 import DesignSystem
-import RxSwift
-import RxCocoa
-import ReactorKit
 import SnapKit
 import Then
 
 
 
 
-public class BibbiProfileView: UIView {
-    public let profileImageView: UIImageView = UIImageView()
-    public let profileDefaultLabel: BBLabel = BBLabel(.head1, textAlignment: .center, textColor: .gray200)
-    public let circleButton: UIButton = UIButton.createCircleButton(radius: 15)
-    public let birthDayView: UIImageView = UIImageView()
-    public let profileNickNameButton: UIButton = UIButton()
-    public let profileCreateLabel: UILabel = BBLabel(.caption, textAlignment: .center ,textColor: .gray400)
+final class BibbiProfileView: UIView {
+    let profileImageView: UIImageView = UIImageView()
+    let profileDefaultLabel: BBLabel = BBLabel(.head1, textAlignment: .center, textColor: .gray200)
+    let circleButton: UIButton = UIButton.createCircleButton(radius: 15)
+    let birthDayView: UIImageView = UIImageView()
+    let profileNickNameButton: UIButton = UIButton()
+    let profileCreateLabel: UILabel = BBLabel(.caption, textAlignment: .center ,textColor: .gray400)
     
     
-    public var isSetting: Bool = false {
+    var isSetting: Bool = false {
         didSet {
             setupUserProfile(isUser: isSetting)
         }
     }
     
-    public var isBirthDay: Bool = false {
+    var isBirthDay: Bool = false {
         didSet {
             setupBirtyDay(isBirtyDay: isBirthDay)
         }
@@ -175,3 +173,4 @@ public class BibbiProfileView: UIView {
         birthDayView.isHidden = !isBirtyDay
     }
 }
+

--- a/14th-team5-iOS/App/Sources/Presentation/Resign/View/BibbiCheckBoxView.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Resign/View/BibbiCheckBoxView.swift
@@ -1,8 +1,8 @@
 //
-//  BibbiTermsView.swift
-//  Core
+//  BibbiCheckBoxView.swift
+//  App
 //
-//  Created by Kim dohyun on 1/2/24.
+//  Created by Kim dohyun on 10/9/24.
 //
 
 import UIKit
@@ -20,9 +20,9 @@ enum ReasonTypes: String, CaseIterable {
 }
 
 
-public final class BibbiCheckBoxView: UIView {
+final class BibbiCheckBoxView: UIView {
     private let checkStackView: UIStackView = UIStackView()
-    public var checkButtons: [UIButton] = []
+    var checkButtons: [UIButton] = []
     
     
     
@@ -85,3 +85,4 @@ public final class BibbiCheckBoxView: UIView {
     }
     
 }
+

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ProfileFeedGlobalState.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/ProfileFeedGlobalState.swift
@@ -9,6 +9,11 @@ import Foundation
 
 import RxSwift
 
+public enum BibbiFeedType: Int {
+    case survival = 0
+    case mission = 1
+}
+
 public enum ProfileFeedEvent {
     case didTapSegmentedPage(BibbiFeedType)
     case didReceiveMemberId(BibbiFeedType)

--- a/14th-team5-iOS/Core/Sources/URLTypes.swift
+++ b/14th-team5-iOS/Core/Sources/URLTypes.swift
@@ -7,13 +7,6 @@
 
 import UIKit
 
-// TODO: - 요거 옮겨주세요~
-public enum BibbiFeedType: Int {
-    case survival = 0
-    case mission = 1
-}
-
-
 public enum URLTypes {
     case settings
     case appStore


### PR DESCRIPTION
## 🔵PR을 올리기 전 아래 사항을 확인해주세요.
- 구현한 로직과 기능이 올바르게 작동되는지 충분히 테스트해주세요.
- 코드의 성능이나 메모리 효율성이 적절하게 고려되었는지, 불필요한 코드가 없는지 검토해주세요.
- 이번 PR에서 구현된 주요 기능이나 해결된 문제에 대해 자세히 서술해주세요.
(위 내용은 지워주세요)



## 😽개요

* 가족방 이름 설정화면 AutoLayout을 수정했습니다.
* 가족방 이름 설정화면에 `TextFiled` 입력 시 10자 이내 Error 문구 안 뜨는 이슈 수정했습니다.

## 🛠️작업 내용

### 가족방 이름 설정화면에 `TextFiled` 입력 시 10자 이내 Error 문구 안 뜨는 이슈
- 사용자가 가족방 이름을 지속적으로(연타) 입력해도 `debounce` 가 걸려 있었기 때문에 (10자가 넘겨져도) Error 문구가 뜨지 않았습니다.
- 가족방 이름 설정 화면에서 중앙 정렬이 되어야 하는데 `inset(20)`이 걸려 있어서 코드 삭제했습니다.




## ✅테스트 케이스

* 가족방 이름 설정 화면에서 10자 이상 넘길시 Error 문구 뜨는지 확인
* 가족방 이름 설정 화면 Layout이 Figam와 동일한지
