### PR TITLE
feat: Tuist CFBundleShortVersionString 1.2.3으로 업데이트

### DIFF
--- a/14th-team5-iOS/App/Project.swift
+++ b/14th-team5-iOS/App/Project.swift
@@ -19,7 +19,7 @@ private let targets: [Target] = [
                 "CFBundleDisplayName": .string("Bibbi"),
                 "CFBundleVersion": .string("1"),
                 "CFBuildVersion": .string("0"),
-                "CFBundleShortVersionString": .string("1.2.2"),
+                "CFBundleShortVersionString": .string("1.2.3"),
                 "UILaunchStoryboardName": .string("LaunchScreen.storyboard"),
                 "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),
                 "UIUserInterfaceStyle": .string("Dark"),

--- a/14th-team5-iOS/Core/Sources/Extensions/Bundle+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Bundle+Ext.swift
@@ -65,6 +65,6 @@ extension Bundle {
     }
     
     public var xAppKey: String {
-        "7c5aaa36-570e-491f-b18a-26a1a0b72959"
+        "db3ca026-0f9c-415a-a250-c97807f54add"
     }
 }

--- a/14th-team5-iOS/Core/Sources/Trash/BBNetwork/API.swift
+++ b/14th-team5-iOS/Core/Sources/Trash/BBNetwork/API.swift
@@ -53,7 +53,7 @@ public enum BibbiAPI {
         public var value: String {
             switch self {
             case let .auth(token): return "Bearer \(token)"
-            case .xAppKey: return "7b159d28-b106-4b6d-a490-1fd654ce40c2" // TODO: - 번들에서 가져오기
+            case .xAppKey: return "db3ca026-0f9c-415a-a250-c97807f54add" // TODO: - 번들에서 가져오기
             case let .xAuthToken(token): return "\(token)"
             case .contentForm: return "application/x-www-form-urlencoded"
             case .contentJson: return "application/json"


### PR DESCRIPTION

## 😽개요
- Bundle+Ext xAppKey 값 수정
- BBNetwork Header xAppKey 값 수정

## 🛠️작업 내용
- `1.2.3`차 업데이트를 위해 `xAppKey`수정했습니다.
- Tuist에 `CFBundleShortVersionString`을 `1.2.3`으로 수정했습니다.


## ✅테스트 케이스

* 네트워크 통신 시 `X-APP-KEY`값이 `1.2.3`버전으로 들어갔는지 확인해요
* `CFBundleShortVersionString`이 1.2.3인지 확인해요

---

