### PR TITLE
fix: 가족 이름이 공백으로 뜨는 문제 수정

### DIFF
--- a/14th-team5-iOS/App/Sources/Presentation/Management/Reactor/FamilyNameSettingViewReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Management/Reactor/FamilyNameSettingViewReactor.swift
@@ -69,14 +69,14 @@ public final class FamilyNameSettingViewReactor: Reactor {
                 .compactMap { $0 }
                 .withUnretained(self)
                 .flatMap { owner, familyGroupInfo -> Observable<Mutation> in
-                    if familyGroupInfo.familyNameEditorId.isEmpty {
+                    if familyGroupInfo.familyNameEditorId == nil {
                         return .concat(
                             .just(.setFamilyNickNameVaildation(false)),
                             .just(.setFamilyGroupEditValidation(true)),
                             .just(.setFamilyGroupInfoItem(familyGroupInfo))
                         )
                     }
-                    let editorId = familyGroupInfo.familyNameEditorId
+                    let editorId = familyGroupInfo.familyNameEditorId ?? ""
                     return owner.fetchFamilyEditerUseCase.execute(memberId: editorId)
                         .asObservable()
                         .compactMap { $0 }

--- a/14th-team5-iOS/App/Sources/Presentation/Management/Reactor/ManagementReactor.swift
+++ b/14th-team5-iOS/App/Sources/Presentation/Management/Reactor/ManagementReactor.swift
@@ -137,12 +137,11 @@ public final class ManagementReactor: Reactor {
             
         case .fetchFamilyGroupInfo:
             return fetchFamilyGroupInfoUseCase.execute()
-                .withUnretained(self)
                 .flatMap {
-                    guard let familyInfo = $0.1 else {
+                    guard let familyName = $0?.familyName else {
                         return Observable<Mutation>.just(.setFamilyName("나의 가족"))
                     }
-                    return Observable<Mutation>.just(.setFamilyName(familyInfo.familyName))
+                    return Observable<Mutation>.just(.setFamilyName(familyName))
                 }
             
         case let .fetchPaginationFamilyMemeber(refresh):

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/BBAPIWorker.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/BBAPIWorker.swift
@@ -96,7 +96,7 @@ open class BBRxAPIWorker {
     /// - Parameters:
     ///   - service: 이 인스턴스가 사용하기를 원하는 `NetworkService`입니다. 기본값은 `BBNetworkDefaultService()`입니다.
     ///   - errorResolver: 이 인스턴스가 사용하기를 원하는 `APIErrorMapper`입니다. 기본값은 `APIDefaultErrorMapper()`입니다.
-    ///   - errorLogger: 이 인스턴스가 사용하기를 원하는 `APIErrorLogger`입니다. 기본값은 `APIDefaultErrorLogger()`입니다.
+    ///   - errorLogger: 이 인스턴스가 사용하기를 원하는 `BBErrorLogger`입니다. 기본값은 `APIWorkerErrorLogger()`입니다.
     public init(
         with service: any BBNetworkService = BBNetworkDefaultService(),
         errorMapper: any APIErrorMapper = APIDefaultErrorMapper(),

--- a/14th-team5-iOS/Data/Sources/APIs/Family/FamilyAPI/DataMapping/FamilyGroupInfoResponseDTO.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/Family/FamilyAPI/DataMapping/FamilyGroupInfoResponseDTO.swift
@@ -20,8 +20,8 @@ extension FamilyGroupInfoResponseDTO {
     func toDomain() -> FamilyGroupInfoEntity {
         return .init(
             familyId: familyId,
-            familyName: familyName ?? "",
-            familyNameEditorId: familyNameEditorId ?? "",
+            familyName: familyName,
+            familyNameEditorId: familyNameEditorId,
             createdAt: createdAt.iso8601ToDate()
         )
     }

--- a/14th-team5-iOS/Domain/Sources/Entities/Family/FamilyGroupInfoEntity.swift
+++ b/14th-team5-iOS/Domain/Sources/Entities/Family/FamilyGroupInfoEntity.swift
@@ -9,15 +9,15 @@ import Foundation
 
 public struct FamilyGroupInfoEntity {
     public let familyId: String
-    public let familyName: String
-    public let familyNameEditorId: String
+    public let familyName: String?
+    public let familyNameEditorId: String?
     public let createdAt: Date
     
     
     public init(
         familyId: String,
-        familyName: String,
-        familyNameEditorId: String,
+        familyName: String?,
+        familyNameEditorId: String?,
         createdAt: Date
     ) {
         self.familyId = familyId


### PR DESCRIPTION
## 😽개요

* 가족 이름 첫 세팅 시, 가족 이름이 공백으로 뜨는 문제 수정

## 🛠️작업 내용

### FamilyGroupInfoResponseDTO 스키마 수정

* 가족 이름이 없을 시, 서버에서 **familyName**을 `nil` 값으로 주는데, 엔터티로 변환할 때도 그대로 nil값을 넣도록 수정하였습니다. (""과 nil은 아예 다른 값이라고 생각)


## ✅테스트 케이스

* 새로운 가족 방을 만들어 해당 가족 이름이 의도대로 뜨는지 확인

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close #673 