### PR TITLE
위젯이 안되는 현상을 수정해요

### DIFF
--- a/14th-team5-iOS/Bibbi/Project.swift
+++ b/14th-team5-iOS/Bibbi/Project.swift
@@ -15,11 +15,13 @@ private let targets: [Target] = [
             products: .bibbi,
             dependencies: ModuleLayer.Bibbi.dependencies,
             bundleId: "com.5ing.bibbi",
-            infoPlist: .extendingDefault(with: [                
+            infoPlist: .extendingDefault(with: [
+                "SERVICE_NAME": .string("$(SERVICE_NAME)"),
+                "ACCESS_GROUP": .string("$(ACCESS_GROUP"),
                 "CFBundleDisplayName": .string("Bibbi"),
                 "CFBundleVersion": .string("1"),
                 "CFBuildVersion": .string("0"),
-                "CFBundleShortVersionString": .string("1.3.1"),
+                "CFBundleShortVersionString": .string("1.3.2"),
                 "UILaunchStoryboardName": .string("LaunchScreen"),
                 "UISupportedInterfaceOrientations": .array([.string("UIInterfaceOrientationPortrait")]),
                 "UIUserInterfaceStyle": .string("Dark"),
@@ -67,6 +69,8 @@ private let targets: [Target] = [
         dependencies: ExtensionsLayer.Widget.dependencies,
         bundleId: "com.5ing.bibbi.widget",
         infoPlist: .extendingDefault(with: [
+            "SERVICE_NAME": .string("$(SERVICE_NAME)"),
+            "ACCESS_GROUP": .string("$(ACCESS_GROUP"),
             "CFBundleDisplayName": .string("Bibbi"),
             "NSExtension" : .dictionary([
                 "NSExtensionPointIdentifier": .string("com.apple.widgetkit-extension")

--- a/14th-team5-iOS/Bibbi/WidgetExtension/Sources/FamilyWidget/FamilyWidgetTimelineProvider.swift
+++ b/14th-team5-iOS/Bibbi/WidgetExtension/Sources/FamilyWidget/FamilyWidgetTimelineProvider.swift
@@ -30,7 +30,7 @@ final class FamilyWidgetTimelineProvider: TimelineProvider {
         let refreshDate = Calendar.current.date(byAdding: .minute, value: 5, to: currentDate)!
         
         
-        repository.fetchRecentFamilyPost { result in
+        repository.fetchRecentFamilyPost(date: .today) { result in
             var entry: FamilyWidgetEntry
             switch result {
             case .success(let family):

--- a/14th-team5-iOS/Bibbi/WidgetExtension/Sources/FamilyWidget/FamilyWidgetView.swift
+++ b/14th-team5-iOS/Bibbi/WidgetExtension/Sources/FamilyWidget/FamilyWidgetView.swift
@@ -20,7 +20,7 @@ struct FamilyWidgetView: View {
             getPhotoView(info: info)
                 .widgetURL(URL(string: "post/view/\(info.postId ?? "")"))
         } else {
-            if isCurrentTimeBetween18And24() {
+            if isCurrentTimeBetween10And24() {
                 greenDefaultView
             } else {
                 yellowDefaultView
@@ -224,13 +224,13 @@ struct FamilyWidgetView: View {
         }
     }
     
-    private func isCurrentTimeBetween18And24() -> Bool {
+    private func isCurrentTimeBetween10And24() -> Bool {
         let calendar = Calendar.current
         let currentDate = Date()
         
         let components = calendar.dateComponents([.hour], from: currentDate)
         if let currentHour = components.hour {
-            return currentHour >= 18 && currentHour < 24
+            return currentHour >= 10 && currentHour < 24
         }
         
         return false

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/Network/Components/BBNetworkHeader.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBNetwork/Network/Components/BBNetworkHeader.swift
@@ -86,8 +86,8 @@ private extension BBNetworkHeader {
     }
 
     func fetchXAuthTokenValue() -> String {
-        if let authToken: AccessToken = KeychainWrapper.standard[.accessToken] {
-            return authToken.accessToken ?? ""
+        if let authToken: AuthToken = KeychainWrapper.standard[.accessToken] {
+            return authToken.accessToken
         }
         return ""
     }

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBStorages/KeychainWrapper/KeychainWrapper.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBStorages/KeychainWrapper/KeychainWrapper.swift
@@ -28,25 +28,17 @@ final public class KeychainWrapper {
     private(set) public var accessGroup: String?
     
     private static let defaultServiceName: String = {
-        return Bundle.main.bundleIdentifier ?? "KeychainWrapper"
+        return Bundle.module.appVersion
     }()
     
     
     // MARK: - Intializer
     
     public init(
-        serviceName: String,
-        accessGroup: String? = nil
     ) {
-        self.serviceName = serviceName
-        self.accessGroup = accessGroup
+        self.serviceName = Bundle.main.serviceName
+        self.accessGroup = Bundle.main.accessGroup
     }
-    
-    private convenience init() {
-        self.init(serviceName: KeychainWrapper.defaultServiceName)
-    }
-    
-    
     
     // MARK: - Read
     

--- a/14th-team5-iOS/Core/Sources/Bibbi/BBStorages/UserDefaultsWrapper/UserDefaultsWrapper.swift
+++ b/14th-team5-iOS/Core/Sources/Bibbi/BBStorages/UserDefaultsWrapper/UserDefaultsWrapper.swift
@@ -13,12 +13,12 @@ final public class UserDefaultsWrapper {
     
     public static let standard = UserDefaultsWrapper()
     
-    private let userDefaults: UserDefaults!
+    private let userDefaults: UserDefaults
     
     private(set) public var suitName: String
     
     private static let defaultSuitName: String = {
-        "UserDefaultsWrapper"
+        "com.5ing.bibbi"
     }()
     
     
@@ -30,7 +30,7 @@ final public class UserDefaultsWrapper {
     
     init(suitName: String) {
         self.suitName = suitName
-        self.userDefaults = UserDefaults(suiteName: suitName)
+        self.userDefaults = UserDefaults(suiteName: suitName) ?? UserDefaults()
     }
     
     

--- a/14th-team5-iOS/Core/Sources/Extensions/Bundle+Ext.swift
+++ b/14th-team5-iOS/Core/Sources/Extensions/Bundle+Ext.swift
@@ -64,7 +64,31 @@ extension Bundle {
         }
     }
     
+    public var serviceName: String {
+        guard let dict = Bundle.main.infoDictionary else {
+            return ""
+        }
+        
+        if let serviceName = dict["SERVICE_NAME"] as? String, !serviceName.isEmpty {
+            return serviceName
+        } else {
+            return ""
+        }
+    }
+    
+    public var accessGroup: String {
+        guard let dict = Bundle.main.infoDictionary else {
+            return ""
+        }
+        
+        if let accessGroup = dict["ACCESS_GROUP"] as? String, !accessGroup.isEmpty {
+            return accessGroup
+        } else {
+            return ""
+        }
+    }
+    
     public var xAppKey: String {
-        "38a4c674-28cc-458a-8688-466fc4422756"
+        "487f6efd-c2cb-4b50-94de-9c1756d2f086"
     }
 }

--- a/14th-team5-iOS/Core/Sources/Trash/BBNetwork/API.swift
+++ b/14th-team5-iOS/Core/Sources/Trash/BBNetwork/API.swift
@@ -53,7 +53,7 @@ public enum BibbiAPI {
         public var value: String {
             switch self {
             case let .auth(token): return "Bearer \(token)"
-            case .xAppKey: return "38a4c674-28cc-458a-8688-466fc4422756" // TODO: - 번들에서 가져오기
+            case .xAppKey: return "487f6efd-c2cb-4b50-94de-9c1756d2f086" // TODO: - 번들에서 가져오기
             case let .xAuthToken(token): return "\(token)"
             case .contentForm: return "application/x-www-form-urlencoded"
             case .contentJson: return "application/json"

--- a/14th-team5-iOS/Core/Sources/Trash/BBRx/Repositories/Token/TokenRepository.swift
+++ b/14th-team5-iOS/Core/Sources/Trash/BBRx/Repositories/Token/TokenRepository.swift
@@ -25,7 +25,7 @@ public struct AccessToken: Codable, Equatable {
 
 @available(*, deprecated, renamed: "TokenKeychain")
 public class TokenRepository: RxObject {
-    public lazy var keychain = KeychainWrapper(serviceName: "Bibbi", accessGroup: "P9P4WJ623F.com.5ing.bibbi")
+    public lazy var keychain = KeychainWrapper()
     
     public let accessToken = BehaviorRelay<AccessToken?>(value: (KeychainWrapper.standard[.accessToken] as String?)?.decode(AccessToken.self))
     

--- a/14th-team5-iOS/Data/Sources/APIs/Widget/WidgetAPIWorker.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/Widget/WidgetAPIWorker.swift
@@ -12,8 +12,8 @@ extension WidgetAPIWorker {
     /// 가장 최근에 올라온 가족의 게시글 하나를 조회하는 Method입니다.
     /// HTTP Method: GET
     /// - Returns: GetRecentPostsResponseDTO
-    func fetchRecentFamilyPost() -> Observable<GetRecentPostsResponseDTO> {
-        let spec = WidgetAPIs.fetchRecentFamilyPost.spec
+    func fetchRecentFamilyPost(date: String) -> Observable<GetRecentPostsResponseDTO> {
+        let spec = WidgetAPIs.fetchRecentFamilyPost(date).spec
 
         return request(spec)
     }

--- a/14th-team5-iOS/Data/Sources/APIs/Widget/WidgetAPIs.swift
+++ b/14th-team5-iOS/Data/Sources/APIs/Widget/WidgetAPIs.swift
@@ -9,14 +9,17 @@ import Core
 
 enum WidgetAPIs: BBAPI {
     /// 당일 최근 가족 게시물 타입 위젯 조회
-    case fetchRecentFamilyPost
+    case fetchRecentFamilyPost(String)
     
     var spec: Spec {
         switch self {
-        case .fetchRecentFamilyPost:
+        case let .fetchRecentFamilyPost(date):
             return .init(
                 method: .get,
-                path: "/widgets/single-recent-family-post"
+                path: "/widgets/single-recent-family-post",
+                queryParameters: [
+                    "date": "\(date)"
+                ]
             )
         }
     }

--- a/14th-team5-iOS/Data/Sources/Repositories/AppRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Repositories/AppRepository.swift
@@ -33,7 +33,7 @@ extension AppRepository {
     
     public func fetchAppVersion() -> Observable<AppVersionEntity> {
         // TODO: - xAppKey 불러오는 코드 다시 작성하기
-        let appKey = "38a4c674-28cc-458a-8688-466fc4422756"
+        let appKey = "487f6efd-c2cb-4b50-94de-9c1756d2f086"
         
         return meAPIWorker.fetchAppVersion(appKey: appKey)
             .map { $0.toDomain() }

--- a/14th-team5-iOS/Data/Sources/Repositories/WidgetRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Repositories/WidgetRepository.swift
@@ -18,8 +18,11 @@ public final class WidgetRepository: WidgetRepositoryProtocol {
     
     public init () { }
     
-    public func fetchRecentFamilyPost(completion: @escaping (Result<WidgetPostEntity, Error>) -> Void) {
-        widgetAPIWorker.fetchRecentFamilyPost()
+    public func fetchRecentFamilyPost(
+        date: String,
+        completion: @escaping (Result<WidgetPostEntity, Error>
+        ) -> Void) {
+        widgetAPIWorker.fetchRecentFamilyPost(date: date)
             .map { $0.toDomain() }
             .subscribe(
                 onNext: { result in

--- a/14th-team5-iOS/Data/Sources/Trash/Account/AccountRepository/AccountRepository.swift
+++ b/14th-team5-iOS/Data/Sources/Trash/Account/AccountRepository/AccountRepository.swift
@@ -31,7 +31,7 @@ public final class AccountRepository: AccountImpl {
     public var disposeBag: DisposeBag = DisposeBag()
     
     private let accessToken: String = App.Repository.token.accessToken.value?.accessToken ?? ""
-    private let keychain = KeychainWrapper(serviceName: "Bibbi", accessGroup: "P9P4WJ623F.com.5ing.bibbi")
+    private let keychain = KeychainWrapper()
     
     let signInHelper = AccountSignInHelper()
     private let apiWorker = AccountAPIWorker()

--- a/14th-team5-iOS/Domain/Sources/Repositories/WidgetRepository.swift
+++ b/14th-team5-iOS/Domain/Sources/Repositories/WidgetRepository.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol WidgetRepositoryProtocol {
-    func fetchRecentFamilyPost(completion: @escaping (Result<WidgetPostEntity, Error>) -> Void)
+    func fetchRecentFamilyPost(date: String, completion: @escaping (Result<WidgetPostEntity, Error>) -> Void)
 }

--- a/14th-team5-iOS/Domain/Sources/UseCases/Widget/FetchRecentFamilyPostUseCase.swift
+++ b/14th-team5-iOS/Domain/Sources/UseCases/Widget/FetchRecentFamilyPostUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol FetchRecentFamilyPostUseCaseProtocol {
-    func excute(completion: @escaping (Result<WidgetPostEntity, Error>) -> Void)
+    func excute(date: String, completion: @escaping (Result<WidgetPostEntity, Error>) -> Void)
 }
 
 public class FetchRecentFamilyPostUseCase: FetchRecentFamilyPostUseCaseProtocol {
@@ -18,7 +18,11 @@ public class FetchRecentFamilyPostUseCase: FetchRecentFamilyPostUseCaseProtocol 
         self.widgetRepository = widgetRepository
     }
     
-    public func excute(completion: @escaping (Result<WidgetPostEntity, Error>) -> Void) {
-        return widgetRepository.fetchRecentFamilyPost(completion: completion)
+    public func excute(
+        date: String,
+        completion: @escaping (Result<WidgetPostEntity, Error>
+        ) -> Void
+    ) {
+        return widgetRepository.fetchRecentFamilyPost(date: date, completion: completion)
     }
 }


### PR DESCRIPTION
## 😽개요

위젯에 token값이 제대로 저장되지 않아, 최근 가족 사진이 뜨지 않는 문제를 해결합니다.

## 🛠️작업 내용

### Keychain access group을 설정해요
기존에는 servicename 은 `Bundle.main.bundleIdentifier`로, accessGroup은 `nil`로 설정
따라서 위젯에서는 앱과 동일한 키체인에 접근이 불가능했습니다.

아래와 같이 수정했어요.

```swift
 self.serviceName = Bundle.main.serviceName
 self.accessGroup = Bundle.main.accessGroup
```

이 2가지는 BUNDLE에 추가하였으니, String 문자열 그대로 사용하지 않도록 주의 부탁드려요.
```swift
 public var serviceName: String { }

    public var accessGroup: String { }
```

### API를 수정해요

위젯 API에 query parameter가 누락되어 수정하였습니다.
최근 가족 게시물을 불러올 수 있어요.

 ```swift
enum WidgetAPIs: BBAPI {
    /// 당일 최근 가족 게시물 타입 위젯 조회
    case fetchRecentFamilyPost(String)

    var spec: Spec {
        switch self {
        case let .fetchRecentFamilyPost(date):
            return .init(
                method: .get,
                path: "/widgets/single-recent-family-post",
                queryParameters: [
                    "date": "\(date)"
                ]
            )
        }
    }
```


## ✅테스트 케이스

* 최근 가족 사진이 올라오는지 확인
* 위젯 눌렀을 때 자동 로그인 되는지 확인

---
