### PR TITLE
feat: navigation bar scale

### DIFF
--- a/14th-team5-iOS/Bibbi/Sources/Application/Router/PostDeepLink.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/Router/PostDeepLink.swift
@@ -27,15 +27,11 @@ final class PostDeepLink: DeepLinkProtocol {
         queryParams: [URLQueryItem]?
     ) {
         guard pathComponents.count >= 3,
-              let date = queryParams?.first(where: { $0.name == "dateOfPost" })?.value,
+              let _ = queryParams?.first(where: { $0.name == "dateOfPost" })?.value,
               let isComment = queryParams?.first(where: { $0.name == "openComment" })?.value else {
             return
         }
-//        
-//        let postId = pathComponents[2]
-//        let isToday = (date == "hi")
-//        let hasComment = (isComment == "true")
-//        
+        
         type = .openTodayPost(pathComponents[2])
     }
     

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Calendar/ViewController/MonthlyCalendarViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Calendar/ViewController/MonthlyCalendarViewController.swift
@@ -84,7 +84,7 @@ public final class MonthlyCalendarViewController: BBNavigationViewController<Mon
         navigationBar.do {
             $0.navigationTitle = "추억 캘린더"
             $0.leftBarButtonItem = .arrowLeft
-            $0.rightBarButtonItem = nil
+            $0.rightBarRightButtonItem = nil
         }
         
         collectionView.do {

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Home/ViewControllers/MainViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Home/ViewControllers/MainViewController.swift
@@ -112,7 +112,7 @@ final class MainViewController: BBNavigationViewController<MainViewReactor>, UIC
         navigationBar.do {
             $0.leftBarButtonItem = .person(new: false)
             $0.rightBarLeftButtonItem = .alarm
-            $0.rightBarButtonItem = .calendar
+            $0.rightBarRightButtonItem = .calendar
         }
         
         contributorView.do {

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Management/ViewController/FamilyNameSettingViewController.swift
@@ -254,7 +254,7 @@ extension FamilyNameSettingViewController {
     
     private func updateNavigationBarLayout(isUpdate: Bool) {
         navigationBar.leftBarButtonItem = .arrowLeft
-        navigationBar.rightBarButtonItem = isUpdate == true ? .none : .refresh
+        navigationBar.rightBarRightButtonItem = isUpdate == true ? .none : .refresh
     }
 }
 

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Management/ViewController/ManagementViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Management/ViewController/ManagementViewController.swift
@@ -171,7 +171,7 @@ public final class ManagementViewController: BBNavigationViewController<Manageme
             $0.navigationTitle = "가족"
             $0.navigationTitleFontStyle = .head2Bold
             $0.leftBarButtonItem = .arrowLeft
-            $0.rightBarButtonItem = .setting
+            $0.rightBarRightButtonItem = .setting
          }
         
         divider.do {

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/PostDetail/ViewControllers/PostViewController.swift
@@ -69,7 +69,7 @@ final class PostViewController: BaseViewController<PostReactor> {
         
         reactor.state.map { $0.selectedIndex }
             .compactMap { $0 }
-            .observe(on: MainScheduler.instance)
+            .observe(on: MainScheduler.asyncInstance)
             .withUnretained(self)
             .bind(onNext: {
                 guard reactor.currentState.originPostLists.items.count > 1 else { return }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBNavigationBar/BBNavigationBar.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBNavigationBar/BBNavigationBar.swift
@@ -25,10 +25,9 @@ public class BBNavigationBar: UIView {
     
     private let leftBarButton = BBNavigationBarButton()
     
-    private let rightBarStackView = UIStackView()
     private let rightBarLeftButton = BBNavigationBarButton()
     /// Navigation의 RightBar의 기본적인 Button, 2개 사용해야 할 경우 rightBarLeftButton 같이 사용해주세요.
-    private let rightBarButton = BBNavigationBarButton()
+    private let rightBarRightButton = BBNavigationBarButton()
     
     private let newMarkImageView = UIImageView()
     
@@ -83,10 +82,10 @@ public class BBNavigationBar: UIView {
     }
     
     /// 오른쪽 버튼의 스타일을 설정합니다.
-    public var rightBarButtonItem: BBNavigationButtonStyle? {
+    public var rightBarRightButtonItem: BBNavigationButtonStyle? {
         didSet {
-            setupButtonImage(rightBarButton, type: rightBarButtonItem)
-            setupButtonBackground(rightBarButton, type: rightBarButtonItem)
+            setupButtonImage(rightBarRightButton, type: rightBarRightButtonItem)
+            setupButtonBackground(rightBarRightButton, type: rightBarRightButtonItem)
         }
     }
     
@@ -143,7 +142,7 @@ public class BBNavigationBar: UIView {
     public var rightBarButtonItemTintColor: UIColor = UIColor.gray300 {
         didSet {
             rightBarLeftButton.tintColor = rightBarButtonItemTintColor
-            rightBarButton.tintColor = rightBarButtonItemTintColor
+            rightBarRightButton.tintColor = rightBarButtonItemTintColor
         }
     }
     
@@ -159,10 +158,9 @@ public class BBNavigationBar: UIView {
     /// 오른쪽 버튼이 leading으로부터 얼마나 떨어져 있는지 설정합니다.
     public var rightBarButtonItemYOffset: CGFloat = 0.0 {
         didSet {
-            rightBarStackView.snp.updateConstraints {
+            rightBarRightButton.snp.updateConstraints {
                 $0.trailing.equalTo(rightBarButtonItemYOffset)
             }
-            rightBarButton.layoutIfNeeded()
         }
     }
     
@@ -195,11 +193,11 @@ public class BBNavigationBar: UIView {
     private func setupUI() {
         addSubview(containerView)
         containerView.addSubviews(
-            leftBarButton, navigationImageView, navigationTitleLabel, rightBarStackView
+            leftBarButton, navigationImageView, navigationTitleLabel,
+            rightBarLeftButton, rightBarRightButton
         )
         
         leftBarButton.addSubview(newMarkImageView)
-        rightBarStackView.addArrangedSubviews(rightBarLeftButton, rightBarButton)
     }
     
     private func setupAutolayout() {
@@ -223,10 +221,17 @@ public class BBNavigationBar: UIView {
             $0.width.height.equalTo(52)
         }
         
-        rightBarStackView.snp.makeConstraints {
+        rightBarRightButton.snp.makeConstraints {
             $0.trailing.equalTo(0)
             $0.centerY.equalTo(self.snp.centerY)
-            $0.height.equalTo(52)
+            $0.width.height.equalTo(52)
+        }
+        
+        
+        rightBarLeftButton.snp.makeConstraints {
+            $0.trailing.equalTo(rightBarRightButton.snp.leading)
+            $0.centerY.equalTo(self.snp.centerY)
+            $0.width.height.equalTo(52)
         }
 
         newMarkImageView.snp.makeConstraints {
@@ -253,11 +258,6 @@ public class BBNavigationBar: UIView {
             
         }
         
-        rightBarStackView.do {
-            $0.spacing = 12
-            $0.distribution = .fillEqually
-        }
-        
         rightBarLeftButton.do {
             $0.addTarget(
                 self,
@@ -266,10 +266,10 @@ public class BBNavigationBar: UIView {
             )
         }
         
-        rightBarButton.do {
+        rightBarRightButton.do {
             $0.addTarget(
                 self,
-                action: #selector(didTapRightButton),
+                action: #selector(didTapRightBarRightButton),
                 for: .touchUpInside
             )
         }
@@ -390,7 +390,7 @@ extension BBNavigationBar {
         self.leftBarButtonItemScale = leftBarButtonItemScale
         self.leftBarButtonItemYOffset = leftBarButtonYOffset
         
-        self.rightBarButtonItem = rightBarButtonItem
+        self.rightBarRightButtonItem = rightBarButtonItem
         self.rightBarButtonItemTintColor = rightBarButtonTint
         self.rightBarButtonItemScale = rightBarButtonItemScale
         self.rightBarButtonItemYOffset = rightBarButtonYOffset
@@ -413,7 +413,11 @@ extension BBNavigationBar {
     }
 
     private func setupRightButtonImageScale(_ scale: CGFloat) {
-        rightBarButton.imageView?.layer.transform = CATransform3DMakeScale(
+        rightBarLeftButton.imageView?.layer.transform = CATransform3DMakeScale(
+            scale, scale, scale
+        )
+        
+        rightBarRightButton.imageView?.layer.transform = CATransform3DMakeScale(
             scale, scale, scale
         )
     }
@@ -453,7 +457,7 @@ extension BBNavigationBar {
         delegate?.navigationBar?(button, didTapRightBarLeftButton: event)
     }
 
-    @objc func didTapRightButton(_ button: UIButton, event: UIButton.Event) {
+    @objc func didTapRightBarRightButton(_ button: UIButton, event: UIButton.Event) {
         guard let _ = button.currentImage else { return }
         delegate?.navigationBar?(button, didTapRightBarButton: event)
     }


### PR DESCRIPTION

## 😽개요

## 🛠️작업 내용

### 네비게이션 바 버튼의 이미지 스케일을 수정합니다.
기존 스택ㅂ에서 버튼의 이미지 스케일이 조정이 되고 있지 않아 이부분을 수정하였습니다.

| 이미지① |
| :----: |
|<img src="https://github.com/user-attachments/assets/6b08b317-5da6-4820-85aa-455e04cbcb08" width="350" /> |

