### PR TITLE
알림 화면을 개선해요

### DIFF
--- a/14th-team5-iOS/Bibbi/Sources/Application/Router/DDeepLinkManager.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/Router/DDeepLinkManager.swift
@@ -7,18 +7,13 @@ final class DeepLinkHandler {
     var deepLink: DeepLinkProtocol?
     
     init(urlString: String) {
-        guard let url = URL(string: urlString) else {
+        let urlHandler = URLHandler(urlString: urlString)
+        
+        guard let pathComponents = urlHandler.getPathComponents(),
+            let queryParams = urlHandler.getQueryItems() else {
             deepLink = nil
             return
         }
-        
-        let pathComponents = url.pathComponents
-            .filter { !$0.isEmpty && $0 != "/" }
-        
-        let queryParams = URLComponents(
-            url: url,
-            resolvingAgainstBaseURL: false
-        )?.queryItems
         
         switch pathComponents.first?.lowercased() {
         case "main":
@@ -46,9 +41,11 @@ final class DeepLinkHandler {
             deepLink = nil
         }
     }
-    
+}
+
+extension DeepLinkHandler {
     /// DeeplinkManager 인스턴스를 만들고 execute문을 실행하면 딥링크 처리 후 화면 이동합니다.
-    func execute() {
+    public func execute() {
         do {
             guard let deepLink else {
                 throw DeepLinkError.notFound
@@ -60,54 +57,5 @@ final class DeepLinkHandler {
         } catch {
             BBToast.text("알 수 없는 오류가 발생했습니다.").show()
         }
-    }
-}
-
-enum DeepLinkError: Error {
-    case invalidLink
-    case notFound
-    case errorOccurred
-    case invalidNavigation
-    
-    var message: String {
-        switch self {
-        case .invalidLink:
-            return "잘못된 링크입니다."
-        case .notFound:
-            return "요청한 페이지를 찾을 수 없습니다."
-        case .errorOccurred:
-            return "요청 중 에러가 발생했습니다."
-        case .invalidNavigation:
-            return "현재 페이지를 찾을 수 없습니다."
-        }
-    }
-}
-
-protocol DeepLinkProtocol {
-    func doDeepLink() throws
-}
-
-extension DeepLinkProtocol {
-    func getNavigationController() -> UINavigationController? {
-        return (UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow }?
-            .rootViewController as? UINavigationController)
-    }
-    
-    func popToViewController<T: UIViewController>(ofType type: T.Type, animated: Bool = true) {
-        guard let navigationController = getNavigationController() else {
-            return
-        }
-        
-        for controller in navigationController.viewControllers.reversed() {
-            if controller is T {
-                navigationController.popToViewController(controller, animated: animated)
-                return
-            }
-        }
-        
-        navigationController.popToRootViewController(animated: animated)
     }
 }

--- a/14th-team5-iOS/Bibbi/Sources/Application/Router/DeepLinkError.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/Router/DeepLinkError.swift
@@ -1,0 +1,26 @@
+//
+//  DeepLinkError.swift
+//  Bibbi
+//
+//  Created by 마경미 on 25.03.25.
+//
+
+enum DeepLinkError: Error {
+    case invalidLink
+    case notFound
+    case errorOccurred
+    case invalidNavigation
+    
+    var message: String {
+        switch self {
+        case .invalidLink:
+            return "잘못된 링크입니다."
+        case .notFound:
+            return "요청한 페이지를 찾을 수 없습니다."
+        case .errorOccurred:
+            return "요청 중 에러가 발생했습니다."
+        case .invalidNavigation:
+            return "현재 페이지를 찾을 수 없습니다."
+        }
+    }
+}

--- a/14th-team5-iOS/Bibbi/Sources/Application/Router/DeepLinkProtocol.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/Router/DeepLinkProtocol.swift
@@ -1,0 +1,37 @@
+//
+//  DeepLinkProtocol.swift
+//  Bibbi
+//
+//  Created by 마경미 on 25.03.25.
+//
+
+import UIKit
+
+protocol DeepLinkProtocol {
+    func doDeepLink() throws
+}
+
+extension DeepLinkProtocol {
+    func getNavigationController() -> UINavigationController? {
+        return (UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }?
+            .rootViewController as? UINavigationController)
+    }
+    
+    func popToViewController<T: UIViewController>(ofType type: T.Type, animated: Bool = true) {
+        guard let navigationController = getNavigationController() else {
+            return
+        }
+        
+        for controller in navigationController.viewControllers.reversed() {
+            if controller is T {
+                navigationController.popToViewController(controller, animated: animated)
+                return
+            }
+        }
+        
+        navigationController.popToRootViewController(animated: animated)
+    }
+}

--- a/14th-team5-iOS/Bibbi/Sources/Application/Router/MainDeepLink.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Application/Router/MainDeepLink.swift
@@ -14,7 +14,7 @@ import Domain
 final class MainDeepLink: DeepLinkProtocol {
     enum MainDeepLinkType {
         case openMain
-        case openMission
+        case openMissionAlert
     }
     
     var type: MainDeepLinkType?
@@ -27,7 +27,7 @@ final class MainDeepLink: DeepLinkProtocol {
             $0.name == "openMission"})?.value {
             
             if isMission == "true" {
-                type = .openMission
+                type = .openMissionAlert
             } else {
                 type = .openMain
             }
@@ -40,7 +40,7 @@ final class MainDeepLink: DeepLinkProtocol {
         }
         
         switch type {
-        case .openMission: openMission()
+        case .openMissionAlert: openMission()
         case .openMain: popToMain()
         }
     }
@@ -59,11 +59,15 @@ extension MainDeepLink {
     // 임시로 홈화면에서 Mission alert 띄우기로 개발되어있음
     private func openMission() {
         popToMain()
-        
+
         let handler: BBAlertActionHandler = { [weak self] alert in
             self?.toCamera(.mission)
         }
-        BBAlert.style(.mission, primaryAction: handler).show()
+        
+        BBAlert.style(
+            .mission,
+            primaryAction: handler
+        ).show()
     }
     
     func toCamera(_ type: UploadLocation) {

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Notification/Reactor/NotificationReactor.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Notification/Reactor/NotificationReactor.swift
@@ -19,14 +19,12 @@ final class NotificationReactor: Reactor {
     }
     
     enum Mutation {
-        case setNotificationDataSource([NotificationCellReactor])
+        case setNotificationDataSource([NotificationCellReactor]?)
     }
     
     struct State {
-        @Pulse var notificationDataSource: [NotificationSectionModel] = [.init(
-            model: (),
-            items: []
-        )]
+        var isShowEmptyCase: Bool?
+        @Pulse var notificationDataSource: [NotificationSectionModel]? = nil
     }
     
     var initialState: State = .init()
@@ -49,10 +47,16 @@ extension NotificationReactor {
         var newState = state
         
         switch mutation {
-            
         case let .setNotificationDataSource(items):
-            let dataSource = NotificationSectionModel(model: (), items: items)
-            newState.notificationDataSource = [dataSource]
+            if let items,
+               !items.isEmpty {
+                let dataSource = NotificationSectionModel(model: (), items: items)
+                newState.notificationDataSource = [dataSource]
+                newState.isShowEmptyCase = false
+            } else {
+                newState.notificationDataSource = nil
+                newState.isShowEmptyCase = true
+            }
         }
         
         return newState
@@ -70,18 +74,29 @@ extension NotificationReactor {
                 }
                 return .just(.setNotificationDataSource(items))
             }
+            .catchAndReturn(.setNotificationDataSource(nil))
     }
     
     func didTapNotificationCell(
         _ item: NotificationCellReactor
     ) -> Observable<Mutation> {
-        guard let link = item.initialState.notification.deepLink else {
+        let noti = item.currentState.notification
+        
+        guard let link = noti.deepLink else {
             return .empty()
         }
         
-        DeepLinkHandler(
-            urlString: link
-        ).execute()
+        let deepLinkHandler = DeepLinkHandler(urlString: link)
+        
+        if let deepLink = deepLinkHandler.deepLink as? MainDeepLink,
+           let date = noti.createdAt.toDate() {
+            if deepLink.type == .openMissionAlert && date < Date() {
+                return .empty()
+            }
+        }
+        
+        deepLinkHandler.execute()
+        
         return .empty()
     }
 }

--- a/14th-team5-iOS/Bibbi/Sources/Presentation/Notification/ViewControllers/NotificationViewController.swift
+++ b/14th-team5-iOS/Bibbi/Sources/Presentation/Notification/ViewControllers/NotificationViewController.swift
@@ -177,6 +177,9 @@ final class NotificationViewController: BBNavigationViewController<NotificationR
     private typealias RxDataSource = RxTableViewSectionedReloadDataSource<NotificationSectionModel>
     
     private let dividerView: UIView = UIView()
+    private let emptyView: BBEmptyView = BBEmptyView(configure: .init(
+        text: "아직 알림이 없어요\n생일, 댓글 등 소식이 있으면 알려드릴게요")
+    )
     private lazy var tableView: UITableView = UITableView()
     private lazy var footerView: UITableViewHeaderFooterView = UITableViewHeaderFooterView()
     
@@ -201,7 +204,9 @@ final class NotificationViewController: BBNavigationViewController<NotificationR
     override func setupUI() {
         super.setupUI()
         
-        contentView.addSubview(tableView)
+        contentView.addSubviews(
+            tableView
+        )
     }
     
     override func setupAutoLayout() {
@@ -236,6 +241,10 @@ final class NotificationViewController: BBNavigationViewController<NotificationR
             
             $0.backgroundColor = .clear
             $0.separatorStyle = .none
+            
+            $0.tableFooterView = NotificationFooterView(
+                reuseIdentifier: NotificationFooterView.id
+            )
         }
     }
 }
@@ -258,20 +267,44 @@ extension NotificationViewController {
     
     private func bindOutput(reactor: Reactor) {
         reactor.pulse(\.$notificationDataSource)
+            .observe(on: MainScheduler.instance)
+            .compactMap { $0 }
             .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.isShowEmptyCase }.compactMap { $0 }
+            .observe(on: MainScheduler.asyncInstance)
+            .withUnretained(self)
+            .bind(onNext: {
+                $0.1 ? $0.0.addEmptyView() : $0.0.removeEmptyView()
+            })
             .disposed(by: disposeBag)
     }
 }
 
-extension NotificationViewController: UITableViewDelegate {
-    func tableView(
-        _ tableView: UITableView,
-        viewForFooterInSection section: Int
-    ) -> UIView? {
-        let view = NotificationFooterView(
-            reuseIdentifier: NotificationFooterView.id
-        )
+extension NotificationViewController {
+    private func addEmptyView() {
+        contentView.addSubview(emptyView)
         
-        return view
+        emptyView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
+    
+    private func removeEmptyView() {
+        emptyView.removeFromSuperview()
+    }
+}
+
+extension NotificationViewController: UITableViewDelegate {
+//    func tableView(
+//        _ tableView: UITableView,
+//        viewForFooterInSection section: Int
+//    ) -> UIView? {
+//        let view = NotificationFooterView(
+//            reuseIdentifier: NotificationFooterView.id
+//        )
+//        
+//        return view
+//    }
 }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBView/BBEmptyView.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBCommons/BBView/BBEmptyView.swift
@@ -1,0 +1,156 @@
+//
+//  BBEmptyView.swift
+//  Core
+//
+//  Created by 마경미 on 15.04.25.
+//
+
+import UIKit
+
+import DesignSystem
+
+final public class BBEmptyView: UIView {
+    public struct Configure {
+        /// full - 화면 전체를 가리며, 화면 중앙에 갈 수 있도록 설정 됨
+        /// fit - 지정된 사이즈만큼만 가리며, 화면 위쪽에 갈 수 있도록 설정 됨
+        public enum ViewType {
+            case full
+            case fit
+        }
+        
+        /// Empty Case에 사용되는 이미지가 추가 될 경우 Asset에 추가해서 사용.
+        public enum Asset {
+            case emptyGraphic
+
+            var image: UIImage {
+                switch self {
+                case .emptyGraphic:
+                    return DesignSystemAsset.emptyCaseGraphicEmoji.image
+                }
+            }
+        }
+        
+        /// Empty Case에 사용되는 이미지 사이즈 (big: 148, medium: 32, small: 24)
+        public enum AssetSize {
+            case big
+            case medium
+            case small
+            
+            var value: (CGFloat, CGFloat) {
+                switch self {
+                case .big: /// notification View
+                    return (125, 115)
+                case .medium:
+                    return (32, 32)
+                case .small:
+                    return (24, 24)
+                }
+            }
+        }
+        
+        let viewType: ViewType
+        let asset: Asset
+        let text: String?
+        let assetSize: AssetSize
+        
+        /// default: viewType = full, asset = emptyGraphic, assetSize: big
+        public init(
+            viewType: ViewType = .full,
+            asset: Asset = .emptyGraphic,
+            assetSize: AssetSize = .big,
+            text: String?
+        ) {
+            self.viewType = viewType
+            self.asset = asset
+            self.assetSize = assetSize
+            self.text = text
+        }
+    }
+    
+    private let configure: Configure
+    
+    private let stackView: UIStackView = UIStackView()
+    private let imageView: UIImageView = .init()
+    private let label: BBLabel = .init(
+        .body1Regular,
+        textAlignment: .center,
+        textColor: .gray500
+    )
+    
+    public init(configure: Configure) {
+        self.configure = configure
+        super.init(frame: .zero)
+        setupUI()
+        setupAutoLayout()
+        setupAttributes()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension BBEmptyView {
+    private func setupUI() {
+        addSubviews(stackView)
+        stackView.addArrangedSubviews(imageView, label)
+    }
+    
+    private func setupAutoLayout() {
+        switch configure.viewType {
+        case .fit: setFitTypeAutoLayout()
+        case .full: setFullTypeAutoLayout()
+        }
+    }
+    
+    private func setupAttributes() {
+        backgroundColor = .bibbiBlack
+        
+        stackView.do {
+            $0.axis = .vertical
+            $0.spacing = 20
+        }
+        
+        imageView.do {
+            $0.image = configure.asset.image
+            $0.contentMode = .scaleAspectFit
+        }
+        
+        label.do {
+            $0.numberOfLines = 0
+            $0.text = configure.text
+            $0.sizeToFit()
+        }
+    }
+}
+
+extension BBEmptyView {
+    private func setFitTypeAutoLayout() {
+        imageView.snp.makeConstraints {
+            $0.width.equalTo(configure.assetSize.value.0)
+            $0.height.equalTo(configure.assetSize.value.1)
+        }
+
+        stackView.snp.makeConstraints {
+            $0.directionalVerticalEdges.equalToSuperview()
+        }
+    }
+    
+    private func setFullTypeAutoLayout() {
+        if let topVC = UIApplication.topViewController() {
+            let safeTop = topVC.view.safeAreaInsets.top
+            let screenHeight = UIScreen.main.bounds.height
+            let topOffset = (screenHeight / 2) - safeTop
+            
+            imageView.snp.makeConstraints {
+                $0.width.equalTo(configure.assetSize.value.0)
+                $0.height.equalTo(configure.assetSize.value.1)
+            }
+
+            stackView.snp.makeConstraints {
+                $0.directionalHorizontalEdges.equalToSuperview()
+                $0.centerY.equalToSuperview().offset(-safeTop)
+            }
+        }
+    }
+}

--- a/14th-team5-iOS/Core/Sources/Extensions/String+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/String+Ext.swift
@@ -12,6 +12,13 @@ import CryptoKit
 extension String {
     public static var none: String { "" }
     public static var unknown: String { "알 수 없음" }
+    
+    public static var today: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale.current
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        return dateFormatter.string(from: Date())
+    }
 }
 
 extension String {

--- a/14th-team5-iOS/Core/Sources/Extensions/UIApplication+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/UIApplication+Ext.swift
@@ -1,0 +1,27 @@
+//
+//  UIApplication+Ext.swift
+//  Core
+//
+//  Created by 마경미 on 03.06.25.
+//
+
+import UIKit
+
+extension UIApplication {
+    static func topViewController(
+        base: UIViewController? = UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .first?.rootViewController
+    ) -> UIViewController? {
+        if let nav = base as? UINavigationController {
+            return topViewController(base: nav.visibleViewController)
+        }
+        if let tab = base as? UITabBarController {
+            return topViewController(base: tab.selectedViewController)
+        }
+        if let presented = base?.presentedViewController {
+            return topViewController(base: presented)
+        }
+        return base
+    }
+}

--- a/14th-team5-iOS/Core/Sources/Utils/URLHandler.swift
+++ b/14th-team5-iOS/Core/Sources/Utils/URLHandler.swift
@@ -1,0 +1,47 @@
+//
+//  URLHandler.swift
+//  Core
+//
+//  Created by 마경미 on 25.03.25.
+//
+
+import Foundation
+
+final public class URLHandler {
+    let urlString: String
+    
+    public init(urlString: String) {
+        self.urlString = urlString
+    }
+}
+
+extension URLHandler {
+    public func getURL() -> URL? {
+        return URL(string: urlString)
+    }
+    
+    public func getPathComponents() -> [String]? {
+        guard let url = getURL() else {
+            return nil
+        }
+        
+        let pathComponents = url.pathComponents.filter {
+                !$0.isEmpty && $0 != "/"
+            }
+        
+        return pathComponents
+    }
+    
+    public func getQueryItems() -> [URLQueryItem]? {
+        guard let url = getURL() else {
+            return nil
+        }
+        
+       let queryItems = URLComponents(
+            url: url,
+            resolvingAgainstBaseURL: false
+        )?.queryItems
+        
+        return queryItems
+    }
+}


### PR DESCRIPTION
## 😽개요

## 🛠️작업 내용

### 지난 미션은 화면 이동하지 않도록 수정했어요

cell을 선택하는 reactor 안에서 다음과 같이 지난 날짜를 구분해요.
```swift
        if let deepLink = deepLinkHandler.deepLink as? MainDeepLink,
           let date = noti.createdAt.toDate() {
            if deepLink.type == .openMissionAlert && date < Date() {
                return .empty()
            }
        }

        deepLinkHandler.execute()
```

### 빈 알림 화면을 만들었어요.

다음과 같이 empty view를 공용으로 사용할 수 있도록 구현했어요
```swift
private let emptyView: BBEmptyView = BBEmptyView(configure: .init(
        text: "아직 알림이 없어요\n생일, 댓글 등 소식이 있으면 알려드릴게요")
    )
```

empty view는 다음과 같은 속성을 설정할 수 있어요
```swift
        /// default: viewType = full, asset = emptyGraphic, assetSize: big
        public init(
            viewType: ViewType = .full,
            asset: Asset = .emptyGraphic,
            assetSize: AssetSize = .big,
            text: String?
        ) {
            self.viewType = viewType
            self.asset = asset
            self.assetSize = assetSize
            self.text = text
        }
```

| 이미지① |
| :----: |
| <img src="https://github.com/user-attachments/assets/aadeea27-da05-407c-8d76-d83decfb3945" width="350" />
 |



