### PR TITLE
fix: ResignAPI 호출 시 UserDefaults MemberId nil 값 뜨는 이슈 수정해요

### DIFF
--- a/14th-team5-iOS/Data/Sources/Storages/UserDefaults/MyUserDefaults/MyUserDefaults.swift
+++ b/14th-team5-iOS/Data/Sources/Storages/UserDefaults/MyUserDefaults/MyUserDefaults.swift
@@ -32,7 +32,7 @@ final public class MyUserDefaults: MyUserDefaultsType {
     
     public func loadMemberId() -> String? {
         guard
-            let memberId: String? = userDefaults[.memberId]
+            let memberId: String = userDefaults[.memberId]
         else { return nil }
         return memberId
     }
@@ -46,7 +46,7 @@ final public class MyUserDefaults: MyUserDefaultsType {
     
     public func loadUserName() -> String? {
         guard
-            let userName: String? = userDefaults[.userName]
+            let userName: String = userDefaults[.userName]
         else { return nil }
         return userName
     }


### PR DESCRIPTION
## 🔵PR을 올리기 전 아래 사항을 확인해주세요.
- 구현한 로직과 기능이 올바르게 작동되는지 충분히 테스트해주세요.
- 코드의 성능이나 메모리 효율성이 적절하게 고려되었는지, 불필요한 코드가 없는지 검토해주세요.
- 이번 PR에서 구현된 주요 기능이나 해결된 문제에 대해 자세히 서술해주세요.
(위 내용은 지워주세요)



## 😽개요
* `MyUserDefault` 내부 메서드인 `loadFamilyId`, `loadFamilyName` Type Annotation String으로 수정해요

## 🛠️작업 내용
- 기존 UserDefaults `memberId` 값이 nil 값으로 반환 되고 있었던걸 familyId 원본 값으로 반환하도록 수정하였습니다.
- `ManagementViewController` 에서 `toSetting` 메서드에 `memberid` 값이 없어서 설정 아이콘을 눌러도 `PrivacyViewController`로 이동하지 않았는데 `UserDefaults`를 수정하면서 이동하도록 수정되었습니다.

## ✅테스트 케이스

* `ManagementViewController`에서 설정 아이콘 클릭 시 `PrivacyViewController`로 이동하는지 확인해요
* 회원 탈퇴 API 요청 시 정상적으로 요청되는지 확인해요
* `memberId` 값이 있는지 확인해요

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

