### PR TITLE
fix: AppRepository fetchAppVersion App-Key 최신 앱키로 변경

### DIFF
--- a/14th-team5-iOS/Data/Sources/APIs/App/Repository/AppRepository.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/App/Repository/AppRepository.swift
@@ -33,7 +33,7 @@ extension AppRepository {
     
     public func fetchAppVersion() -> Observable<AppVersionEntity?> {
         // TODO: - xAppKey 불러오는 코드 다시 작성하기
-        let appKey = "7b159d28-b106-4b6d-a490-1fd654ce40c2"
+        let appKey = "da91623d-fe55-4115-8e14-aa7581761963"
         
         return appApiWorker.fetchAppVersion(appKey: appKey)
             .map { $0?.toDomain() }


### PR DESCRIPTION
## 🔵PR을 올리기 전 아래 사항을 확인해주세요.
- 구현한 로직과 기능이 올바르게 작동되는지 충분히 테스트해주세요.
- 코드의 성능이나 메모리 효율성이 적절하게 고려되었는지, 불필요한 코드가 없는지 검토해주세요.
- 이번 PR에서 구현된 주요 기능이나 해결된 문제에 대해 자세히 서술해주세요.
(위 내용은 지워주세요)



## 😽개요

* 앱스토어에 출시된 `Bibbi` App 강제 업데이트 팝업 노출 이슈 수정

## 🛠️작업 내용
- 최신 버전임에도 강제 업데이트 팝업 노출 이슈를 수정
- `AppRepository`선언된 `App-Key`를 `1.2.4` 버전의 앱키로 변경하였습니다.


## 🟡차후 계획 (Optional)

* Swaager 기준으로 API 통합하면서 중복된 API Method를 제거하는게 좋을 것 같네요 지금 `AppVersion` 호출하는 메서드가 2개 선언되어있어서 잘못하면 기존과 같은 이슈가 발생할 수 있을 것 같습니다.


## ✅테스트 케이스

* `AppVersion` API Response 값 제대로 가져오는지 확인해요
* 최신버전일 경우 강제 업데이트 팝업이 안뜨는지 확인해요

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

