### PR TITLE
fix: BBAlert 버튼 패딩 수정

### DIFF
--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBAlert/AlertViews/DefaultToastView/DefaultAlertView.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBAlert/AlertViews/DefaultToastView/DefaultAlertView.swift
@@ -95,9 +95,9 @@ public class DefaultAlertView: UIView, BBAlertView {
     private func setupSubviewConstraints() {
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            buttonStack.bottomAnchor.constraint(equalTo: self.layoutMarginsGuide.bottomAnchor),
-            buttonStack.leadingAnchor.constraint(equalTo: self.layoutMarginsGuide.leadingAnchor),
-            buttonStack.trailingAnchor.constraint(equalTo: self.layoutMarginsGuide.trailingAnchor),
+            buttonStack.bottomAnchor.constraint(equalTo: self.layoutMarginsGuide.bottomAnchor, constant: -4),
+            buttonStack.leadingAnchor.constraint(equalTo: self.layoutMarginsGuide.leadingAnchor, constant: 8),
+            buttonStack.trailingAnchor.constraint(equalTo: self.layoutMarginsGuide.trailingAnchor, constant: -8),
         ])
         
         if case .vertical = viewConfig.buttonAxis {


### PR DESCRIPTION
## 😽개요

* BBAlert의 (좌우) 버튼 패딩 수정


## 🗾이미지

| 이미지① |
| :----: |
| <image src="https://github.com/user-attachments/assets/91c68631-f2c0-434d-ac32-147d84e21ff5" width="350">|

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

close #675 
