### PR TITLE
feat: 음성 댓글 삭제 API 및 오류 핸들링 로직을 추가해요

### DIFF
--- a/14th-team5-iOS/Bibbi/Sources/Application/DIContainer/CommentDIContainer.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/DIContainer/CommentDIContainer.swift
@@ -25,6 +25,10 @@ final class CommentDIContainer: BaseContainer {
         )
     }
     
+    private func makeDeleteVoiceCommentUseCase() -> DeleteVoiceCommentUseCaseProtocol {
+        DeleteVoiceCommentUseCase(voiceCommentRepository: makeVoiceRepository())
+    }
+    
     private func makeVoiceCommentPresignedURLUseCase() -> VoiceCommentPresignedURLUseCaseProtocol {
         VoiceCommentPresignedURLUseCase(voiceCommentRepository: makeVoiceRepository())
     }
@@ -69,6 +73,10 @@ final class CommentDIContainer: BaseContainer {
     // MARK: - Register
     
     func registerDependencies() {
+        container.register(type: DeleteVoiceCommentUseCaseProtocol.self) { _ in
+            self.makeDeleteVoiceCommentUseCase()
+        }
+        
         container.register(type: VoiceCommentPresignedURLUseCaseProtocol.self) { _ in
             self.makeVoiceCommentPresignedURLUseCase()
         }

--- a/14th-team5-iOS/Bibbi/Sources/Application/Navigator/CommentNavigator.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/Navigator/CommentNavigator.swift
@@ -16,6 +16,7 @@ protocol CommentNavigatorProtocol: BaseNavigator {
     func showErrorToast()
     func showCommentDeleteToast()
     func showFetchFailureToast()
+    func showCommentErrorToast(_ description: String)
 }
 
 final class CommentNavigator: CommentNavigatorProtocol {
@@ -57,6 +58,17 @@ final class CommentNavigator: CommentNavigatorProtocol {
         BBToast.default(
             image: DesignSystemAsset.warning.image,
             title: "댓글이 삭제되었습니다",
+            viewConfig: viewConfig,
+            config: config
+        ).show()
+    }
+    
+    func showCommentErrorToast(_ description: String) {
+        let config = BBToastConfiguration(direction: .top(yOffset: 75))
+        let viewConfig = BBToastViewConfiguration(minWidth: 100)
+        BBToast.default(
+            image: DesignSystemAsset.warning.image,
+            title: description,
             viewConfig: viewConfig,
             config: config
         ).show()

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
@@ -20,6 +20,7 @@ final public class CommentCellReactor: Reactor {
     public enum Action {
         case fetchUserName
         case fetchProfileImage
+        case didChangedInitalLayout
         case didTapProfileButton
         case didTapPlayButton(String)
         case prepareForReuse
@@ -89,6 +90,9 @@ final public class CommentCellReactor: Reactor {
         let memberId = initialState.comment.memberId
         
         switch action {
+        case .didChangedInitalLayout:
+            return .just(.setEqualizerState(.inital))
+            
         case .prepareForReuse:
             return .just(.setEqualizerState(.inital))
             

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
@@ -21,7 +21,7 @@ final public class CommentCellReactor: Reactor {
         case fetchUserName
         case fetchProfileImage
         case didTapProfileButton
-        case didTapPlayButton
+        case didTapPlayButton(String)
         case prepareForReuse
     }
     
@@ -63,7 +63,24 @@ final public class CommentCellReactor: Reactor {
     // MARK: - Intializer
     
     public init(_ comment: PostCommentEntity) {
-        self.initialState = State(comment: comment)
+        self.initialState = State(audioId: comment.commentId, comment: comment)
+    }
+    
+    
+    public func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+        let didTappedPlayButtonMutation = provider.commentService.event
+            .flatMap(with: self) {
+                switch $1 {
+                case let .didTappedPlaybutton(commentId):
+                    let toggleState: BBEqualizerState = commentId == $0.currentState.comment.commentId ? .play : .inital
+                    return .concat(
+                        Observable<Mutation>.just(.setEqualizerState(toggleState))
+                    )
+                default:
+                    return .empty()
+                }
+            }
+        return Observable<Mutation>.merge(mutation, didTappedPlayButtonMutation)
     }
     
     
@@ -94,12 +111,11 @@ final public class CommentCellReactor: Reactor {
             
             return Observable<Mutation>.empty()
         case .didTapPlayButton:
-            let toggleState = currentState.equalizerState == .inital ? BBEqualizerState.play : .inital
             let audioId = currentState.comment.commentId
-            return .concat(
-                .just(.setEqualizerState(toggleState)),
-                .just(.setPlayAudioId(audioId))
-            )
+            
+            provider.commentService.didTappedPlayButton(with: audioId)
+            
+            return .empty()
         }
     }
     

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/Cell/CommentCellReactor.swift
@@ -72,10 +72,9 @@ final public class CommentCellReactor: Reactor {
             .flatMap(with: self) {
                 switch $1 {
                 case let .didTappedPlaybutton(commentId):
-                    let toggleState: BBEqualizerState = commentId == $0.currentState.comment.commentId ? .play : .inital
-                    return .concat(
-                        Observable<Mutation>.just(.setEqualizerState(toggleState))
-                    )
+                    let isCurrentComment = commentId == $0.currentState.comment.commentId
+                    let newEqualizerState: BBEqualizerState = isCurrentComment ? .play : .inital
+                    return Observable<Mutation>.just(.setEqualizerState(newEqualizerState))
                 default:
                     return .empty()
                 }
@@ -112,10 +111,12 @@ final public class CommentCellReactor: Reactor {
             return Observable<Mutation>.empty()
         case .didTapPlayButton:
             let audioId = currentState.comment.commentId
+            let isCurrentState = currentState.equalizerState == .inital
+            let currentEqualizerState: BBEqualizerState = isCurrentState ? .play : .inital
             
             provider.commentService.didTappedPlayButton(with: audioId)
             
-            return .empty()
+            return .just(.setEqualizerState(currentEqualizerState))
         }
     }
     

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
@@ -111,13 +111,25 @@ final public class CommentViewReactor: Reactor {
                     let body = CreateVoicePresignedURLRequest(imageName: fileName)
                     
                     return $0.voicePresignedURLUseCase.execute(postId: postId, body, mp4File: voiceCommentFile)
-                        .debug("✅ 음성 녹음 API를 요청합니다 \(self.postId) ✅")
-                        .flatMap { presingedURL -> Observable<Mutation> in
-                            let fileURL = self.convertFileURL(presingedURL.audioURL)
+                        .withUnretained(self)
+                        .flatMap { owner, presingedURL -> Observable<Mutation> in
+                            let fileURL = owner.convertFileURL(presingedURL.audioURL)
                             let commentBody = CreateVoiceRequest(fileUrl: fileURL)
-                            return self.createVoiceCommentUseCase.execute(postId: postId, body: commentBody).flatMap { comment -> Observable<Mutation> in
+                            return self.createVoiceCommentUseCase.execute(postId: postId, body: commentBody)
+                                .observe(on: RxScheduler.main)
+                                .flatMap { comment -> Observable<Mutation> in
                                 let reactor = CommentCellReactor(comment)
-                                return .just(.appendComment(reactor))
+                                
+                                if let count = owner.commentCount {
+                                    owner.provider.postGlobalState.renewalPostCommentCount(count + 1)
+                                }
+                                
+                                
+                                return .concat(
+                                    .just(.appendComment(reactor)),
+                                    .just(.setHiddenNoneCommentView(true)),
+                                    .just(.scrollTableToLast(true))
+                                )
                             }
                         }
                 default:
@@ -249,6 +261,7 @@ final public class CommentViewReactor: Reactor {
                         }
                         
                         $0.0.navigator.showCommentDeleteToast()
+                        print("❌ 텍스트 댓글 커멘트 카운트 입니다. \($0.0.commentCount) ❌")
                         if $0.0.commentCount == 0 + 1 {
                             return Observable<Mutation>.concat(
                                 Observable<Mutation>.just(.setHiddenNoneCommentView(false)),

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
@@ -20,7 +20,7 @@ final public class CommentViewReactor: Reactor {
     public enum Action {
         case fetchComment
         case createComment(String)
-        case deleteComment(String)
+        case deleteComment(String, String)
     }
     
     
@@ -71,6 +71,7 @@ final public class CommentViewReactor: Reactor {
     @Injected var fetchCommentUseCase: FetchCommentUseCaseProtocol
     @Injected var createCommentUseCase: CreateCommentUseCaseProtocol
     @Injected var deleteCommentUseCase: DeleteCommentUseCaseProtocol
+    @Injected var deleteVoiceCommentUseCase: DeleteVoiceCommentUseCaseProtocol
     @Injected var createVoiceCommentUseCase: CreateVoiceCommentUseCaseProtocol
     @Injected var voicePresignedURLUseCase: VoiceCommentPresignedURLUseCaseProtocol
     @Injected var provider: ServiceProviderProtocol
@@ -110,6 +111,7 @@ final public class CommentViewReactor: Reactor {
                     let body = CreateVoicePresignedURLRequest(imageName: fileName)
                     
                     return $0.voicePresignedURLUseCase.execute(postId: postId, body, mp4File: voiceCommentFile)
+                        .debug("✅ 음성 녹음 API를 요청합니다 \(self.postId) ✅")
                         .flatMap { presingedURL -> Observable<Mutation> in
                             let fileURL = self.convertFileURL(presingedURL.audioURL)
                             let commentBody = CreateVoiceRequest(fileUrl: fileURL)
@@ -118,6 +120,8 @@ final public class CommentViewReactor: Reactor {
                                 return .just(.appendComment(reactor))
                             }
                         }
+                default:
+                    return .empty()
                 }
             }
         return Observable<Mutation>.merge(mutation, commentMutation)
@@ -225,33 +229,61 @@ final public class CommentViewReactor: Reactor {
                         }
             )
             
-        case let .deleteComment(commentId):
-            return deleteCommentUseCase.execute(postId: postId, commentId: commentId)
-                .withUnretained(self)
-                .flatMap {
-                    guard
-                        let delete = $0.1, delete.success
-                    else {
+        case let .deleteComment(commentId, commentType):
+            switch commentType {
+            case "TEXT":
+                return deleteCommentUseCase.execute(postId: postId, commentId: commentId)
+                    .withUnretained(self)
+                    .flatMap {
+                        guard
+                            let delete = $0.1, delete.success
+                        else {
+                            Haptic.notification(type: .error)
+                            $0.0.navigator.showErrorToast()
+                            return Observable<Mutation>.empty()
+                        }
+                        
+                        // TODO: - Provider 바꾸기
+                        if let count = $0.0.commentCount {
+                            $0.0.provider.postGlobalState.renewalPostCommentCount(count - 1)
+                        }
+                        
+                        $0.0.navigator.showCommentDeleteToast()
+                        if $0.0.commentCount == 0 + 1 {
+                            return Observable<Mutation>.concat(
+                                Observable<Mutation>.just(.setHiddenNoneCommentView(false)),
+                                Observable<Mutation>.just(.deleteComment(commentId))
+                            )
+                        } else {
+                            return Observable<Mutation>.just(.deleteComment(commentId))
+                        }
+                    }
+            default:
+                return deleteVoiceCommentUseCase.execute(postId: postId, commentId: commentId)
+                    .withUnretained(self)
+                    .flatMap { owner, entity -> Observable<Mutation> in
+                        if let count = owner.commentCount {
+                            owner.provider.postGlobalState.renewalPostCommentCount(count - 1)
+                        }
+                        
+                        owner.navigator.showCommentDeleteToast()
+                        print("🥰 음성 댓글 커멘트 카운트 입니다. \(owner.commentCount) 🥰")
+                        if owner.commentCount == 0 + 1 {
+                            return .concat(
+                                .just(.setHiddenNoneCommentView(false)),
+                                .just(.deleteComment(commentId))
+                            )
+                        } else {
+                            print("😎 음성 댓글을 삭제하는 로직 입니다. \(owner.commentCount) 😎")
+                            return .just(.deleteComment(commentId))
+                        }
+                    }.catchError(with: self) { owner, _ in
                         Haptic.notification(type: .error)
-                        $0.0.navigator.showErrorToast()
-                        return Observable<Mutation>.empty()
+                        owner.navigator.showErrorToast()
+                        return .empty()
                     }
-                    
-                    // TODO: - Provider 바꾸기
-                    if let count = $0.0.commentCount {
-                        $0.0.provider.postGlobalState.renewalPostCommentCount(count - 1)
-                    }
-                    
-                    $0.0.navigator.showCommentDeleteToast()
-                    if $0.0.commentCount == 0 + 1 {
-                        return Observable<Mutation>.concat(
-                            Observable<Mutation>.just(.setHiddenNoneCommentView(false)),
-                            Observable<Mutation>.just(.deleteComment(commentId))
-                        )
-                    } else {
-                        return Observable<Mutation>.just(.deleteComment(commentId))
-                    }
-                }
+            }
+
         }
     }
     

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/Reactor/CommentViewReactor.swift
@@ -12,6 +12,7 @@ import Foundation
 
 import ReactorKit
 import RxSwift
+import Util
 
 final public class CommentViewReactor: Reactor {
     
@@ -123,14 +124,22 @@ final public class CommentViewReactor: Reactor {
                                 if let count = owner.commentCount {
                                     owner.provider.postGlobalState.renewalPostCommentCount(count + 1)
                                 }
-                                
-                                
                                 return .concat(
                                     .just(.appendComment(reactor)),
                                     .just(.setHiddenNoneCommentView(true)),
                                     .just(.scrollTableToLast(true))
                                 )
+                            }.catchError(with: self) {
+                                Haptic.notification(type: .error)
+                                BBLogManager.sendError(error: $1)
+                                $0.navigator.showCommentErrorToast($1.localizedDescription)
+                                return .empty()
                             }
+                        }.catchError(with: self) {
+                            Haptic.notification(type: .error)
+                            BBLogManager.sendError(error: $1)
+                            $0.navigator.showCommentErrorToast($1.localizedDescription)
+                            return .empty()
                         }
                 default:
                     return .empty()
@@ -261,7 +270,6 @@ final public class CommentViewReactor: Reactor {
                         }
                         
                         $0.0.navigator.showCommentDeleteToast()
-                        print("❌ 텍스트 댓글 커멘트 카운트 입니다. \($0.0.commentCount) ❌")
                         if $0.0.commentCount == 0 + 1 {
                             return Observable<Mutation>.concat(
                                 Observable<Mutation>.just(.setHiddenNoneCommentView(false)),
@@ -280,19 +288,18 @@ final public class CommentViewReactor: Reactor {
                         }
                         
                         owner.navigator.showCommentDeleteToast()
-                        print("🥰 음성 댓글 커멘트 카운트 입니다. \(owner.commentCount) 🥰")
                         if owner.commentCount == 0 + 1 {
                             return .concat(
                                 .just(.setHiddenNoneCommentView(false)),
                                 .just(.deleteComment(commentId))
                             )
                         } else {
-                            print("😎 음성 댓글을 삭제하는 로직 입니다. \(owner.commentCount) 😎")
                             return .just(.deleteComment(commentId))
                         }
-                    }.catchError(with: self) { owner, _ in
+                    }.catchError(with: self) {
                         Haptic.notification(type: .error)
-                        owner.navigator.showErrorToast()
+                        BBLogManager.sendError(error: $1)
+                        $0.navigator.showErrorToast()
                         return .empty()
                     }
             }

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -28,9 +28,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     private let createdAtLabel: BBLabel = BBLabel(.body2Regular, textColor: .gray500)
     private let commentEqualizerView: BBEqualizerView = BBEqualizerView(state: .inital)
     private let voicePlayButton: UIButton = UIButton(type: .custom)
+    private let voicePlayContainerView: UIView = UIView()
     private let voiceCotainerView: UIView = UIView()
     private let commentLabel: BBLabel = BBLabel(.body1Regular, textColor: .gray100)
-    private let playerManager: BBRecorderManager = BBRecorderManager()
+    public weak var playerManager: BBRecorderManager?
     
     
     // MARK: - Properties
@@ -39,6 +40,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     
     
     // MARK: - Helpers
+    deinit {
+        print("😆 커멘트 셀이 메모리에서 해체되는 것을 확인합니다. 😆")
+    }
+    
     
     public override func prepareForReuse() {
         super.prepareForReuse()
@@ -47,7 +52,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         createdAtLabel.text = ""
         profileImage.image = nil
         commentEqualizerView.resetEqualizerLayout()
-        playerManager.pauseAudioPlayback()
+        playerManager = nil
         disposeBag = DisposeBag()
     }
     
@@ -71,13 +76,20 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .bind(to: reactor.action)
         .disposed(by: disposeBag)
         
+        self.rx.deallocated
+            .bind(with: self, onNext: { owner, _ in
+                owner.commentEqualizerView.invalidateEqaulizerLayout()
+                owner.playerManager = nil
+            })
+            .disposed(by: disposeBag)
+        
         profileButton.rx.tap
             .throttle(RxInterval._300milliseconds, scheduler: RxScheduler.main)
             .map { Reactor.Action.didTapProfileButton }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
-        voicePlayButton.rx.tap
+        voicePlayContainerView.rx.tap
             .throttle(.milliseconds(300), scheduler: RxScheduler.main)
             .do { _ in Haptic.impact(style: .medium) }
             .withLatestFrom(reactor.state.map { $0.audioId })
@@ -140,6 +152,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .observe(on: ConcurrentDispatchQueueScheduler(qos: .background))
         .requestAudioFileDecibels { $0 }
         .observe(on: RxScheduler.main)
+        .catchError(with: self) {
+            $0.showErrorToast($1.localizedDescription)
+            return .empty()
+        }
         .bind(to: commentEqualizerView.rx.equalizerLevels)
         .disposed(by: disposeBag)
         
@@ -151,8 +167,30 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .filter { $0.0 == .inital && $0.1 == "VOICE" }
         .map { $0.2 }
         .requestAudioCurrentTime { $0 }
+        .catchError(with: self) {
+            $0.showErrorToast($1.localizedDescription)
+            return .empty()
+        }
         .observe(on: RxScheduler.main)
         .bind(to: commentEqualizerView.timerLabel.rx.text)
+        .disposed(by: disposeBag)
+        
+        
+        Observable.combineLatest(
+            reactor.pulse(\.$equalizerState),
+            reactor.state.map { $0.comment.commentType},
+            reactor.state.map { $0.comment.commentId}
+        )
+        .filter { $0.0 == .play && $0.1 == "VOICE" }
+        .map { $0.2 }
+        .requestAudioElapsedTime { $0 }
+        .distinctUntilChanged()
+        .observe(on: RxScheduler.main)
+        .catchError(with: self) {
+            $0.showErrorToast($1.localizedDescription)
+            return .empty()
+        }
+        .bind(to: commentEqualizerView.rx.elapsedTime)
         .disposed(by: disposeBag)
         
         Observable.combineLatest(
@@ -162,11 +200,17 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .willChangedAudioTime { $0 }
         .distinctUntilChanged()
         .observe(on: RxScheduler.main)
+        .take(until: rx.deallocated)
+        .catchError(with: self) {
+            $0.showErrorToast($1.localizedDescription)
+            return .empty()
+        }
         .bind(to: commentEqualizerView.timerLabel.rx.text)
         .disposed(by: disposeBag)
         
         reactor.state.map { $0.equalizerState }
             .map { $0 == .play }
+            .distinctUntilChanged()
             .bind(to: voicePlayButton.rx.isSelected)
             .disposed(by: disposeBag)
         
@@ -186,9 +230,9 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             let (state, audioId) = response
             switch state {
             case .inital:
-                owner.playerManager.pauseAudioPlayback()
+                owner.playerManager?.pauseAudioPlayback()
             case .play:
-                owner.playerManager.playAudio(from: audioId)
+                owner.playerManager?.playAudio(from: audioId)
             default:
                 break
             }
@@ -199,7 +243,8 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     
     public override func setupUI() {
         super.setupUI()
-        voiceCotainerView.addSubviews(commentEqualizerView, voicePlayButton)
+        voicePlayContainerView.addSubview(voicePlayButton)
+        voiceCotainerView.addSubviews(commentEqualizerView, voicePlayContainerView)
         profileBackground.addSubviews(profilePlaceholder, profileImage, profileButton)
         contentView.addSubviews(profileBackground, labelStack, commentLabel, voiceCotainerView)
         labelStack.addArrangedSubviews(nameLabel, createdAtLabel)
@@ -232,24 +277,29 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         }
         
         commentEqualizerView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.height.equalTo(40)
+            $0.centerY.equalToSuperview()
             $0.left.equalTo(voicePlayButton.snp.right).offset(16)
             $0.right.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview()
+        }
+        
+        voicePlayContainerView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.left.equalToSuperview().inset(2)
+            $0.size.height.equalTo(40)
+            $0.centerY.equalToSuperview()
         }
         
         voicePlayButton.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(14)
-            $0.left.equalToSuperview().inset(19)
-            $0.width.height.equalTo(11)
-            $0.centerY.equalToSuperview()
+            $0.size.equalTo(11)
+            $0.center.equalToSuperview()
         }
         
         voiceCotainerView.snp.makeConstraints {
             $0.top.equalTo(labelStack.snp.bottom).offset(8)
             $0.left.equalTo(labelStack)
             $0.right.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(16)
+            $0.bottom.equalToSuperview().offset(-16)
         }
         
         commentLabel.snp.makeConstraints {
@@ -265,6 +315,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         
         contentView.do {
             $0.backgroundColor = UIColor.bibbiBlack
+        }
+        
+        voiceCotainerView.do {
+            $0.backgroundColor = .clear
         }
         
         profileButton.do {
@@ -305,5 +359,19 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         commentLabel.do {
             $0.numberOfLines = 0
         }
+    }
+}
+
+
+private extension CommentCell {
+    func showErrorToast(_ descrption: String) {
+        let config = BBToastConfiguration(direction: .top(yOffset: 75))
+        let viewConfig = BBToastViewConfiguration(minWidth: 100)
+        BBToast.default(
+            image: DesignSystemAsset.warning.image,
+            title: descrption,
+            viewConfig: viewConfig,
+            config: config
+        ).show()
     }
 }

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -200,7 +200,6 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             reactor.pulse(\.$audioId)
         )
         .willChangedAudioTime { $0 }
-        .debug("😡 변경 되고 있는 녹음 시간 입니다. 😡")
         .observe(on: RxScheduler.main)
         .bind(to: commentEqualizerView.timerLabel.rx.text)
         .disposed(by: disposeBag)

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -41,11 +41,6 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     
     
     // MARK: - Helpers
-    deinit {
-        print("😆 커멘트 셀이 메모리에서 해체되는 것을 확인합니다. 😆")
-    }
-    
-    
     public override func prepareForReuse() {
         super.prepareForReuse()
         

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -11,6 +11,7 @@ import UIKit
 
 import ReactorKit
 import RxSwift
+import RxCocoa
 import SnapKit
 import Then
 
@@ -32,7 +33,7 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
     private let voiceCotainerView: UIView = UIView()
     private let commentLabel: BBLabel = BBLabel(.body1Regular, textColor: .gray100)
     public weak var playerManager: BBRecorderManager?
-    
+    private var hasErrorOccurred = false
     
     // MARK: - Properties
     
@@ -152,7 +153,10 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .observe(on: ConcurrentDispatchQueueScheduler(qos: .background))
         .requestAudioFileDecibels { $0 }
         .observe(on: RxScheduler.main)
+        .distinctUntilChanged()
         .catchError(with: self) {
+            guard !$0.hasErrorOccurred else { return .empty() }
+            $0.hasErrorOccurred = true
             $0.showErrorToast($1.localizedDescription)
             return .empty()
         }
@@ -167,9 +171,8 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .filter { $0.0 == .inital && $0.1 == "VOICE" }
         .map { $0.2 }
         .requestAudioCurrentTime { $0 }
-        .catchError(with: self) {
-            $0.showErrorToast($1.localizedDescription)
-            return .empty()
+        .catchError(with: self) { _, _ in
+            return .just("0:00")
         }
         .observe(on: RxScheduler.main)
         .bind(to: commentEqualizerView.timerLabel.rx.text)
@@ -186,9 +189,8 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .requestAudioElapsedTime { $0 }
         .distinctUntilChanged()
         .observe(on: RxScheduler.main)
-        .catchError(with: self) {
-            $0.showErrorToast($1.localizedDescription)
-            return .empty()
+        .catchError(with: self) { _,_ in
+            return .just(1.0)
         }
         .bind(to: commentEqualizerView.rx.elapsedTime)
         .disposed(by: disposeBag)
@@ -201,10 +203,6 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         .distinctUntilChanged()
         .observe(on: RxScheduler.main)
         .take(until: rx.deallocated)
-        .catchError(with: self) {
-            $0.showErrorToast($1.localizedDescription)
-            return .empty()
-        }
         .bind(to: commentEqualizerView.timerLabel.rx.text)
         .disposed(by: disposeBag)
         

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -80,7 +80,8 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         voicePlayButton.rx.tap
             .throttle(.milliseconds(300), scheduler: RxScheduler.main)
             .do { _ in Haptic.impact(style: .medium) }
-            .map { Reactor.Action.didTapPlayButton }
+            .withLatestFrom(reactor.state.map { $0.audioId })
+            .map { Reactor.Action.didTapPlayButton($0) }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -200,9 +200,8 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             reactor.pulse(\.$audioId)
         )
         .willChangedAudioTime { $0 }
-        .distinctUntilChanged()
+        .debug("😡 변경 되고 있는 녹음 시간 입니다. 😡")
         .observe(on: RxScheduler.main)
-        .take(until: rx.deallocated)
         .bind(to: commentEqualizerView.timerLabel.rx.text)
         .disposed(by: disposeBag)
         
@@ -216,6 +215,30 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
             .skip(1)
             .observe(on: RxScheduler.main)
             .bind(to: commentEqualizerView.rx.state)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map { $0.comment.commentType }
+            .bind(with: self) { owner, type in
+                switch type {
+                case "TEXT":
+                    owner.commentLabel.snp.makeConstraints {
+                        $0.top.equalTo(owner.labelStack.snp.bottom).offset(8)
+                        $0.leading.equalTo(owner.labelStack.snp.leading)
+                        $0.trailing.equalToSuperview().offset(-8)
+                        $0.bottom.equalToSuperview().offset(-10)
+                    }
+                case "VOICE":
+                    owner.voiceCotainerView.snp.makeConstraints {
+                        $0.top.equalTo(owner.labelStack.snp.bottom).offset(8)
+                        $0.left.equalTo(owner.labelStack)
+                        $0.right.equalToSuperview().inset(20)
+                        $0.bottom.equalToSuperview().offset(-16)
+                    }
+                default:
+                    break
+                }
+            }
             .disposed(by: disposeBag)
         
         Observable.combineLatest(
@@ -291,20 +314,6 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         voicePlayButton.snp.makeConstraints {
             $0.size.equalTo(11)
             $0.center.equalToSuperview()
-        }
-        
-        voiceCotainerView.snp.makeConstraints {
-            $0.top.equalTo(labelStack.snp.bottom).offset(8)
-            $0.left.equalTo(labelStack)
-            $0.right.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().offset(-16)
-        }
-        
-        commentLabel.snp.makeConstraints {
-            $0.top.equalTo(labelStack.snp.bottom).offset(8)
-            $0.leading.equalTo(labelStack.snp.leading)
-            $0.trailing.equalToSuperview().offset(-8)
-            $0.bottom.equalToSuperview().offset(-10)
         }
     }
     

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/View/Cell/CommentCell.swift
@@ -201,7 +201,13 @@ final public class CommentCell: BaseTableViewCell<CommentCellReactor> {
         )
         .willChangedAudioTime { $0 }
         .observe(on: RxScheduler.main)
-        .bind(to: commentEqualizerView.timerLabel.rx.text)
+        .bind(with: self) { owner, timer in
+            if timer == "0:00" {
+                owner.reactor?.action.onNext(.didChangedInitalLayout)
+                owner.commentEqualizerView.resetEqualizerLayout()
+            }
+            owner.commentEqualizerView.timerLabel.text = timer
+        }
         .disposed(by: disposeBag)
         
         reactor.state.map { $0.equalizerState }

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/ViewController/CommentViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/ViewController/CommentViewController.swift
@@ -69,7 +69,12 @@ final public class CommentViewController: ReactorViewController<CommentViewReact
         // TODO: - 코드 리팩토링하기
         commentTableView.rx.itemDeleted
             .withUnretained(self)
-            .bind { $0.0.reactor?.action.onNext(.deleteComment($0.0.dataSource[$0.1].currentState.comment.commentId)) }
+            .bind { $0.0.reactor?.action.onNext(
+                .deleteComment(
+                    $0.0.dataSource[$0.1].currentState.comment.commentId,
+                    $0.0.dataSource[$0.1].currentState.comment.commentType
+                ))
+            }
             .disposed(by: disposeBag)
         
         recorderManager.rx.requestMicrophonePermission

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/ViewController/CommentViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Comment/ViewController/CommentViewController.swift
@@ -225,11 +225,12 @@ extension CommentViewController {
     }
     
     private func prepareDatasource() -> RxDataSource {
-        let dataSource = RxDataSource { dataSource, tableView, indexPath, reactor in
+        let dataSource = RxDataSource { [weak self] dataSource, tableView, indexPath, reactor in
             let cell = tableView.dequeueReusableCell(
                 withIdentifier: CommentCell.id
             ) as! CommentCell
             cell.reactor = reactor
+            cell.playerManager = self?.recorderManager
             return cell
         }
         dataSource.canEditRowAtIndexPath = {

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBProgressHUD/BBProgressHUDConfiguration.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBProgressHUD/BBProgressHUDConfiguration.swift
@@ -16,7 +16,7 @@ public struct BBProgressHUDConfiguration {
     public let exitingAnimation: BBProgressHUD.Animation
     public let background: BBProgressHUD.Background
         
-    public let view: UIView?
+    public weak var view: UIView?
     
     public let allowProgressHUDOverlap: Bool
 

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBRecorder/BBEqualizerView.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBRecorder/BBEqualizerView.swift
@@ -24,8 +24,9 @@ public final class BBEqualizerView: UIView {
     }
     public var displayLink: CADisplayLink?
     public let timerLabel: BBLabel = BBLabel(.body1Regular)
-    private var lastUpdateTime: Date = Date()
+    private var lastUpdateTime: Date?
     public var equalizerIndex: Int = 0
+    public var elapsedTime: TimeInterval = 0.0
     public var equalizerLevels: [CGFloat] = [] {
         didSet { setNeedsDisplay() }
     }
@@ -164,6 +165,7 @@ public final class BBEqualizerView: UIView {
         equalizerLevels = []
         equalizerIndex = 0
         state = .inital
+        lastUpdateTime = nil
     }
     
     
@@ -171,12 +173,46 @@ public final class BBEqualizerView: UIView {
     private func didUpdateEqaulizerLevel() {
         let currentTime = Date()
         let maxDotCount = 30
-        if currentTime.timeIntervalSince(lastUpdateTime) >= 1.0 {
-            lastUpdateTime = currentTime
-            equalizerIndex = min(equalizerIndex + 1, maxDotCount)
+        switch state {
+        case .record:
+            if let lastTime = lastUpdateTime {
+                if currentTime.timeIntervalSince(lastTime) >= 1.0 {
+                    lastUpdateTime = currentTime
+                    equalizerIndex = min(equalizerIndex + 1, maxDotCount)
+                }
+            } else {
+                lastUpdateTime = Date()
+            }
+            equalizerLevels = Array(equalizerLevels.prefix(maxDotCount))
+            setNeedsDisplay()
+        case .play:
+            if let lastTime = lastUpdateTime {
+                let elapsedTimeSinceStart = currentTime.timeIntervalSince(lastTime)
+                if elapsedTimeSinceStart >= elapsedTime {
+                    equalizerIndex = maxDotCount
+                    displayLink?.invalidate()
+                    displayLink = nil
+                    setNeedsDisplay()
+                    return
+                }
+                let progress = elapsedTimeSinceStart / elapsedTime
+                let targetIndex = Int(progress * Double(maxDotCount))
+                        
+                if targetIndex > equalizerIndex {
+                    equalizerIndex = targetIndex
+                    setNeedsDisplay()
+                }
+            } else {
+                lastUpdateTime = Date()
+            }
+
+            while equalizerLevels.count < maxDotCount {
+                equalizerLevels.append(CGFloat.random(in: 0.5...1.0))
+            }
+            equalizerLevels = Array(equalizerLevels.prefix(maxDotCount))
+        default:
+            break
         }
-        equalizerLevels = Array(equalizerLevels.prefix(maxDotCount))
-        setNeedsDisplay()
     }
     
 }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBRecorder/BBRecorderManager.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBRecorder/BBRecorderManager.swift
@@ -22,6 +22,12 @@ public class BBRecorderManager: NSObject {
         self.audioEngine = AVAudioEngine()
         self.inputNode = audioEngine.inputNode
         super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleAudioSessionInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
         start()
     }
 
@@ -68,6 +74,31 @@ public class BBRecorderManager: NSObject {
             audioPlayer?.play()
         } catch {
             print(error.localizedDescription)
+        }
+    }
+    
+    @objc private func handleAudioSessionInterruption(_ notification: Notification) {
+        guard let userInfo = notification.userInfo else { return }
+        if let interruptionValue = userInfo[AVAudioSessionInterruptionTypeKey] as? NSNumber,
+           let interruptionType = AVAudioSession.InterruptionType(rawValue: UInt(interruptionValue.intValue)) {
+            
+            switch interruptionType {
+            case .began:
+                audioPlayer?.pause()
+                recorderCore.audioRecorder.pause()
+                break
+            case .ended:
+                if recorderCore.audioRecorder.isRecording {
+                    recorderCore.audioRecorder.record()
+                }
+                if let audioPlayer = audioPlayer, !audioPlayer.isPlaying {
+                    audioPlayer.play()
+                }
+                break
+            @unknown default:
+                break
+            }
+            
         }
     }
 }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/BBAPIWorker.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/BBAPIWorker.swift
@@ -51,12 +51,12 @@ extension APIWorkerError: LocalizedError {
         switch self {
         case .noResponse:
             return "서버로부터 받아온 데이터가 없습니다."
-        case .unknown(let error):
-            return "알 수 없는 오류가 발생했습니다 [이유: \(error.localizedDescription)]"
+        case .unknown:
+            return "알 수 없는 오류가 발생했습니다."
         case .parsing:
             return "데이터를 처리하는 중에 문제가 발생했습니다. 서버에서 반환된 데이터가 예상한 형식과 맞지 않습니다."
-        case .networkFailure(let reason):
-            return "네트워크 통신 중 오류가 발생했습니다. [이유: \(reason.localizedDescription)]"
+        case .networkFailure:
+            return "네트워크 통신 중 오류가 발생했습니다."
         }
     }
 }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBServices/CommentService.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBServices/CommentService.swift
@@ -12,6 +12,7 @@ import RxSwift
 
 public enum CommentEvent {
     case didReceiveVoiceCommentFile(_ file: Data)
+    case didTappedPlaybutton(_ commentId: String)
 }
 
 public protocol CommentServiceType {
@@ -19,6 +20,8 @@ public protocol CommentServiceType {
     
     @discardableResult
     func didReceiveVoiceCommentFile(_ file: Data) -> Observable<Data>
+    @discardableResult
+    func didTappedPlayButton(with commentId: String) -> Observable<String>
 }
 
 public final class CommentService: BaseService, CommentServiceType {
@@ -28,6 +31,11 @@ public final class CommentService: BaseService, CommentServiceType {
     public func didReceiveVoiceCommentFile(_ file: Data) -> RxSwift.Observable<Data> {
         event.onNext(.didReceiveVoiceCommentFile(file))
         return Observable<Data>.just(file)
+    }
+    
+    public func didTappedPlayButton(with commentId: String) -> Observable<String> {
+        event.onNext(.didTappedPlaybutton(commentId))
+        return Observable<String>.just(commentId)
     }
     
     

--- a/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
@@ -204,7 +204,7 @@ public extension ObservableType {
                 
                 let timer = Observable<Int>
                     .interval(.seconds(1), scheduler: RxScheduler.main)
-                    .flatMap { times -> Observable<String> in
+                    .flatMapLatest { times -> Observable<String> in
                         let currentTime = max(0, duration - Double(times))
                         let playerMinutes = Int(currentTime) / 60
                         let playerSeconds = Int(currentTime) % 60
@@ -228,14 +228,15 @@ public extension ObservableType {
     }
     
     func requestAudioElapsedTime(_ transform: @escaping (Element) -> String) -> Observable<TimeInterval> {
-        return flatMap { element -> Observable<TimeInterval> in
+        return flatMapLatest { element -> Observable<TimeInterval> in
             let fileIdKey = transform(element)
             guard let filePath = BBDiskCacheStorage<String, URL>.read(forkey: fileIdKey) else {
                 return .error(BBDiskCacheStroageError.cannotCreateCacheFile)
             }
             
             let asset = AVURLAsset(url: filePath)
-            let elapsedTime: TimeInterval = CMTimeGetSeconds(asset.duration)
+            let elapsedTime: TimeInterval = round(CMTimeGetSeconds(asset.duration))
+            
             guard elapsedTime.isFinite || !elapsedTime.isZero else {
                 return .error(NSError(domain: "❌잘못된 음성 녹음 파일 입니다.❌", code: -1))
             }

--- a/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
@@ -227,6 +227,23 @@ public extension ObservableType {
         }
     }
     
+    func requestAudioElapsedTime(_ transform: @escaping (Element) -> String) -> Observable<TimeInterval> {
+        return flatMap { element -> Observable<TimeInterval> in
+            let fileIdKey = transform(element)
+            guard let filePath = BBDiskCacheStorage<String, URL>.read(forkey: fileIdKey) else {
+                return .error(BBDiskCacheStroageError.cannotCreateCacheFile)
+            }
+            
+            let asset = AVURLAsset(url: filePath)
+            let elapsedTime: TimeInterval = CMTimeGetSeconds(asset.duration)
+            guard elapsedTime.isFinite || !elapsedTime.isZero else {
+                return .error(NSError(domain: "❌잘못된 음성 녹음 파일 입니다.❌", code: -1))
+            }
+            
+            return .just(elapsedTime)
+        }
+    }
+    
     
     func requestAudioCurrentTime(_ transform: @escaping (Element) -> String) -> Observable<String> {
         return flatMap { element -> Observable<String> in
@@ -254,6 +271,7 @@ public extension ObservableType {
         return flatMapLatest { element -> Observable<[CGFloat]> in
             let fileIDKey = transform(element)
             var decibels: [CGFloat] = []
+            print("✅ 요청한 데시벨의 키값을 조회합니다 \(fileIDKey) ✅")
             guard let filePath = BBDiskCacheStorage<String, URL>.read(forkey: fileIDKey) else {
                 return .error(BBDiskCacheStroageError.cannotCreateCacheFile)
             }

--- a/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Reactive+Ext.swift
@@ -272,7 +272,6 @@ public extension ObservableType {
         return flatMapLatest { element -> Observable<[CGFloat]> in
             let fileIDKey = transform(element)
             var decibels: [CGFloat] = []
-            print("✅ 요청한 데시벨의 키값을 조회합니다 \(fileIDKey) ✅")
             guard let filePath = BBDiskCacheStorage<String, URL>.read(forkey: fileIDKey) else {
                 return .error(BBDiskCacheStroageError.cannotCreateCacheFile)
             }

--- a/14th-team5-iOS/Core/Sources/Extensions/Task+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Task+Ext.swift
@@ -1,0 +1,22 @@
+//
+//  Task+Ext.swift
+//  Core
+//
+//  Created by 김도현 on 2/18/25.
+//
+
+import Foundation
+
+
+public extension Task where Failure == Error {
+    static func synchronous(priority: TaskPriority? = nil, operation: @escaping @Sendable () async throws -> Success) {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        Task(priority: priority) {
+            defer { semaphore.signal() }
+            return try await operation()
+        }
+
+        semaphore.wait()
+    }
+}

--- a/14th-team5-iOS/Data/Sources/Repositories/CommentRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Repositories/CommentRepository.swift
@@ -30,7 +30,7 @@ extension CommentRepository {
             .do(onNext: { response in
                 _ = response.results.map { dto in
                     if dto.commentType == "VOICE" {
-                        Task {
+                        Task.synchronous {
                             do {
                                 guard let voiceURL = URL(string: dto.comment),
                                       let bufferData = try? Data(contentsOf: voiceURL) else { return }

--- a/14th-team5-iOS/Data/Sources/Repositories/VoiceRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Repositories/VoiceRepository.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Domain
 import Core
+import Util
 
 import RxSwift
 
@@ -23,26 +24,32 @@ extension VoiceRepository: VoiceRepositoryProtocol {
     
     public func createVoiceComment(postId: String, body: CreateVoiceRequest) -> Observable<PostCommentEntity> {
         let body = CreateVoiceCommentRequestDTO(fileUrl: body.fileUrl)
+        
         return voiceApiWorker.createVoiceComment(postId: postId, body: body)
-            .do(onNext: { response in
+            .flatMap { response -> Observable<PostCommentEntity> in
                 if response.commentType == "VOICE" {
-                    Task {
-                        do {
-                            guard let voiceURL = URL(string: response.comment),
-                                  let bufferData = try? Data(contentsOf: voiceURL) else {
-                                return
+                    return Observable.create { observer in
+                        Task {
+                            do {
+                                guard let voiceURL = URL(string: response.comment),
+                                      let bufferData = try? Data(contentsOf: voiceURL) else {
+                                    return
+                                }
+                                try await self.voiceStorage.setObject(bufferData, for: response.commentId)
+                                observer.onNext(response.toDomain())
+                                observer.onCompleted()
+                            } catch {
+                                BBLogManager.sendError(error: error)
+                                observer.onError(error)
                             }
-                            try await self.voiceStorage.setObject(bufferData, for: response.commentId)
-                        } catch {
-                            print("😳음성 녹음 URL을 저장하는데 실패 했습니다.")
-                            print(error.localizedDescription)
                         }
+                        return Disposables.create()
                     }
                 }
-            })
-            .map { $0.toDomain() }
-        
+                return .just(response.toDomain())
+            }
     }
+
     
     public func createVoicePresignedURL(postId: String, body: CreateVoicePresignedURLRequest) -> Observable<VoicePresignedEntity> {
         let body = CreateVoicePresignedURLRequestDTO(imageName: body.imageName)
@@ -52,6 +59,15 @@ extension VoiceRepository: VoiceRepositoryProtocol {
     
     public func deleteVoiceComment(postId: String, commentId: String) -> Observable<DeleteVoiceCommentEntity> {
         return voiceApiWorker.deleteVoiceComment(postId: postId, commentId: commentId)
+            .do(onNext: { response in
+                if response.success {
+                    do {
+                        try self.voiceStorage.removeObject(forKey: commentId)
+                    } catch {
+                        BBLogManager.sendError(error: error)
+                    }
+                }
+            })
             .map { $0.toDomain() }
     }
     

--- a/14th-team5-iOS/Domain/Sources/UseCases/Voice/DeleteVoiceCommentUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/Voice/DeleteVoiceCommentUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  DeleteVoiceCommentUseCase.swift
+//  Domain
+//
+//  Created by 김도현 on 2/9/25.
+//
+
+import Foundation
+
+import RxSwift
+
+public protocol DeleteVoiceCommentUseCaseProtocol {
+    func execute(postId: String, commentId: String) -> Observable<DeleteVoiceCommentEntity>
+}
+
+public final class DeleteVoiceCommentUseCase: DeleteVoiceCommentUseCaseProtocol {
+    private let voiceCommentRepository: VoiceRepositoryProtocol
+    
+    
+    public init(voiceCommentRepository: VoiceRepositoryProtocol) {
+        self.voiceCommentRepository = voiceCommentRepository
+    }
+    
+    public func execute(postId: String, commentId: String) -> Observable<DeleteVoiceCommentEntity> {
+        return voiceCommentRepository.deleteVoiceComment(postId: postId, commentId: commentId)
+    }
+}

--- a/14th-team5-iOS/Domain/Sources/UseCases/Voice/VoiceCommentPresignedURLUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/Voice/VoiceCommentPresignedURLUseCase.swift
@@ -32,7 +32,6 @@ public final class VoiceCommentPresignedURLUseCase: VoiceCommentPresignedURLUseC
                     return .error(BBUploadError.invalidServerResponse)
                 }
                 return self.voiceCommentRepository.uploadMediaToS3(presignedURL.audioURL, mp4File: mp4File).flatMap { isSuccess -> Observable<VoicePresignedEntity> in
-                    print("VOICE COMMENT UPLOAD SUCCESS: \(isSuccess)")
                     if isSuccess {
                         return .just(presignedURL)
                     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,12 +71,12 @@ platform :ios do
 
 
     increment_build_number(
-      xcodeproj: "14th-team5-iOS/App/App.xcodeproj",
+      xcodeproj: "14th-team5-iOS/Bibbi/Bibbi.xcodeproj",
       build_number: new_build_number
     )
 
     update_project_team(
-      path: "14th-team5-iOS/App/App.xcodeproj",
+      path: "14th-team5-iOS/Bibbi/Bibbi.xcodeproj",
       teamid: "#{TEAM_ID}"
     )
 
@@ -159,12 +159,12 @@ platform :ios do
 
 
     increment_build_number(
-      xcodeproj: "14th-team5-iOS/App/App.xcodeproj",
+      xcodeproj: "14th-team5-iOS/Bibbi/Bibbi.xcodeproj",
       build_number: new_build_number
     )
 
     update_project_team(
-      path: "14th-team5-iOS/App/App.xcodeproj",
+      path: "14th-team5-iOS/Bibbi/Bibbi.xcodeproj",
       teamid: "#{TEAM_ID}"
     )
 


### PR DESCRIPTION
## 🔵PR을 올리기 전 아래 사항을 확인해주세요.
- 구현한 로직과 기능이 올바르게 작동되는지 충분히 테스트해주세요.
- 코드의 성능이나 메모리 효율성이 적절하게 고려되었는지, 불필요한 코드가 없는지 검토해주세요.
- 이번 PR에서 구현된 주요 기능이나 해결된 문제에 대해 자세히 서술해주세요.
(위 내용은 지워주세요)



## 😽개요

* `BBEqualizerView` 상태 값에 따라 UpdateLayout 분기 처리 로직 추가
* `음성 댓글 삭제` 관련 비즈니스 로직 코드 추가
* `CommentCell` 내부 Error Handling 로직 코드 추가
* `BBRecorderManager` 내부 interrupt Handling 노티피케이션 코드 추가
* `BBProgressHUDConfiguration` 순환 참조 이슈 수정

## 🛠️작업 내용

### 음성 댓글 삭제 비즈니스 로직 추가

* 음성 댓글 삭제 비즈니스 로직을 추가했습니다. 음성 댓글 삭제 비즈니스 로직은 기존 텍스트 댓글 비즈니스 로직과 동일하게 가져갔습니다.

| 이미지① |
| :----: |
| |


### BBRecorderManager interrupt Handling 노티피케이션 코드 추가

* 사용자가 음성 녹음 중 혹은 오디오 재생 중일 때 전화가 오거나, siri가 켜지는 (`interrupt`) 현상이 발생하면 녹음을 일시 중지 및 오디오를 일시 중지하도록 코드 추가하였습니다.
```swift
    @objc private func handleAudioSessionInterruption(_ notification: Notification) {
        guard let userInfo = notification.userInfo else { return }
        if let interruptionValue = userInfo[AVAudioSessionInterruptionTypeKey] as? NSNumber,
           let interruptionType = AVAudioSession.InterruptionType(rawValue: UInt(interruptionValue.intValue)) {
            
            switch interruptionType {
            case .began:
                audioPlayer?.pause()
                recorderCore.audioRecorder.pause()
                break
            case .ended:
                if recorderCore.audioRecorder.isRecording {
                    recorderCore.audioRecorder.record()
                }
                if let audioPlayer = audioPlayer, !audioPlayer.isPlaying {
                    audioPlayer.play()
                }
                break
            @unknown default:
                break
            }
            
        }
    }
```


### BBProgressHUDConfiguration 순환 참조 이슈 수정
*  `CommentTableView` 가 사라졌는데도 불구하고 `deinit` 호출이 안돼서 확인을 해봤더니 `BBProgressHUDConfiguration` 내에 선언되어 있던 `view`와 TableView가 강하게 참조하고 있어서 강한 참조가 발생하여 `weak` 키워드를 추가하였습니다.
* BBProgressHUD 인스턴스를 보유하고 있는 CommentTableView가 CommentTableView를 강하게 참조하고 있는 BBProgressHUDConfiguration의 config를 파라메터로 전달 하면서 순환 참조가 발생하게 된거입니다.

```swift
/// CommentTableView
    private lazy var progressHud: BBProgressHUD = {
        let config = BBProgressHUDConfiguration(attachedTo: self) <-- CommentTableView가 View를 강하게 참조
        let viewConfig = BBProgressHUDViewConfiguration(
            offsetFromCenterY: -50,
            backgroundColor: UIColor.clear
        )
        let hud = BBProgressHUD.lottie(
            .airplane,
            title: "열심히 불러오는 중..",
            titleFontStyle: .body1Regular,
            titleColor: .gray400,
            viewConfig: viewConfig,
            config: config <-- BBProgressHUDConfiguration(강한 참조를 하고 있는 인스턴스를 전달)
        )
        return hud
    }()


     /// 수정 전
    public struct BBProgressHUDConfiguration {
      public var view: UIView?     
     }
    
    /// 수정 후
    public struct BBProgressHUDConfiguration {
        public weak var view: UIView?     
    }
```


## 🟡차후 계획 (Optional)

* (작업한 코드가 추후 우리 프로젝트에 어떤 영향을 끼칠지, 앞으로 PR계획을 설명해주세요)


## 🗾이미지 (Optional)

| 이미지① |
| :----: |
| |


## ✅테스트 케이스

* `FileManager` 에 있는 녹음 URL을 잘 가져오는지 확인해용
* 음성 댓글이 삭제 잘 되는지 확인해요
* 디바이스 환경별로 레이아웃이 이상 없는지 확인해요

---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

